### PR TITLE
feat: Agent Teams ランタイム・multi-agent 自動割当

### DIFF
--- a/scripts/lib/AgentTeams.psm1
+++ b/scripts/lib/AgentTeams.psm1
@@ -1,0 +1,380 @@
+# ============================================================
+# AgentTeams.psm1 - Agent Teams runtime engine
+# ClaudeCLI-CodexCLI-CopilotCLI-StartUpTools v2.7.0
+# ============================================================
+
+Set-StrictMode -Version Latest
+
+$script:CoreRoles = @(
+    [pscustomobject]@{ role = 'CTO';       emoji = '🧠'; agents = @('loop-operator', 'planner') }
+    [pscustomobject]@{ role = 'Architect';  emoji = '🏗'; agents = @('architect', 'api-designer') }
+    [pscustomobject]@{ role = 'Developer';  emoji = '👨‍💻'; agents = @() }
+    [pscustomobject]@{ role = 'QA';         emoji = '🧪'; agents = @('qa', 'tdd-guide', 'e2e-runner') }
+    [pscustomobject]@{ role = 'Security';   emoji = '🔐'; agents = @('security', 'security-reviewer') }
+    [pscustomobject]@{ role = 'DevOps';     emoji = '🚀'; agents = @('ops', 'release-manager') }
+    [pscustomobject]@{ role = 'Reviewer';   emoji = '🔎'; agents = @('code-reviewer') }
+)
+
+$script:TaskTypePatterns = @(
+    [pscustomobject]@{ type = 'api';       pattern = 'API|REST|endpoint|backend|サーバー';                      agents = @('dev-api', 'api-designer') }
+    [pscustomobject]@{ type = 'ui';        pattern = 'UI|frontend|フロントエンド|React|Vue|画面';               agents = @('dev-ui') }
+    [pscustomobject]@{ type = 'database';  pattern = 'DB|database|migration|スキーマ|テーブル';                 agents = @('database-reviewer') }
+    [pscustomobject]@{ type = 'security';  pattern = 'security|auth|認証|権限|脆弱性|secret';                  agents = @('security-reviewer') }
+    [pscustomobject]@{ type = 'ci';        pattern = 'CI|CD|pipeline|Actions|build|デプロイ';                   agents = @('ops', 'build-error-resolver') }
+    [pscustomobject]@{ type = 'test';      pattern = 'test|テスト|Pester|Jest|E2E|品質';                       agents = @('tester', 'tdd-guide', 'e2e-runner') }
+    [pscustomobject]@{ type = 'refactor';  pattern = 'refactor|リファクタ|整理|命名|技術負債';                  agents = @('refactor-cleaner') }
+    [pscustomobject]@{ type = 'docs';      pattern = 'docs|README|ドキュメント|documentation';                  agents = @('doc-updater') }
+    [pscustomobject]@{ type = 'incident';  pattern = 'incident|障害|緊急|ダウン|復旧';                          agents = @('incident-triager', 'build-error-resolver') }
+    [pscustomobject]@{ type = 'typescript';pattern = 'TypeScript|ts|tsx|Node\.js';                              agents = @('typescript-reviewer') }
+    [pscustomobject]@{ type = 'python';    pattern = 'Python|Django|Flask|FastAPI|pip';                         agents = @('python-reviewer') }
+    [pscustomobject]@{ type = 'go';        pattern = 'Go|golang|go\.mod';                                      agents = @('go-reviewer', 'go-build-resolver') }
+    [pscustomobject]@{ type = 'rust';      pattern = 'Rust|cargo|Cargo\.toml';                                  agents = @('rust-reviewer', 'rust-build-resolver') }
+    [pscustomobject]@{ type = 'java';      pattern = 'Java|Spring|Maven|Gradle';                                agents = @('java-reviewer', 'java-build-resolver') }
+    [pscustomobject]@{ type = 'cpp';       pattern = 'C\+\+|cpp|CMake';                                        agents = @('cpp-reviewer', 'cpp-build-resolver') }
+    [pscustomobject]@{ type = 'kotlin';    pattern = 'Kotlin|Android';                                          agents = @('kotlin-reviewer', 'kotlin-build-resolver') }
+)
+
+function Import-AgentDefinitions {
+    param(
+        [Parameter(Mandatory)]
+        [string]$AgentsDir
+    )
+
+    $agents = @()
+    if (-not (Test-Path $AgentsDir)) {
+        return $agents
+    }
+
+    foreach ($file in @(Get-ChildItem -Path $AgentsDir -Filter '*.md' -File | Where-Object { $_.Name -ne 'CLAUDE.md' })) {
+        $content = Get-Content -Path $file.FullName -Raw -Encoding UTF8
+        $agent = [ordered]@{
+            id          = $file.BaseName
+            name        = $file.BaseName
+            description = ''
+            tools       = @()
+            filePath    = $file.FullName
+        }
+
+        if ($content -match '(?s)^---\s*\r?\n(.+?)\r?\n---') {
+            $frontmatter = $Matches[1]
+            foreach ($line in ($frontmatter -split '\r?\n')) {
+                if ($line -match '^name:\s*(.+)$') {
+                    $agent.name = $Matches[1].Trim()
+                }
+                elseif ($line -match '^description:\s*(.+)$') {
+                    $agent.description = $Matches[1].Trim()
+                }
+                elseif ($line -match '^tools:\s*(.+)$') {
+                    $agent.tools = @($Matches[1].Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+                }
+            }
+        }
+
+        if (-not $agent.description) {
+            $bodyLines = ($content -replace '(?s)^---\s*\r?\n.+?\r?\n---\s*\r?\n', '') -split '\r?\n'
+            foreach ($bodyLine in $bodyLines) {
+                $trimmed = $bodyLine.Trim()
+                if ($trimmed -and $trimmed -notmatch '^#') {
+                    $agent.description = $trimmed
+                    break
+                }
+            }
+        }
+
+        $agents += [pscustomobject]$agent
+    }
+
+    return $agents
+}
+
+function Get-TaskTypeAnalysis {
+    param(
+        [Parameter(Mandatory)]
+        [string]$TaskDescription
+    )
+
+    $matchedTypes = @()
+    $matchedAgents = @()
+
+    foreach ($tp in $script:TaskTypePatterns) {
+        if ($TaskDescription -match $tp.pattern) {
+            $matchedTypes += $tp.type
+            $matchedAgents += $tp.agents
+        }
+    }
+
+    $matchedAgents = @($matchedAgents | Select-Object -Unique)
+
+    if ($matchedTypes.Count -eq 0) {
+        $matchedTypes = @('general')
+    }
+
+    return [pscustomobject]@{
+        types  = $matchedTypes
+        agents = $matchedAgents
+    }
+}
+
+function Get-BacklogRuleMatch {
+    param(
+        [Parameter(Mandatory)]
+        [string]$TaskDescription,
+        [string]$RulesPath
+    )
+
+    $result = [pscustomobject]@{
+        priority = 'P2'
+        owner    = 'ScrumMaster'
+        source   = 'AgentTeamsMatrix'
+        matched  = $false
+    }
+
+    if (-not $RulesPath -or -not (Test-Path $RulesPath)) {
+        return $result
+    }
+
+    try {
+        $rules = Get-Content -Path $RulesPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+        foreach ($rule in @($rules.rules)) {
+            if ($TaskDescription -match $rule.pattern) {
+                $result.priority = $rule.priority
+                $result.owner = $rule.owner
+                $result.matched = $true
+                break
+            }
+        }
+
+        if (-not $result.matched -and $rules.default) {
+            $result.priority = $rules.default.priority
+            $result.owner = $rules.default.owner
+            $result.source = $rules.default.source
+        }
+    }
+    catch {
+        # rules file parse error - use defaults
+    }
+
+    return $result
+}
+
+function New-AgentTeam {
+    param(
+        [Parameter(Mandatory)]
+        [string]$TaskDescription,
+        [string]$AgentsDir,
+        [string]$RulesPath
+    )
+
+    $analysis = Get-TaskTypeAnalysis -TaskDescription $TaskDescription
+    $backlogRule = Get-BacklogRuleMatch -TaskDescription $TaskDescription -RulesPath $RulesPath
+
+    $availableAgents = @()
+    if ($AgentsDir -and (Test-Path $AgentsDir)) {
+        $availableAgents = @(Import-AgentDefinitions -AgentsDir $AgentsDir)
+    }
+
+    $team = [ordered]@{
+        taskDescription = $TaskDescription
+        taskTypes       = $analysis.types
+        priority        = $backlogRule.priority
+        owner           = $backlogRule.owner
+        coreTeam        = @()
+        specialists     = @()
+        allAgentIds     = @()
+        teamSize        = 0
+    }
+
+    foreach ($coreRole in $script:CoreRoles) {
+        $roleAgents = @()
+        foreach ($agentId in $coreRole.agents) {
+            $found = $availableAgents | Where-Object { $_.id -eq $agentId } | Select-Object -First 1
+            if ($found) {
+                $roleAgents += $found
+            }
+        }
+        $team.coreTeam += [pscustomobject]@{
+            role       = $coreRole.role
+            emoji      = $coreRole.emoji
+            agentIds   = @($coreRole.agents)
+            agentCount = $roleAgents.Count
+        }
+    }
+
+    $specialistIds = @()
+    foreach ($agentId in $analysis.agents) {
+        $coreAgentIds = @($script:CoreRoles | ForEach-Object { $_.agents } | ForEach-Object { $_ })
+        if ($agentId -notin $coreAgentIds) {
+            $found = $availableAgents | Where-Object { $_.id -eq $agentId } | Select-Object -First 1
+            if ($found) {
+                $team.specialists += [pscustomobject]@{
+                    id          = $found.id
+                    name        = $found.name
+                    description = $found.description
+                    reason      = "Task type match: $($analysis.types -join ', ')"
+                }
+                $specialistIds += $found.id
+            }
+        }
+    }
+
+    $team.allAgentIds = @(
+        @($script:CoreRoles | ForEach-Object { $_.agents } | ForEach-Object { $_ }) +
+        $specialistIds
+    ) | Select-Object -Unique
+    $team.teamSize = $team.coreTeam.Count + $team.specialists.Count
+
+    return [pscustomobject]$team
+}
+
+function Format-AgentTeamDiscussion {
+    param(
+        [Parameter(Mandatory)]
+        [pscustomobject]$Team,
+        [string]$Topic
+    )
+
+    $lines = @()
+    $lines += ''
+    $lines += "=== Agent Teams Discussion ==="
+    $lines += "Topic: $Topic"
+    $lines += "Task Types: $($Team.taskTypes -join ', ')"
+    $lines += "Priority: $($Team.priority) | Owner: $($Team.owner)"
+    $lines += ''
+
+    foreach ($role in @($Team.coreTeam)) {
+        $agentList = if ($role.agentIds.Count -gt 0) { $role.agentIds -join ', ' } else { '(auto-assign)' }
+        $lines += "  $($role.emoji) **$($role.role)**: [$agentList]"
+    }
+
+    if (@($Team.specialists).Count -gt 0) {
+        $lines += ''
+        $lines += '  --- Specialists ---'
+        foreach ($specialist in @($Team.specialists)) {
+            $lines += "  + $($specialist.name): $($specialist.description)"
+            $lines += "    Reason: $($specialist.reason)"
+        }
+    }
+
+    $lines += ''
+    $lines += "Team Size: $($Team.teamSize) roles ($(@($Team.specialists).Count) specialists)"
+    $lines += "=== End Discussion ==="
+    $lines += ''
+
+    return ($lines -join "`n")
+}
+
+function Show-AgentTeamComposition {
+    param(
+        [Parameter(Mandatory)]
+        [pscustomobject]$Team
+    )
+
+    Write-Host ''
+    Write-Host '=== Agent Team Composition ===' -ForegroundColor Magenta
+    Write-Host "Task: $($Team.taskDescription)" -ForegroundColor Cyan
+    Write-Host "Types: $($Team.taskTypes -join ', ') | Priority: $($Team.priority) | Owner: $($Team.owner)" -ForegroundColor DarkGray
+    Write-Host ''
+
+    Write-Host '  Core Team:' -ForegroundColor Yellow
+    foreach ($role in @($Team.coreTeam)) {
+        $agentList = if ($role.agentIds.Count -gt 0) { $role.agentIds -join ', ' } else { '(auto-assign)' }
+        Write-Host "    $($role.emoji) $($role.role): $agentList" -ForegroundColor Green
+    }
+
+    if (@($Team.specialists).Count -gt 0) {
+        Write-Host ''
+        Write-Host '  Specialists:' -ForegroundColor Yellow
+        foreach ($specialist in @($Team.specialists)) {
+            Write-Host "    + $($specialist.name)" -ForegroundColor Cyan
+            Write-Host "      $($specialist.description)" -ForegroundColor DarkGray
+        }
+    }
+
+    Write-Host ''
+    Write-Host "  Team Size: $($Team.teamSize) roles ($(@($Team.specialists).Count) specialists)" -ForegroundColor Magenta
+    Write-Host ''
+}
+
+function Get-AgentTeamReport {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot,
+        [string]$TaskDescription = ''
+    )
+
+    $agentsDir = Join-Path $ProjectRoot '.claude\claudeos\agents'
+    $rulesPath = Join-Path $ProjectRoot 'config\agent-teams-backlog-rules.json'
+
+    $availableAgents = @()
+    if (Test-Path $agentsDir) {
+        $availableAgents = @(Import-AgentDefinitions -AgentsDir $agentsDir)
+    }
+
+    $report = [ordered]@{
+        agentsDir       = $agentsDir
+        agentsDirExists = (Test-Path $agentsDir)
+        agentCount      = $availableAgents.Count
+        agents          = $availableAgents
+        rulesPath       = $rulesPath
+        rulesExist      = (Test-Path $rulesPath)
+        team            = $null
+    }
+
+    if ($TaskDescription) {
+        $report.team = New-AgentTeam -TaskDescription $TaskDescription -AgentsDir $agentsDir -RulesPath $rulesPath
+    }
+
+    return [pscustomobject]$report
+}
+
+function Show-AgentTeamReport {
+    param([pscustomobject]$Report)
+
+    Write-Host ''
+    Write-Host '=== Agent Teams Runtime ===' -ForegroundColor Magenta
+    Write-Host ''
+
+    if ($Report.agentsDirExists) {
+        Write-Host "[ OK ] Agent definitions: $($Report.agentCount) agents loaded" -ForegroundColor Green
+        Write-Host "       Path: $($Report.agentsDir)" -ForegroundColor DarkGray
+    }
+    else {
+        Write-Host "[WARN] Agent definitions directory not found: $($Report.agentsDir)" -ForegroundColor Yellow
+    }
+
+    if ($Report.rulesExist) {
+        Write-Host "[ OK ] Backlog rules: $($Report.rulesPath)" -ForegroundColor Green
+    }
+    else {
+        Write-Host "[WARN] Backlog rules not found: $($Report.rulesPath)" -ForegroundColor Yellow
+    }
+
+    Write-Host ''
+
+    if ($Report.agentCount -gt 0) {
+        Write-Host '  Available Agents:' -ForegroundColor Yellow
+        foreach ($agent in @($Report.agents)) {
+            $desc = if ($agent.description) { " - $($agent.description)" } else { '' }
+            Write-Host "    $($agent.id)$desc" -ForegroundColor Cyan
+        }
+    }
+
+    if ($null -ne $Report.team) {
+        Write-Host ''
+        Show-AgentTeamComposition -Team $Report.team
+    }
+
+    Write-Host ''
+}
+
+Export-ModuleMember -Function @(
+    'Import-AgentDefinitions',
+    'Get-TaskTypeAnalysis',
+    'Get-BacklogRuleMatch',
+    'New-AgentTeam',
+    'Format-AgentTeamDiscussion',
+    'Show-AgentTeamComposition',
+    'Get-AgentTeamReport',
+    'Show-AgentTeamReport'
+)

--- a/scripts/main/Start-Menu.ps1
+++ b/scripts/main/Start-Menu.ps1
@@ -211,6 +211,7 @@ function Show-Menu {
     Write-Host "    6.  ドライブマッピング診断" -ForegroundColor Magenta
     Write-Host "    7.  Windows Terminal セットアップ" -ForegroundColor Magenta
     Write-Host "    8.  MCP ヘルスチェック" -ForegroundColor Magenta
+    Write-Host "    9.  Agent Teams ランタイム" -ForegroundColor Magenta
     Write-Host ""
 
     Write-Host "    0.  終了" -ForegroundColor Gray
@@ -293,6 +294,7 @@ while ($true) {
         "6"  { Invoke-MenuScript -File "scripts\test\test-drive-mapping.ps1" }
         "7"  { Invoke-MenuScript -File "scripts\setup\setup-windows-terminal.ps1" }
         "8"  { Invoke-MenuScript -File "scripts\test\Test-McpHealth.ps1" }
+        "9"  { Invoke-MenuScript -File "scripts\test\Test-AgentTeams.ps1" }
         "0"  { exit 0 }
         default {
             Write-Host ""

--- a/scripts/test/Test-AgentTeams.ps1
+++ b/scripts/test/Test-AgentTeams.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+    Agent Teams runtime diagnostic and team composition tool.
+.DESCRIPTION
+    Displays available agents, analyzes a task description, and shows
+    the recommended team composition with specialist assignments.
+#>
+
+param(
+    [ValidateSet('Text', 'Json')]
+    [string]$OutputFormat = 'Text',
+    [string]$ProjectRoot,
+    [string]$Task = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Continue'
+
+if (-not $ProjectRoot) {
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+}
+
+Import-Module (Join-Path $ProjectRoot 'scripts\lib\AgentTeams.psm1') -Force
+
+$report = Get-AgentTeamReport -ProjectRoot $ProjectRoot -TaskDescription $Task
+
+if ($OutputFormat -eq 'Json') {
+    $report | ConvertTo-Json -Depth 8
+}
+else {
+    Show-AgentTeamReport -Report $report
+}

--- a/tests/AgentTeams.Tests.ps1
+++ b/tests/AgentTeams.Tests.ps1
@@ -1,0 +1,356 @@
+# ============================================================
+# AgentTeams.Tests.ps1 - AgentTeams.psm1 のユニットテスト
+# Pester 5.x
+# ============================================================
+
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    Import-Module (Join-Path $script:RepoRoot 'scripts\lib\AgentTeams.psm1') -Force
+}
+
+Describe 'Import-AgentDefinitions' {
+
+    Context 'agents ディレクトリが存在する場合' {
+
+        BeforeAll {
+            $script:AgentsDir = Join-Path $TestDrive 'agents'
+            New-Item -ItemType Directory -Path $script:AgentsDir -Force | Out-Null
+
+            $frontmatterAgent = @"
+---
+name: test-architect
+description: Test architecture agent
+tools: Read, Write, Edit
+---
+
+# Test Architect
+
+Designs systems.
+"@
+            Set-Content -Path (Join-Path $script:AgentsDir 'test-architect.md') -Value $frontmatterAgent -Encoding UTF8
+
+            $simplAgent = @"
+# Simple Agent
+
+Handles simple tasks.
+"@
+            Set-Content -Path (Join-Path $script:AgentsDir 'simple-agent.md') -Value $simplAgent -Encoding UTF8
+
+            Set-Content -Path (Join-Path $script:AgentsDir 'CLAUDE.md') -Value '# skip' -Encoding UTF8
+        }
+
+        It 'Agent 定義ファイルを読み込めること' {
+            $result = Import-AgentDefinitions -AgentsDir $script:AgentsDir
+            @($result).Count | Should -Be 2
+        }
+
+        It 'frontmatter の name を正しくパースすること' {
+            $result = Import-AgentDefinitions -AgentsDir $script:AgentsDir
+            $architect = @($result) | Where-Object { $_.id -eq 'test-architect' }
+            $architect.name | Should -Be 'test-architect'
+        }
+
+        It 'frontmatter の description を正しくパースすること' {
+            $result = Import-AgentDefinitions -AgentsDir $script:AgentsDir
+            $architect = @($result) | Where-Object { $_.id -eq 'test-architect' }
+            $architect.description | Should -Be 'Test architecture agent'
+        }
+
+        It 'frontmatter の tools を配列としてパースすること' {
+            $result = Import-AgentDefinitions -AgentsDir $script:AgentsDir
+            $architect = @($result) | Where-Object { $_.id -eq 'test-architect' }
+            $architect.tools.Count | Should -Be 3
+            $architect.tools[0] | Should -Be 'Read'
+        }
+
+        It 'frontmatter がない場合は本文から description を抽出すること' {
+            $result = Import-AgentDefinitions -AgentsDir $script:AgentsDir
+            $simple = @($result) | Where-Object { $_.id -eq 'simple-agent' }
+            $simple.description | Should -Be 'Handles simple tasks.'
+        }
+
+        It 'CLAUDE.md をスキップすること' {
+            $result = Import-AgentDefinitions -AgentsDir $script:AgentsDir
+            $claude = @($result) | Where-Object { $_.id -eq 'CLAUDE' }
+            $claude | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'agents ディレクトリが存在しない場合' {
+        It '空配列を返すこと' {
+            $result = Import-AgentDefinitions -AgentsDir (Join-Path $TestDrive 'nonexistent')
+            @($result).Count | Should -Be 0
+        }
+    }
+
+    Context '実際の claudeos agents を読み込む場合' {
+        It '30 個以上の Agent を読み込めること' {
+            $agentsDir = Join-Path $script:RepoRoot '.claude\claudeos\agents'
+            if (Test-Path $agentsDir) {
+                $result = Import-AgentDefinitions -AgentsDir $agentsDir
+                @($result).Count | Should -BeGreaterOrEqual 30
+            }
+        }
+    }
+}
+
+Describe 'Get-TaskTypeAnalysis' {
+
+    Context 'API 関連タスクの場合' {
+        It 'api タイプが含まれること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription 'Create REST API endpoint'
+            $result.types | Should -Contain 'api'
+        }
+
+        It 'dev-api が推薦されること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription 'Build REST API'
+            $result.agents | Should -Contain 'dev-api'
+        }
+    }
+
+    Context 'セキュリティ関連タスクの場合' {
+        It 'security タイプが含まれること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription '認証モジュールのセキュリティレビュー'
+            $result.types | Should -Contain 'security'
+        }
+    }
+
+    Context 'CI 関連タスクの場合' {
+        It 'ci タイプが含まれること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription 'Fix CI pipeline build failure'
+            $result.types | Should -Contain 'ci'
+        }
+
+        It 'build-error-resolver が推薦されること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription 'CI build fails'
+            $result.agents | Should -Contain 'build-error-resolver'
+        }
+    }
+
+    Context '複数タイプが該当する場合' {
+        It '複数タイプが返されること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription 'API endpoint with database migration and security audit'
+            $result.types.Count | Should -BeGreaterOrEqual 3
+        }
+
+        It 'エージェントが重複なしで返されること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription 'security authentication security review'
+            $uniqueCount = ($result.agents | Select-Object -Unique).Count
+            $uniqueCount | Should -Be $result.agents.Count
+        }
+    }
+
+    Context 'マッチしないタスクの場合' {
+        It 'general タイプが返されること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription 'do something completely unrelated xyz'
+            $result.types | Should -Contain 'general'
+        }
+    }
+
+    Context '言語別マッチの場合' {
+        It 'TypeScript タスクが検出されること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription 'Fix TypeScript type errors'
+            $result.types | Should -Contain 'typescript'
+            $result.agents | Should -Contain 'typescript-reviewer'
+        }
+
+        It 'Python タスクが検出されること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription 'Django model migration'
+            $result.types | Should -Contain 'python'
+        }
+
+        It 'Rust タスクが検出されること' {
+            $result = Get-TaskTypeAnalysis -TaskDescription 'Update Cargo.toml dependencies'
+            $result.types | Should -Contain 'rust'
+        }
+    }
+}
+
+Describe 'Get-BacklogRuleMatch' {
+
+    Context '有効な rules ファイルの場合' {
+
+        BeforeAll {
+            $script:RulesPath = Join-Path $TestDrive 'rules.json'
+            $rules = @{
+                default = @{ priority = 'P3'; owner = 'Default'; source = 'Test' }
+                rules   = @(
+                    @{ pattern = 'MCP|memory';         priority = 'P1'; owner = 'Ops' }
+                    @{ pattern = 'Agent Teams';         priority = 'P1'; owner = 'Architect' }
+                    @{ pattern = 'docs|README';         priority = 'P2'; owner = 'ScrumMaster' }
+                )
+            } | ConvertTo-Json -Depth 5
+            Set-Content -Path $script:RulesPath -Value $rules -Encoding UTF8
+        }
+
+        It 'MCP タスクに P1/Ops が割り当てられること' {
+            $result = Get-BacklogRuleMatch -TaskDescription 'MCP server health check' -RulesPath $script:RulesPath
+            $result.priority | Should -Be 'P1'
+            $result.owner | Should -Be 'Ops'
+            $result.matched | Should -Be $true
+        }
+
+        It 'Agent Teams タスクに P1/Architect が割り当てられること' {
+            $result = Get-BacklogRuleMatch -TaskDescription 'Agent Teams runtime implementation' -RulesPath $script:RulesPath
+            $result.priority | Should -Be 'P1'
+            $result.owner | Should -Be 'Architect'
+        }
+
+        It 'マッチしないタスクにデフォルトが適用されること' {
+            $result = Get-BacklogRuleMatch -TaskDescription 'random task xyz' -RulesPath $script:RulesPath
+            $result.priority | Should -Be 'P3'
+            $result.owner | Should -Be 'Default'
+            $result.matched | Should -Be $false
+        }
+    }
+
+    Context 'rules ファイルが存在しない場合' {
+        It 'デフォルト値を返すこと' {
+            $result = Get-BacklogRuleMatch -TaskDescription 'test' -RulesPath (Join-Path $TestDrive 'nonexistent.json')
+            $result.priority | Should -Be 'P2'
+            $result.owner | Should -Be 'ScrumMaster'
+        }
+    }
+}
+
+Describe 'New-AgentTeam' {
+
+    BeforeAll {
+        $script:AgentsDir = Join-Path $TestDrive 'team-agents'
+        New-Item -ItemType Directory -Path $script:AgentsDir -Force | Out-Null
+
+        foreach ($name in @('architect', 'planner', 'loop-operator', 'qa', 'security', 'ops', 'code-reviewer', 'api-designer', 'dev-api', 'tester', 'database-reviewer')) {
+            $content = "---`nname: $name`ndescription: $name agent for testing`ntools: Read`n---`n# $name"
+            Set-Content -Path (Join-Path $script:AgentsDir "$name.md") -Value $content -Encoding UTF8
+        }
+
+        $script:RulesPath = Join-Path $TestDrive 'team-rules.json'
+        @{
+            default = @{ priority = 'P2'; owner = 'ScrumMaster'; source = 'Test' }
+            rules   = @(
+                @{ pattern = 'API'; priority = 'P1'; owner = 'DevAPI' }
+            )
+        } | ConvertTo-Json -Depth 5 | Set-Content -Path $script:RulesPath -Encoding UTF8
+    }
+
+    Context 'API タスクの場合' {
+        It 'P1 優先度が設定されること' {
+            $team = New-AgentTeam -TaskDescription 'Create REST API endpoint' -AgentsDir $script:AgentsDir -RulesPath $script:RulesPath
+            $team.priority | Should -Be 'P1'
+        }
+
+        It 'dev-api が specialist に含まれること' {
+            $team = New-AgentTeam -TaskDescription 'REST API implementation' -AgentsDir $script:AgentsDir -RulesPath $script:RulesPath
+            @($team.specialists) | Where-Object { $_.id -eq 'dev-api' } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Core Team の構成' {
+        It '7 つの Core Role が含まれること' {
+            $team = New-AgentTeam -TaskDescription 'general task' -AgentsDir $script:AgentsDir -RulesPath $script:RulesPath
+            @($team.coreTeam).Count | Should -Be 7
+        }
+
+        It 'CTO ロールが含まれること' {
+            $team = New-AgentTeam -TaskDescription 'test task' -AgentsDir $script:AgentsDir -RulesPath $script:RulesPath
+            $cto = @($team.coreTeam) | Where-Object { $_.role -eq 'CTO' }
+            $cto | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'taskTypes の検出' {
+        It 'database タスクが検出されること' {
+            $team = New-AgentTeam -TaskDescription 'Database migration for user table' -AgentsDir $script:AgentsDir -RulesPath $script:RulesPath
+            $team.taskTypes | Should -Contain 'database'
+        }
+    }
+}
+
+Describe 'Format-AgentTeamDiscussion' {
+
+    Context '正常なチームの場合' {
+        It '文字列を返すこと' {
+            $team = New-AgentTeam -TaskDescription 'test task' -AgentsDir (Join-Path $TestDrive 'nonexistent')
+            $result = Format-AgentTeamDiscussion -Team $team -Topic 'Test topic'
+            $result | Should -BeOfType [string]
+        }
+
+        It 'Topic が含まれること' {
+            $team = New-AgentTeam -TaskDescription 'test task' -AgentsDir (Join-Path $TestDrive 'nonexistent')
+            $result = Format-AgentTeamDiscussion -Team $team -Topic 'Important decision'
+            $result | Should -Match 'Important decision'
+        }
+
+        It 'CTO ロールが含まれること' {
+            $team = New-AgentTeam -TaskDescription 'test task' -AgentsDir (Join-Path $TestDrive 'nonexistent')
+            $result = Format-AgentTeamDiscussion -Team $team -Topic 'test'
+            $result | Should -Match 'CTO'
+        }
+    }
+}
+
+Describe 'Show-AgentTeamComposition' {
+
+    Context '正常なチームの場合' {
+        It 'エラーなしで実行できること' {
+            $team = New-AgentTeam -TaskDescription 'Build REST API' -AgentsDir (Join-Path $TestDrive 'nonexistent')
+            { Show-AgentTeamComposition -Team $team } | Should -Not -Throw
+        }
+    }
+}
+
+Describe 'Get-AgentTeamReport' {
+
+    Context '実プロジェクトルートの場合' {
+        It 'agent 定義を読み込めること' {
+            $report = Get-AgentTeamReport -ProjectRoot $script:RepoRoot
+            $report.agentsDirExists | Should -Be $true
+            $report.agentCount | Should -BeGreaterOrEqual 30
+        }
+
+        It 'rules ファイルが存在すること' {
+            $report = Get-AgentTeamReport -ProjectRoot $script:RepoRoot
+            $report.rulesExist | Should -Be $true
+        }
+    }
+
+    Context 'TaskDescription を指定した場合' {
+        It 'team が生成されること' {
+            $report = Get-AgentTeamReport -ProjectRoot $script:RepoRoot -TaskDescription 'Fix CI build errors'
+            $report.team | Should -Not -BeNullOrEmpty
+            $report.team.taskTypes | Should -Contain 'ci'
+        }
+    }
+
+    Context 'TaskDescription を指定しない場合' {
+        It 'team が null であること' {
+            $report = Get-AgentTeamReport -ProjectRoot $script:RepoRoot
+            $report.team | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Show-AgentTeamReport' {
+
+    Context '正常なレポートの場合' {
+        It 'エラーなしで実行できること' {
+            $report = Get-AgentTeamReport -ProjectRoot $script:RepoRoot -TaskDescription 'Test task'
+            { Show-AgentTeamReport -Report $report } | Should -Not -Throw
+        }
+    }
+
+    Context 'エージェントなしのレポートの場合' {
+        It 'エラーなしで実行できること' {
+            $report = [pscustomobject]@{
+                agentsDir       = 'nonexistent'
+                agentsDirExists = $false
+                agentCount      = 0
+                agents          = @()
+                rulesPath       = 'nonexistent'
+                rulesExist      = $false
+                team            = $null
+            }
+            { Show-AgentTeamReport -Report $report } | Should -Not -Throw
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Agent Teams ランタイムエンジンを `scripts/lib/AgentTeams.psm1` として新規実装
- 37のAgent定義（.md frontmatter）を読み込み、タスク種別に応じて自動Team構成
- 17パターンのタスク分類 × backlog-rules.json連携による優先度・オーナー自動判定
- Start-Menu に「9. Agent Teams ランタイム」メニュー追加

## Architecture

```
TaskDescription → Get-TaskTypeAnalysis → Get-BacklogRuleMatch
                                      ↓
                              New-AgentTeam
                              ├── 7 Core Roles (CTO/Architect/Developer/QA/Security/DevOps/Reviewer)
                              └── Task-specific Specialists (auto-selected from 37 agents)
```

## Changes
| ファイル | 変更内容 |
|----------|----------|
| `scripts/lib/AgentTeams.psm1` | 新規: Agent Teams ランタイムモジュール (380行) |
| `scripts/test/Test-AgentTeams.ps1` | 新規: スタンドアロン診断スクリプト |
| `tests/AgentTeams.Tests.ps1` | 新規: Pester テスト (30+ ケース) |
| `scripts/main/Start-Menu.ps1` | 変更: メニュー項目「9」追加 |

## Test plan
- [ ] CI (全Pesterテスト) が全パス
- [ ] `Test-AgentTeams.ps1` のText/Json両出力が正常
- [ ] 37 Agent定義が正しくロードされる
- [ ] タスク種別自動分類が正しく動作する
- [ ] Start-Menu の「9」でAgent Teams診断が起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)