### PR TITLE
feat: ローカル起動時にSTART_PROMPTを自動送信

### DIFF
--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -178,15 +178,25 @@ try {
 
         Sync-LauncherClaudeGlobalConfig -StartupRoot $ScriptRoot -ProjectDir $localProjectDir
 
+        $localPromptPath = Join-Path $ScriptRoot 'Claude\templates\claude\START_PROMPT.md'
+        $localPromptArgs = @()
+        if (Test-Path $localPromptPath) {
+            $localPromptSections = Get-StartPromptSections -PromptPath $localPromptPath
+            $localPromptArgs = @($localPromptSections.FullText)
+            Write-Info "START_PROMPT を自動送信します ($localPromptPath)"
+        }
+
+        $claudeLocalArgs = @($toolConfig.args) + $localPromptArgs
+
         if ($DryRun) {
-            foreach ($line in (New-LauncherDryRunMessage -Command 'claude' -Arguments @($toolConfig.args) -WorkingDirectory $localProjectDir)) {
+            foreach ($line in (New-LauncherDryRunMessage -Command 'claude' -Arguments $claudeLocalArgs -WorkingDirectory $localProjectDir)) {
                 Write-Info $line
             }
             $launchContext.Result = 'success'
             exit 0
         }
 
-        & claude @($toolConfig.args)
+        & claude @claudeLocalArgs
         $launchContext.Result = if ($LASTEXITCODE -eq 0) { 'success' } else { 'failure' }
         exit $LASTEXITCODE
     }


### PR DESCRIPTION
## Summary
- Claude Code のローカル起動時に `Claude/templates/claude/START_PROMPT.md` の内容を CLI 位置引数として自動送信
- これまで SSH 経路のみで有効だった自動プロンプト送信がローカルでも機能
- テンプレートが存在しない場合は従来通り引数なしで起動（後方互換性あり）

## 変更内容
`scripts/main/Start-ClaudeCode.ps1` のローカル起動パスに以下を追加:
1. `Get-StartPromptSections` で START_PROMPT.md をパース
2. `FullText`（LOOP_COMMANDS + PROMPT_BODY）を `claude` の位置引数に追加
3. DryRun 時にもプロンプト内容が引数に含まれる

## テスト結果
- Pester: **109 passed / 0 failed**

## Test plan
- [x] Pester 全テスト通過
- [ ] GitHub Actions CI 通過確認
- [ ] ローカル実際起動で START_PROMPT が自動送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)