### PR TITLE
fix: SSH デプロイスクリプトの CRLF → LF 正規化

### DIFF
--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -105,6 +105,9 @@ function Invoke-ClaudeSshViaStdin {
         return 0
     }
 
+    # Bash on the remote side must receive LF-only content.
+    $normalizedScript = (($ScriptText -replace "`r`n", "`n") -replace "`r", "`n")
+
     $sshCommand = if ($env:AI_STARTUP_SSH_EXE) { $env:AI_STARTUP_SSH_EXE } else { 'ssh' }
     $connectTimeout = if ($env:AI_STARTUP_SSH_CONNECT_TIMEOUT) { $env:AI_STARTUP_SSH_CONNECT_TIMEOUT } else { '10' }
 
@@ -122,8 +125,8 @@ function Invoke-ClaudeSshViaStdin {
     Write-Info "SSH 接続中: $LinuxHost ..."
     [void]$process.Start()
     $process.StandardInput.NewLine = "`n"
-    $process.StandardInput.Write($ScriptText)
-    if (-not $ScriptText.EndsWith("`n")) {
+    $process.StandardInput.Write($normalizedScript)
+    if (-not $normalizedScript.EndsWith("`n")) {
         $process.StandardInput.WriteLine()
     }
     $process.StandardInput.Close()


### PR DESCRIPTION
## Summary
- `Invoke-ClaudeSshViaStdin` で送信するスクリプトの CRLF を LF に正規化
- Windows で生成されたデプロイスクリプトが Linux bash でエラー（`$'\r': command not found`）を引き起こしていた

## 原因
`Invoke-LauncherSshScript` には `$RunScript -replace "\r\n", "\n"` の正規化処理があったが、`Invoke-ClaudeSshViaStdin` にはなかった。PowerShell の here-string (`@"..."@`) は Windows 上で CRLF を生成するため、デプロイスクリプト全体にCRLFが混入していた。

## テスト結果
- Pester: **109 passed / 0 failed**

## Test plan
- [x] Pester 全テスト通過
- [ ] GitHub Actions CI 通過確認
- [ ] SSH 経由の実際の起動で `$'\r'` エラーが解消されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)