### PR TITLE
feat: v2.1.0 - SSH起動安定化・Copilot --yolo統一・エラー修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# CHANGELOG
+
+## [v2.1.0] - 2026-03-13
+
+### 修正内容
+
+#### SSH 起動の安定化
+- `Start-Process -NoNewWindow -Wait -PassThru` による直接コマンド方式に変更
+- 従来の bash スクリプト転送方式を廃止し SSH コマンドを直接実行
+- SSH 接続オプション (`ConnectTimeout=10`, `StrictHostKeyChecking=accept-new`) を追加
+- SSH 終了時のエラー表示を修正: exit code 255（接続失敗）のみをエラーとして扱う
+
+#### ツール起動コマンドの統一
+- GitHub Copilot CLI の起動コマンドを `copilot --yolo` に統一（ローカル・SSH 共通）
+- ローカル Copilot 起動を `Start-Process` に変更し PowerShell 引数展開問題を解消
+
+#### メニュー改善
+- 「最近使用したプロジェクト」セクション（R1〜RC）を Start-Menu から削除
+
+#### エラー修正
+- `Set-StrictMode -Version Latest` 環境での `$LASTEXITCODE` 未設定エラーを解消
+- `$LASTEXITCODE = 0` 事前初期化により StrictMode 互換性を確保
+
+### 変更ファイル
+- `scripts/main/Start-ClaudeCode.ps1`
+- `scripts/main/Start-CodexCLI.ps1`
+- `scripts/main/Start-CopilotCLI.ps1`
+- `scripts/main/Start-All.ps1`
+- `scripts/main/Start-Menu.ps1`
+- `scripts/lib/LauncherCommon.psm1`
+- `config/config.json.template`
+- `tests/StartScripts.Tests.ps1`
+
+---
+
+## [v2.0.0] - 2026 以前
+
+初期リリース: Claude Code / Codex CLI / GitHub Copilot CLI 統合ランチャー


### PR DESCRIPTION
## 概要

今セッションで実施した一連の不具合修正をまとめたPRです。

## 変更内容

### 🔧 SSH 起動の安定化
- \Start-Process -NoNewWindow -Wait -PassThru\ による直接コマンド方式に変更（bash スクリプト転送廃止）
- SSH 終了時エラー: exit code 255（接続失敗）のみエラー扱い、1〜254はツール正常終了とみなす

### 🚀 ツール起動コマンドの統一
- GitHub Copilot CLI を \copilot --yolo\ に統一（ローカル・SSH 共通）
- ローカル Copilot 起動を \Start-Process\ に変更し「too many arguments」エラーを解消

### 🗑️ メニュー改善
- 「最近使用したプロジェクト」セクション（R1〜RC）を削除

### 🐛 エラー修正
- \Set-StrictMode -Version Latest\ 環境での \\0\ 未設定エラーを解消

## テスト結果
\\\
Tests Passed: 109, Failed: 0, Skipped: 0
\\\

## コミット一覧
- \56a4dbc\ ローカルCopilot起動をStart-Processに変更して引数展開問題を解消
- \70755d8\ Copilot CLIをローカル/SSHとも copilot --yolo に統一
- \d26a76\ Set-StrictMode環境でのLASTEXITCODE未設定エラーを解消
- \2a62399\ SSH起動修正・/exitエラー解消・Recent Projects削除
- \b353ba\ CHANGELOG v2.1.0 追加