### PR TITLE
fix: プロジェクト番号選択時の文字列比較バグを修正

### DIFF
--- a/scripts/lib/LauncherCommon.psm1
+++ b/scripts/lib/LauncherCommon.psm1
@@ -198,11 +198,12 @@ function Resolve-LauncherProject {
     Show-LauncherProjectChoices -Projects $dirs.Name -Local:$Local -LinuxHost $LinuxHost
 
     $num = Read-Host "番号を入力してください"
-    if (-not ($num -as [int]) -or $num -lt 1 -or $num -gt $dirs.Count) {
+    $numInt = $num -as [int]
+    if (-not $numInt -or $numInt -lt 1 -or $numInt -gt $dirs.Count) {
         throw "USER_CANCELLED"
     }
 
-    return $dirs[$num - 1].Name
+    return $dirs[$numInt - 1].Name
 }
 
 function Show-LauncherProjectChoices {
@@ -291,8 +292,11 @@ function Confirm-LauncherStart {
     Write-Host "ツール   : $ToolName"
     Write-Host "プロジェクト: $Project"
     Write-Host "実行モード: $ModeLabel"
-    $confirm = Read-Host "開始しますか？ (y/N)"
-    return ($confirm -match '^(y|yes)$')
+    $confirm = Read-Host "開始しますか？ (Y/n)"
+    if ([string]::IsNullOrWhiteSpace($confirm)) {
+        return $true
+    }
+    return ($confirm -notmatch '^(n|no)$')
 }
 
 function Set-LauncherEnvironment {


### PR DESCRIPTION
## Summary
- `Resolve-LauncherProject` で `Read-Host` の戻り値（文字列）を整数比較せずに使用していたため、プロジェクト番号1〜9を選択すると辞書順比較で `"9" > "73"` が True となり、即キャンセルされるバグを修正
- `Confirm-LauncherStart` のデフォルトを `Y/n`（Enter で即起動）に変更

## Root Cause
PowerShell の `-gt` 演算子は左辺の型に基づいて比較を行う。`Read-Host` は常に文字列を返すため、`$num -gt $dirs.Count` は `"9" -gt 73` → `"9" -gt "73"` → 辞書順で True となっていた。

## Fix
`$numInt = $num -as [int]` で明示的に整数化してから比較するよう修正。

## Test plan
- [x] S1 → プロジェクト番号 9 を選択 → 正常に起動確認プロンプトが表示される
- [ ] S1 → プロジェクト番号 1〜9（1桁）で正常動作
- [ ] S1 → プロジェクト番号 10以上（2桁）で正常動作
- [ ] 無効な入力（文字列、0、範囲外）で USER_CANCELLED

🤖 Generated with [Claude Code](https://claude.com/claude-code)