### PR TITLE
feat: Worktree Manager 実装 — 並列ブランチ自動管理

### DIFF
--- a/scripts/lib/WorktreeManager.psm1
+++ b/scripts/lib/WorktreeManager.psm1
@@ -1,0 +1,297 @@
+# ============================================================
+# WorktreeManager.psm1 - Git Worktree management module
+# ClaudeCLI-CodexCLI-CopilotCLI-StartUpTools v2.7.0
+# Issue #32: Worktree Manager implementation
+# ============================================================
+
+Set-StrictMode -Version Latest
+
+$script:DefaultWorktreeBase = '.worktrees'
+
+function Get-WorktreeBasePath {
+    param(
+        [string]$RepoRoot
+    )
+
+    if (-not $RepoRoot) {
+        $RepoRoot = (git rev-parse --show-toplevel 2>$null)
+        if (-not $RepoRoot) {
+            throw "Not inside a Git repository."
+        }
+    }
+    return Join-Path $RepoRoot $script:DefaultWorktreeBase
+}
+
+function Get-Worktree {
+    <#
+    .SYNOPSIS
+        Lists all Git worktrees for the current repository.
+    .DESCRIPTION
+        Parses 'git worktree list --porcelain' output and returns structured objects.
+    .PARAMETER RepoRoot
+        Repository root path. Auto-detected if omitted.
+    #>
+    param(
+        [string]$RepoRoot
+    )
+
+    if (-not $RepoRoot) {
+        $RepoRoot = (git rev-parse --show-toplevel 2>$null)
+        if (-not $RepoRoot) {
+            throw "Not inside a Git repository."
+        }
+    }
+
+    $raw = git -C $RepoRoot worktree list --porcelain 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to list worktrees: $raw"
+    }
+
+    $worktrees = @()
+    $current = @{}
+    $normalizedRoot = [System.IO.Path]::GetFullPath($RepoRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+
+    foreach ($line in $raw) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            if ($current.Count -gt 0) {
+                $wtPath = $current['worktree']
+                $normalizedWt = [System.IO.Path]::GetFullPath($wtPath).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+                $worktrees += [pscustomobject]@{
+                    Path     = $wtPath
+                    Commit   = $current['HEAD']
+                    Branch   = if ($current.ContainsKey('branch')) { $current['branch'] -replace '^refs/heads/', '' } else { $null }
+                    IsBare   = $current.ContainsKey('bare')
+                    IsMain   = ($normalizedWt -eq $normalizedRoot)
+                }
+                $current = @{}
+            }
+            continue
+        }
+
+        if ($line -match '^worktree (.+)$') {
+            $current['worktree'] = $Matches[1]
+        }
+        elseif ($line -match '^HEAD (.+)$') {
+            $current['HEAD'] = $Matches[1]
+        }
+        elseif ($line -match '^branch (.+)$') {
+            $current['branch'] = $Matches[1]
+        }
+        elseif ($line -eq 'bare') {
+            $current['bare'] = $true
+        }
+    }
+
+    # Flush last entry
+    if ($current.Count -gt 0) {
+        $wtPath = $current['worktree']
+        $normalizedWt = [System.IO.Path]::GetFullPath($wtPath).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+        $worktrees += [pscustomobject]@{
+            Path     = $wtPath
+            Commit   = $current['HEAD']
+            Branch   = if ($current.ContainsKey('branch')) { $current['branch'] -replace '^refs/heads/', '' } else { $null }
+            IsBare   = $current.ContainsKey('bare')
+            IsMain   = ($normalizedWt -eq $normalizedRoot)
+        }
+    }
+
+    return $worktrees
+}
+
+function New-Worktree {
+    <#
+    .SYNOPSIS
+        Creates a new Git worktree with a feature branch.
+    .PARAMETER BranchName
+        Name of the branch to create (e.g., 'feat/my-feature').
+    .PARAMETER BaseBranch
+        Base branch to branch from. Defaults to 'main'.
+    .PARAMETER RepoRoot
+        Repository root path. Auto-detected if omitted.
+    .PARAMETER WorktreeDir
+        Custom worktree directory path. Auto-generated under .worktrees/ if omitted.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$BranchName,
+
+        [string]$BaseBranch = 'main',
+        [string]$RepoRoot,
+        [string]$WorktreeDir
+    )
+
+    if (-not $RepoRoot) {
+        $RepoRoot = (git rev-parse --show-toplevel 2>$null)
+        if (-not $RepoRoot) {
+            throw "Not inside a Git repository."
+        }
+    }
+
+    # Check if branch already exists
+    $existingBranch = git -C $RepoRoot branch --list $BranchName 2>$null
+    if ($existingBranch) {
+        throw "Branch '$BranchName' already exists. Use Switch-Worktree or choose a different name."
+    }
+
+    # Generate worktree path
+    if (-not $WorktreeDir) {
+        $basePath = Get-WorktreeBasePath -RepoRoot $RepoRoot
+        $safeName = $BranchName -replace '[/\\:]', '-'
+        $WorktreeDir = Join-Path $basePath $safeName
+    }
+
+    if (Test-Path $WorktreeDir) {
+        throw "Worktree directory already exists: $WorktreeDir"
+    }
+
+    # Ensure base directory exists
+    $parentDir = Split-Path -Parent $WorktreeDir
+    if (-not (Test-Path $parentDir)) {
+        New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+    }
+
+    # Create worktree with new branch
+    $result = git -C $RepoRoot worktree add -b $BranchName $WorktreeDir $BaseBranch 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to create worktree: $result"
+    }
+
+    return [pscustomobject]@{
+        Path       = $WorktreeDir
+        Branch     = $BranchName
+        BaseBranch = $BaseBranch
+        Created    = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+    }
+}
+
+function Switch-Worktree {
+    <#
+    .SYNOPSIS
+        Returns the path to an existing worktree by branch name.
+    .DESCRIPTION
+        Finds the worktree directory for a given branch. Useful for navigating between worktrees.
+    .PARAMETER BranchName
+        The branch name to find.
+    .PARAMETER RepoRoot
+        Repository root path. Auto-detected if omitted.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$BranchName,
+
+        [string]$RepoRoot
+    )
+
+    $worktrees = Get-Worktree -RepoRoot $RepoRoot
+    $target = $worktrees | Where-Object { $_.Branch -eq $BranchName }
+
+    if (-not $target) {
+        throw "No worktree found for branch '$BranchName'. Available: $(($worktrees | Where-Object { $_.Branch } | ForEach-Object { $_.Branch }) -join ', ')"
+    }
+
+    return $target
+}
+
+function Remove-Worktree {
+    <#
+    .SYNOPSIS
+        Removes a Git worktree and optionally deletes the branch.
+    .PARAMETER BranchName
+        The branch name of the worktree to remove.
+    .PARAMETER DeleteBranch
+        If set, also deletes the local branch after removing the worktree.
+    .PARAMETER Force
+        Force removal even if worktree has uncommitted changes.
+    .PARAMETER RepoRoot
+        Repository root path. Auto-detected if omitted.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$BranchName,
+
+        [switch]$DeleteBranch,
+        [switch]$Force,
+        [string]$RepoRoot
+    )
+
+    if (-not $RepoRoot) {
+        $RepoRoot = (git rev-parse --show-toplevel 2>$null)
+        if (-not $RepoRoot) {
+            throw "Not inside a Git repository."
+        }
+    }
+
+    $worktree = Switch-Worktree -BranchName $BranchName -RepoRoot $RepoRoot
+
+    if ($worktree.IsMain) {
+        throw "Cannot remove the main worktree."
+    }
+
+    # Remove worktree
+    $forceFlag = if ($Force) { '--force' } else { '' }
+    $removeArgs = @('-C', $RepoRoot, 'worktree', 'remove')
+    if ($Force) { $removeArgs += '--force' }
+    $removeArgs += $worktree.Path
+
+    $result = & git @removeArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to remove worktree: $result"
+    }
+
+    # Optionally delete branch
+    if ($DeleteBranch) {
+        $deleteFlag = if ($Force) { '-D' } else { '-d' }
+        $branchResult = git -C $RepoRoot branch $deleteFlag $BranchName 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Worktree removed but failed to delete branch: $branchResult"
+        }
+    }
+
+    # Prune stale worktree references
+    git -C $RepoRoot worktree prune 2>$null
+
+    return [pscustomobject]@{
+        RemovedPath   = $worktree.Path
+        Branch        = $BranchName
+        BranchDeleted = [bool]$DeleteBranch
+    }
+}
+
+function Get-WorktreeSummary {
+    <#
+    .SYNOPSIS
+        Returns a formatted summary of all worktrees for display.
+    .PARAMETER RepoRoot
+        Repository root path. Auto-detected if omitted.
+    #>
+    param(
+        [string]$RepoRoot
+    )
+
+    $worktrees = Get-Worktree -RepoRoot $RepoRoot
+    $summary = @()
+
+    foreach ($wt in $worktrees) {
+        $label = if ($wt.IsMain) { '[MAIN]' } else { '' }
+        $branch = if ($wt.Branch) { $wt.Branch } else { '(detached)' }
+        $commit = if ($wt.Commit) { $wt.Commit.Substring(0, 7) } else { 'unknown' }
+
+        $summary += [pscustomobject]@{
+            Branch  = $branch
+            Commit  = $commit
+            Path    = $wt.Path
+            Label   = $label
+        }
+    }
+
+    return $summary
+}
+
+Export-ModuleMember -Function @(
+    'Get-Worktree'
+    'New-Worktree'
+    'Switch-Worktree'
+    'Remove-Worktree'
+    'Get-WorktreeSummary'
+    'Get-WorktreeBasePath'
+)

--- a/scripts/main/Start-Menu.ps1
+++ b/scripts/main/Start-Menu.ps1
@@ -212,6 +212,7 @@ function Show-Menu {
     Write-Host "    7.  Windows Terminal セットアップ" -ForegroundColor Magenta
     Write-Host "    8.  MCP ヘルスチェック" -ForegroundColor Magenta
     Write-Host "    9.  Agent Teams ランタイム" -ForegroundColor Magenta
+    Write-Host "    10. Worktree Manager" -ForegroundColor Magenta
     Write-Host ""
 
     Write-Host "    0.  終了" -ForegroundColor Gray
@@ -295,6 +296,7 @@ while ($true) {
         "7"  { Invoke-MenuScript -File "scripts\setup\setup-windows-terminal.ps1" }
         "8"  { Invoke-MenuScript -File "scripts\test\Test-McpHealth.ps1" }
         "9"  { Invoke-MenuScript -File "scripts\test\Test-AgentTeams.ps1" }
+        "10" { Invoke-MenuScript -File "scripts\test\Test-WorktreeManager.ps1" }
         "0"  { exit 0 }
         default {
             Write-Host ""

--- a/scripts/test/Test-WorktreeManager.ps1
+++ b/scripts/test/Test-WorktreeManager.ps1
@@ -1,0 +1,44 @@
+# ============================================================
+# Test-WorktreeManager.ps1 - Worktree Manager interactive test
+# Start-Menu entry point for menu option
+# ============================================================
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding           = [System.Text.Encoding]::UTF8
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Import-Module (Join-Path $ProjectRoot "scripts\lib\WorktreeManager.psm1") -Force
+
+Write-Host ""
+Write-Host "  ========================================" -ForegroundColor Cyan
+Write-Host "  Worktree Manager - 状態確認" -ForegroundColor Cyan
+Write-Host "  ========================================" -ForegroundColor Cyan
+Write-Host ""
+
+try {
+    $summary = Get-WorktreeSummary -RepoRoot $ProjectRoot
+
+    if ($summary.Count -eq 0) {
+        Write-Host "  Worktree が見つかりません。" -ForegroundColor Yellow
+    }
+    else {
+        Write-Host "  登録済み Worktree: $($summary.Count) 件" -ForegroundColor Green
+        Write-Host ""
+
+        foreach ($wt in $summary) {
+            $color = if ($wt.Label -eq '[MAIN]') { 'Green' } else { 'Yellow' }
+            $label = if ($wt.Label) { " $($wt.Label)" } else { '' }
+            Write-Host "    $($wt.Branch)$label" -ForegroundColor $color
+            Write-Host "      Commit: $($wt.Commit)" -ForegroundColor DarkGray
+            Write-Host "      Path:   $($wt.Path)" -ForegroundColor DarkGray
+            Write-Host ""
+        }
+    }
+
+    Write-Host "  ========================================" -ForegroundColor Cyan
+    Write-Host "  完了" -ForegroundColor Green
+}
+catch {
+    Write-Host "  エラー: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}

--- a/tests/WorktreeManager.Tests.ps1
+++ b/tests/WorktreeManager.Tests.ps1
@@ -1,0 +1,135 @@
+# ============================================================
+# WorktreeManager.Tests.ps1 - WorktreeManager.psm1 unit tests
+# Pester 5.x
+# Issue #32: Worktree Manager
+# ============================================================
+
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    Import-Module (Join-Path $script:RepoRoot 'scripts\lib\WorktreeManager.psm1') -Force
+}
+
+Describe 'Get-WorktreeBasePath' {
+
+    It 'returns .worktrees under the given repo root' {
+        $result = Get-WorktreeBasePath -RepoRoot 'C:\fake\repo'
+        $result | Should -Be (Join-Path 'C:\fake\repo' '.worktrees')
+    }
+}
+
+Describe 'Get-Worktree' {
+
+    It 'returns at least the main worktree for the current repo' {
+        $result = @(Get-Worktree -RepoRoot $script:RepoRoot)
+        $result.Count | Should -BeGreaterOrEqual 1
+    }
+
+    It 'main worktree has IsMain = $true' {
+        $result = @(Get-Worktree -RepoRoot $script:RepoRoot)
+        $main = $result | Where-Object { $_.IsMain }
+        $main | Should -Not -BeNullOrEmpty
+    }
+
+    It 'each worktree has a Path property' {
+        $result = @(Get-Worktree -RepoRoot $script:RepoRoot)
+        foreach ($wt in $result) {
+            $wt.Path | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It 'each worktree has a Commit hash' {
+        $result = @(Get-Worktree -RepoRoot $script:RepoRoot)
+        foreach ($wt in $result) {
+            $wt.Commit | Should -Match '^[0-9a-f]{40}$'
+        }
+    }
+}
+
+Describe 'New-Worktree and Remove-Worktree' {
+
+    BeforeAll {
+        # Create a temporary bare-like test repo
+        $script:TestRepo = Join-Path $TestDrive 'test-repo'
+        git init -b main $script:TestRepo 2>$null | Out-Null
+        Push-Location $script:TestRepo
+        git config user.email "test@test.com"
+        git config user.name "Test"
+        Set-Content -Path (Join-Path $script:TestRepo 'README.md') -Value '# Test'
+        git -C $script:TestRepo add .
+        git -C $script:TestRepo commit -m "init" 2>$null | Out-Null
+        Pop-Location
+    }
+
+    It 'creates a new worktree with a new branch' {
+        $result = New-Worktree -BranchName 'feat/test-wt' -BaseBranch 'main' -RepoRoot $script:TestRepo
+        $result.Branch | Should -Be 'feat/test-wt'
+        $result.Path | Should -Not -BeNullOrEmpty
+        Test-Path $result.Path | Should -Be $true
+    }
+
+    It 'lists the newly created worktree' {
+        $worktrees = @(Get-Worktree -RepoRoot $script:TestRepo)
+        $found = $worktrees | Where-Object { $_.Branch -eq 'feat/test-wt' }
+        $found | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Switch-Worktree finds the worktree by branch' {
+        $result = Switch-Worktree -BranchName 'feat/test-wt' -RepoRoot $script:TestRepo
+        $result.Branch | Should -Be 'feat/test-wt'
+    }
+
+    It 'throws when creating a duplicate branch' {
+        { New-Worktree -BranchName 'feat/test-wt' -BaseBranch 'main' -RepoRoot $script:TestRepo } |
+            Should -Throw "*already exists*"
+    }
+
+    It 'removes the worktree and optionally deletes the branch' {
+        $result = Remove-Worktree -BranchName 'feat/test-wt' -DeleteBranch -RepoRoot $script:TestRepo
+        $result.Branch | Should -Be 'feat/test-wt'
+        $result.BranchDeleted | Should -Be $true
+    }
+
+    It 'worktree is no longer listed after removal' {
+        $worktrees = @(Get-Worktree -RepoRoot $script:TestRepo)
+        $found = $worktrees | Where-Object { $_.Branch -eq 'feat/test-wt' }
+        $found | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Switch-Worktree error handling' {
+
+    It 'throws for non-existent branch' {
+        { Switch-Worktree -BranchName 'nonexistent-branch-xyz' -RepoRoot $script:RepoRoot } |
+            Should -Throw "*No worktree found*"
+    }
+}
+
+Describe 'Get-WorktreeSummary' {
+
+    It 'returns summary objects with Branch, Commit, Path, Label' {
+        $result = @(Get-WorktreeSummary -RepoRoot $script:RepoRoot)
+        $result.Count | Should -BeGreaterOrEqual 1
+        $result[0].PSObject.Properties.Name | Should -Contain 'Branch'
+        $result[0].PSObject.Properties.Name | Should -Contain 'Commit'
+        $result[0].PSObject.Properties.Name | Should -Contain 'Path'
+        $result[0].PSObject.Properties.Name | Should -Contain 'Label'
+    }
+
+    It 'main worktree has [MAIN] label' {
+        $result = @(Get-WorktreeSummary -RepoRoot $script:RepoRoot)
+        $main = $result | Where-Object { $_.Label -eq '[MAIN]' }
+        $main | Should -Not -BeNullOrEmpty
+    }
+}
+
+Describe 'Remove-Worktree safety' {
+
+    It 'refuses to remove the main worktree' {
+        $worktrees = @(Get-Worktree -RepoRoot $script:RepoRoot)
+        $main = $worktrees | Where-Object { $_.IsMain }
+        if ($main -and $main.Branch) {
+            { Remove-Worktree -BranchName $main.Branch -RepoRoot $script:RepoRoot } |
+                Should -Throw "*Cannot remove the main worktree*"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `WorktreeManager.psm1` モジュール新規作成: Git Worktree の作成・一覧・切替・削除を自動管理
- Pester テスト 15件作成（全合格、全209テスト回帰なし）
- Start-Menu にメニュー項目「10. Worktree Manager」を追加

## 変更内容
| ファイル | 内容 |
|---|---|
| `scripts/lib/WorktreeManager.psm1` | New/Get/Switch/Remove-Worktree, Get-WorktreeSummary, Get-WorktreeBasePath |
| `tests/WorktreeManager.Tests.ps1` | 15件のユニットテスト（Pester 5.x） |
| `scripts/test/Test-WorktreeManager.ps1` | Start-Menu統合エントリポイント |
| `scripts/main/Start-Menu.ps1` | メニュー項目追加 |

## テスト結果
- WorktreeManager テスト: 15/15 合格
- 全テストスイート: 209/209 合格

## 影響範囲
- `scripts/lib/` に新モジュール追加
- Start-Menu に新メニュー項目追加（既存項目に影響なし）

## 残課題
- Worktree の自動クリーンアップ（マージ済みブランチの自動削除）は今後の拡張

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)