### PR TITLE
fix: PTY bridge のプロンプト自動送信タイミングを改善

### DIFF
--- a/scripts/helpers/claude_pty_bridge.py
+++ b/scripts/helpers/claude_pty_bridge.py
@@ -44,7 +44,23 @@ def main() -> int:
         os.write(master_fd, b"\x1b[200~")
         os.write(master_fd, payload.encode("utf-8"))
         os.write(master_fd, b"\x1b[201~")
-        time.sleep(0.25)
+
+        # Wait for Claude Code TUI to finish rendering the pasted content.
+        # Large pastes (500+ lines) need more time to be processed by the TUI.
+        time.sleep(2.0)
+
+        # Drain any pending output from the TUI during processing.
+        for _ in range(5):
+            rr, _, _ = select.select([master_fd], [], [], 0.3)
+            if master_fd in rr:
+                try:
+                    chunk = os.read(master_fd, 16384)
+                    if chunk:
+                        os.write(stdout_fd, chunk)
+                except (BlockingIOError, OSError):
+                    pass
+
+        # Send Enter to submit the pasted prompt.
         os.write(master_fd, b"\r")
         prompt_sent = True
 


### PR DESCRIPTION
## Summary
- SSH経由起動時、500+行のSTART_PROMPTがClaude Code入力欄に貼り付けられたまま自動実行されない問題を修正
- `claude_pty_bridge.py` のブラケットペースト後の待機時間を250ms→2sに延長し、TUI出力バッファのドレインを追加

## 原因
ペースト完了→Enter送信の間隔(250ms)が、Claude Code TUIが529行の大量テキストをレンダリングするには不十分だった。TUIが `[Pasted text #1 +529 lines]` と表示する前にEnterが到着していた。

## テスト結果
- Pester: **109 passed / 0 failed**

## Test plan
- [x] Pester全テスト通過
- [ ] CI通過確認
- [ ] SSH経由起動でSTART_PROMPTが自動送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)