### PR TITLE
chore: テスト copilot統一・CI Node.js 24移行・バックアップ削除・gh scope案内

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test-and-validate:
     runs-on: windows-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ codex --login
 
 # GitHub Copilot CLI
 copilot auth
+
+# GitHub Projects 連携（ClaudeOS で必要）
+gh auth refresh -h github.com -s read:project,project
 ```
 
 6. 診断を実行

--- a/tests/Config.Tests.ps1
+++ b/tests/Config.Tests.ps1
@@ -168,8 +168,8 @@ Describe 'Test-StartupConfigSchema and Assert-StartupConfigSchema' {
                     }
                     copilot     = @{
                         enabled        = $true
-                        command        = 'gh'
-                        args           = @('copilot')
+                        command        = 'copilot'
+                        args           = @('--yolo')
                         installCommand = 'install-copilot'
                         env            = @{}
                     }
@@ -209,8 +209,8 @@ Describe 'Test-StartupConfigSchema and Assert-StartupConfigSchema' {
                     }
                     copilot     = @{
                         enabled        = $true
-                        command        = 'gh'
-                        args           = @('copilot')
+                        command        = 'copilot'
+                        args           = @('--yolo')
                         installCommand = 'install-copilot'
                         env            = @{}
                     }
@@ -262,8 +262,8 @@ Describe 'Test-StartupConfigSchema and Assert-StartupConfigSchema' {
                     }
                     copilot     = @{
                         enabled        = $true
-                        command        = 'gh'
-                        args           = @('copilot')
+                        command        = 'copilot'
+                        args           = @('--yolo')
                         installCommand = 'install-copilot'
                         env            = @{}
                     }
@@ -307,8 +307,8 @@ Describe 'Test-StartupConfigSchema and Assert-StartupConfigSchema' {
                     }
                     copilot     = @{
                         enabled        = $true
-                        command        = 'gh'
-                        args           = @('copilot')
+                        command        = 'copilot'
+                        args           = @('--yolo')
                         installCommand = 'install-copilot'
                         env            = @{}
                     }
@@ -336,7 +336,7 @@ Describe 'Test-StartupConfigSchema and Assert-StartupConfigSchema' {
                     defaultTool = 'claude'
                     claude      = @{ enabled = $true; command = 'claude'; args = @(); installCommand = 'install-claude'; env = @{}; apiKeyEnvVar = 'ANTHROPIC_API_KEY' }
                     codex       = @{ enabled = $true; command = 'codex'; args = @(); installCommand = 'install-codex'; env = @{ OPENAI_API_KEY = '' }; apiKeyEnvVar = 'OPENAI_API_KEY' }
-                    copilot     = @{ enabled = $true; command = 'gh'; args = @('copilot'); installCommand = 'install-copilot'; env = @{} }
+                    copilot     = @{ enabled = $true; command = 'copilot'; args = @('--yolo'); installCommand = 'install-copilot'; env = @{} }
                 }
                 logging = @{
                     enabled = $true
@@ -361,7 +361,7 @@ Describe 'Test-StartupConfigSchema and Assert-StartupConfigSchema' {
                     defaultTool = 'claude'
                     claude      = @{ enabled = $true; command = 'claude'; args = @(); installCommand = 'install-claude'; env = @{}; apiKeyEnvVar = 'ANTHROPIC_API_KEY' }
                     codex       = @{ enabled = $true; command = 'codex'; args = @(); installCommand = 'install-codex'; env = @{ OPENAI_API_KEY = '' }; apiKeyEnvVar = 'OPENAI_API_KEY' }
-                    copilot     = @{ enabled = $true; command = 'gh'; args = @('copilot'); installCommand = 'install-copilot'; env = @{} }
+                    copilot     = @{ enabled = $true; command = 'copilot'; args = @('--yolo'); installCommand = 'install-copilot'; env = @{} }
                 }
                 backupConfig = @{
                     enabled = $true

--- a/tests/StartScripts.Tests.ps1
+++ b/tests/StartScripts.Tests.ps1
@@ -49,9 +49,9 @@ BeforeAll {
             }
             copilot     = @{
                 enabled        = $true
-                command        = 'gh'
-                args           = @('copilot')
-                installCommand = 'winget install GitHub.cli'
+                command        = 'copilot'
+                args           = @('--yolo')
+                installCommand = 'npm install -g @githubnext/github-copilot-cli'
                 env            = @{}
             }
         }
@@ -107,7 +107,7 @@ Describe 'Start-*.ps1 dry-run flows' {
         $scriptPath = Join-Path $script:RepoRoot 'scripts\main\Start-CopilotCLI.ps1'
         $output = & $script:PowerShellExe -NoProfile -File $scriptPath -Project demo -Local -NonInteractive -DryRun 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
-        $output | Should -Match '\[DryRun\].*gh copilot'
+        $output | Should -Match '\[DryRun\].*copilot --yolo'
         $output | Should -Match 'demo'
         (Test-Path (Join-Path $script:ProjectsRoot 'demo\.github\copilot-instructions.md')) | Should -BeTrue
         (Test-Path (Join-Path $script:ProjectsRoot 'demo\.github\mcp.json')) | Should -BeTrue
@@ -188,7 +188,7 @@ Describe 'Start-Menu helper flows' {
                 defaultTool = 'claude'
                 claude = @{ enabled = $true; command = 'claude'; args = @(); installCommand = 'install-claude'; env = @{}; apiKeyEnvVar = 'ANTHROPIC_API_KEY' }
                 codex = @{ enabled = $true; command = 'codex'; args = @(); installCommand = 'install-codex'; env = @{}; apiKeyEnvVar = 'OPENAI_API_KEY' }
-                copilot = @{ enabled = $true; command = 'gh'; args = @('copilot'); installCommand = 'install-copilot'; env = @{} }
+                copilot = @{ enabled = $true; command = 'copilot'; args = @('--yolo'); installCommand = 'install-copilot'; env = @{} }
             }
             recentProjects = @{
                 enabled = $true


### PR DESCRIPTION
## Summary
- テスト設定の copilot を `gh copilot` → `copilot --yolo` に完全統一
- GitHub Actions に `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` 追加で deprecation 解消
- `scripts/claudeos-back/` バックアップ削除
- README に `gh auth refresh -s read:project,project` の案内追加 (Issue #15)

## テスト結果
- Pester: **109 passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #15