### PR TITLE
feat: Issue/Backlog 自動生成 — GitHub Issues 双方向同期

### DIFF
--- a/scripts/lib/IssueSyncManager.psm1
+++ b/scripts/lib/IssueSyncManager.psm1
@@ -1,0 +1,388 @@
+# ============================================================
+# IssueSyncManager.psm1 - GitHub Issues <-> TASKS.md sync
+# ClaudeCLI-CodexCLI-CopilotCLI-StartUpTools v2.7.0
+# Issue #33: Issue / Backlog auto-generation
+# ============================================================
+
+Set-StrictMode -Version Latest
+
+$script:DefaultTasksPath = 'TASKS.md'
+$script:ManualSection = 'Manual Backlog'
+$script:AutoSection = 'Auto Extracted From Agent Teams Matrix'
+$script:IssueSection = 'GitHub Issues Sync'
+
+function Get-TasksFilePath {
+    param([string]$RepoRoot)
+    if (-not $RepoRoot) {
+        $RepoRoot = (git rev-parse --show-toplevel 2>$null)
+    }
+    return Join-Path $RepoRoot $script:DefaultTasksPath
+}
+
+function Get-GitHubIssues {
+    <#
+    .SYNOPSIS
+        Fetches open GitHub Issues for the repository.
+    .PARAMETER Owner
+        Repository owner.
+    .PARAMETER Repo
+        Repository name.
+    .PARAMETER Labels
+        Optional label filter.
+    .PARAMETER State
+        Issue state (open/closed/all). Default: open.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Owner,
+
+        [Parameter(Mandatory)]
+        [string]$Repo,
+
+        [string[]]$Labels = @(),
+        [string]$State = 'open'
+    )
+
+    $args = @('issue', 'list', '--repo', "$Owner/$Repo", '--state', $State, '--json', 'number,title,labels,state,assignees,body', '--limit', '100')
+    if ($Labels.Count -gt 0) {
+        $args += '--label'
+        $args += ($Labels -join ',')
+    }
+
+    $raw = & gh @args 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to fetch issues: $raw"
+    }
+
+    $issues = $raw | ConvertFrom-Json
+    return @($issues)
+}
+
+function ConvertTo-TaskLine {
+    <#
+    .SYNOPSIS
+        Converts a GitHub Issue to a TASKS.md line.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Issue,
+
+        [int]$Index = 0
+    )
+
+    $priority = 'P2'
+    $labelNames = @()
+    if ($Issue.labels) {
+        $labelNames = @($Issue.labels | ForEach-Object { $_.name })
+    }
+    if ($labelNames -contains 'bug') { $priority = 'P1' }
+    if ($labelNames -contains 'enhancement') { $priority = 'P2' }
+    if ($labelNames -contains 'documentation') { $priority = 'P3' }
+
+    $owner = 'Unassigned'
+    if ($Issue.assignees -and $Issue.assignees.Count -gt 0) {
+        $owner = $Issue.assignees[0].login
+    }
+
+    $state = if ($Issue.state -eq 'closed') { '[DONE] ' } else { '' }
+    $num = if ($Index -gt 0) { "$Index. " } else { '' }
+
+    return "${num}${state}[Priority:$priority][Owner:$owner][Source:GitHub#$($Issue.number)] $($Issue.title)"
+}
+
+function ConvertFrom-TaskLine {
+    <#
+    .SYNOPSIS
+        Parses a TASKS.md line back into structured data.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Line
+    )
+
+    $result = [ordered]@{
+        Index    = 0
+        Done     = $false
+        Priority = 'P2'
+        Owner    = 'Unassigned'
+        Source   = ''
+        IssueNum = $null
+        Title    = ''
+        Raw      = $Line
+    }
+
+    if ($Line -match '^\d+') {
+        $result.Index = [int]($Matches[0])
+    }
+
+    $result.Done = $Line -match '\[DONE\]'
+
+    if ($Line -match '\[Priority:([^\]]+)\]') {
+        $result.Priority = $Matches[1]
+    }
+    if ($Line -match '\[Owner:([^\]]+)\]') {
+        $result.Owner = $Matches[1]
+    }
+    if ($Line -match '\[Source:([^\]]+)\]') {
+        $result.Source = $Matches[1]
+    }
+    if ($Line -match '\[Source:GitHub#(\d+)\]') {
+        $result.IssueNum = [int]$Matches[1]
+    }
+
+    # Extract title: everything after the last ] bracket
+    if ($Line -match '\]\s+(.+)$') {
+        $result.Title = $Matches[1]
+    }
+
+    return [pscustomobject]$result
+}
+
+function Get-TasksSections {
+    <#
+    .SYNOPSIS
+        Parses TASKS.md into sections with their content lines.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$TasksPath
+    )
+
+    if (-not (Test-Path $TasksPath)) {
+        return @{
+            Header = @('# TASKS', '')
+            Sections = @{}
+            SectionOrder = @()
+        }
+    }
+
+    $lines = Get-Content -Path $TasksPath -Encoding UTF8
+    $header = @()
+    $sections = [ordered]@{}
+    $sectionOrder = @()
+    $currentSection = $null
+
+    foreach ($line in $lines) {
+        if ($line -match '^##\s+(.+)$') {
+            $currentSection = $Matches[1].Trim()
+            $sections[$currentSection] = @()
+            $sectionOrder += $currentSection
+            continue
+        }
+        if ($null -eq $currentSection) {
+            $header += $line
+        }
+        else {
+            $sections[$currentSection] += $line
+        }
+    }
+
+    return @{
+        Header = $header
+        Sections = $sections
+        SectionOrder = $sectionOrder
+    }
+}
+
+function Sync-IssuesToTasks {
+    <#
+    .SYNOPSIS
+        Syncs GitHub Issues into the TASKS.md file under a dedicated section.
+    .PARAMETER Owner
+        Repository owner.
+    .PARAMETER Repo
+        Repository name.
+    .PARAMETER TasksPath
+        Path to TASKS.md.
+    .PARAMETER DryRun
+        If set, returns what would be written without modifying the file.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Owner,
+
+        [Parameter(Mandatory)]
+        [string]$Repo,
+
+        [string]$TasksPath,
+        [switch]$DryRun
+    )
+
+    if (-not $TasksPath) {
+        $TasksPath = Get-TasksFilePath
+    }
+
+    $issues = Get-GitHubIssues -Owner $Owner -Repo $Repo -State 'open'
+
+    # Filter out pull requests (they also appear as issues)
+    $issues = @($issues | Where-Object { -not ($_.PSObject.Properties.Name -contains 'pull_request') })
+
+    $parsed = Get-TasksSections -TasksPath $TasksPath
+
+    # Build new issue section lines
+    $issueLines = @('')
+    for ($i = 0; $i -lt $issues.Count; $i++) {
+        $issueLines += (ConvertTo-TaskLine -Issue $issues[$i] -Index ($i + 1))
+    }
+    if ($issues.Count -eq 0) {
+        $issueLines += '(No open issues)'
+    }
+    $issueLines += ''
+
+    # Update or add section
+    $parsed.Sections[$script:IssueSection] = $issueLines
+    if ($script:IssueSection -notin $parsed.SectionOrder) {
+        $parsed.SectionOrder += $script:IssueSection
+    }
+
+    # Rebuild file
+    $output = [System.Collections.Generic.List[string]]::new()
+    foreach ($line in $parsed.Header) {
+        $output.Add($line)
+    }
+    foreach ($sectionName in $parsed.SectionOrder) {
+        $output.Add("## $sectionName")
+        foreach ($line in $parsed.Sections[$sectionName]) {
+            $output.Add($line)
+        }
+    }
+
+    if ($DryRun) {
+        return @{
+            Content    = $output.ToArray()
+            IssueCount = $issues.Count
+            TasksPath  = $TasksPath
+        }
+    }
+
+    [System.IO.File]::WriteAllLines($TasksPath, $output, [System.Text.UTF8Encoding]::new($false))
+
+    return @{
+        Synced     = $true
+        IssueCount = $issues.Count
+        TasksPath  = $TasksPath
+    }
+}
+
+function Sync-TasksToIssues {
+    <#
+    .SYNOPSIS
+        Creates GitHub Issues from TASKS.md manual entries that don't have a GitHub source.
+    .PARAMETER Owner
+        Repository owner.
+    .PARAMETER Repo
+        Repository name.
+    .PARAMETER TasksPath
+        Path to TASKS.md.
+    .PARAMETER DryRun
+        If set, returns what would be created without actually creating issues.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Owner,
+
+        [Parameter(Mandatory)]
+        [string]$Repo,
+
+        [string]$TasksPath,
+        [switch]$DryRun
+    )
+
+    if (-not $TasksPath) {
+        $TasksPath = Get-TasksFilePath
+    }
+
+    $parsed = Get-TasksSections -TasksPath $TasksPath
+
+    $manualLines = @()
+    if ($parsed.Sections.Contains($script:ManualSection)) {
+        $manualLines = @($parsed.Sections[$script:ManualSection] | Where-Object { $_ -match '^\d+\.\s' })
+    }
+
+    $toCreate = @()
+    foreach ($line in $manualLines) {
+        $task = ConvertFrom-TaskLine -Line $line
+        if ($task.Done) { continue }
+        if ($task.Source -match 'GitHub#') { continue }
+        if ([string]::IsNullOrWhiteSpace($task.Title)) { continue }
+        $toCreate += $task
+    }
+
+    if ($DryRun) {
+        return @{
+            WouldCreate = @($toCreate | ForEach-Object { $_.Title })
+            Count       = $toCreate.Count
+        }
+    }
+
+    $created = @()
+    foreach ($task in $toCreate) {
+        $body = "Auto-created from TASKS.md`n`nPriority: $($task.Priority)`nOwner: $($task.Owner)`nSource: $($task.Source)"
+        $result = & gh issue create --repo "$Owner/$Repo" --title $task.Title --body $body 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $created += @{ Title = $task.Title; Url = $result }
+        }
+    }
+
+    return @{
+        Created = $created
+        Count   = $created.Count
+    }
+}
+
+function Get-SyncStatus {
+    <#
+    .SYNOPSIS
+        Returns a comparison of TASKS.md vs GitHub Issues.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Owner,
+
+        [Parameter(Mandatory)]
+        [string]$Repo,
+
+        [string]$TasksPath
+    )
+
+    if (-not $TasksPath) {
+        $TasksPath = Get-TasksFilePath
+    }
+
+    $issues = Get-GitHubIssues -Owner $Owner -Repo $Repo
+    $parsed = Get-TasksSections -TasksPath $TasksPath
+
+    $issueSyncLines = @()
+    if ($parsed.Sections.Contains($script:IssueSection)) {
+        $issueSyncLines = @($parsed.Sections[$script:IssueSection] | Where-Object { $_ -match '^\d+\.\s' })
+    }
+
+    $trackedNums = @()
+    foreach ($line in $issueSyncLines) {
+        $task = ConvertFrom-TaskLine -Line $line
+        if ($task.IssueNum) { $trackedNums += $task.IssueNum }
+    }
+
+    $issueNums = @($issues | ForEach-Object { $_.number })
+    $missing = @($issueNums | Where-Object { $_ -notin $trackedNums })
+    $stale = @($trackedNums | Where-Object { $_ -notin $issueNums })
+
+    return [pscustomobject]@{
+        InSync       = ($missing.Count -eq 0 -and $stale.Count -eq 0)
+        MissingInTasks = $missing
+        StaleInTasks   = $stale
+        IssueCount     = $issueNums.Count
+        TrackedCount   = $trackedNums.Count
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Get-GitHubIssues'
+    'ConvertTo-TaskLine'
+    'ConvertFrom-TaskLine'
+    'Get-TasksSections'
+    'Sync-IssuesToTasks'
+    'Sync-TasksToIssues'
+    'Get-SyncStatus'
+    'Get-TasksFilePath'
+)

--- a/tests/IssueSyncManager.Tests.ps1
+++ b/tests/IssueSyncManager.Tests.ps1
@@ -1,0 +1,219 @@
+# ============================================================
+# IssueSyncManager.Tests.ps1 - IssueSyncManager.psm1 unit tests
+# Pester 5.x
+# Issue #33: Issue / Backlog auto-generation
+# ============================================================
+
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    Import-Module (Join-Path $script:RepoRoot 'scripts\lib\IssueSyncManager.psm1') -Force
+}
+
+Describe 'ConvertTo-TaskLine' {
+
+    It 'converts a basic issue to a task line' {
+        $issue = [pscustomobject]@{
+            number    = 42
+            title     = 'Fix login bug'
+            labels    = @([pscustomobject]@{ name = 'bug' })
+            state     = 'open'
+            assignees = @([pscustomobject]@{ login = 'dev1' })
+        }
+        $result = ConvertTo-TaskLine -Issue $issue -Index 1
+        $result | Should -Match '1\.'
+        $result | Should -Match 'Priority:P1'
+        $result | Should -Match 'Owner:dev1'
+        $result | Should -Match 'Source:GitHub#42'
+        $result | Should -Match 'Fix login bug'
+    }
+
+    It 'sets priority P2 for enhancement label' {
+        $issue = [pscustomobject]@{
+            number    = 10
+            title     = 'Add feature'
+            labels    = @([pscustomobject]@{ name = 'enhancement' })
+            state     = 'open'
+            assignees = @()
+        }
+        $result = ConvertTo-TaskLine -Issue $issue -Index 1
+        $result | Should -Match 'Priority:P2'
+        $result | Should -Match 'Owner:Unassigned'
+    }
+
+    It 'sets priority P3 for documentation label' {
+        $issue = [pscustomobject]@{
+            number    = 5
+            title     = 'Update docs'
+            labels    = @([pscustomobject]@{ name = 'documentation' })
+            state     = 'open'
+            assignees = @()
+        }
+        $result = ConvertTo-TaskLine -Issue $issue -Index 1
+        $result | Should -Match 'Priority:P3'
+    }
+
+    It 'marks closed issues as DONE' {
+        $issue = [pscustomobject]@{
+            number    = 3
+            title     = 'Done task'
+            labels    = @()
+            state     = 'closed'
+            assignees = @()
+        }
+        $result = ConvertTo-TaskLine -Issue $issue -Index 1
+        $result | Should -Match '\[DONE\]'
+    }
+
+    It 'handles issues with no labels' {
+        $issue = [pscustomobject]@{
+            number    = 99
+            title     = 'No labels'
+            labels    = @()
+            state     = 'open'
+            assignees = @()
+        }
+        $result = ConvertTo-TaskLine -Issue $issue -Index 1
+        $result | Should -Match 'Priority:P2'
+    }
+}
+
+Describe 'ConvertFrom-TaskLine' {
+
+    It 'parses a standard task line' {
+        $line = '3. [Priority:P1][Owner:dev1][Source:GitHub#42] Fix login bug'
+        $result = ConvertFrom-TaskLine -Line $line
+        $result.Index | Should -Be 3
+        $result.Priority | Should -Be 'P1'
+        $result.Owner | Should -Be 'dev1'
+        $result.IssueNum | Should -Be 42
+        $result.Title | Should -Be 'Fix login bug'
+        $result.Done | Should -Be $false
+    }
+
+    It 'detects DONE status' {
+        $line = '1. [DONE] [Priority:P1][Owner:Ops][Source:Manual] Completed task'
+        $result = ConvertFrom-TaskLine -Line $line
+        $result.Done | Should -Be $true
+    }
+
+    It 'handles non-GitHub source' {
+        $line = '2. [Priority:P2][Owner:ScrumMaster][Source:AgentTeamsMatrix] worktree task'
+        $result = ConvertFrom-TaskLine -Line $line
+        $result.IssueNum | Should -BeNullOrEmpty
+        $result.Source | Should -Be 'AgentTeamsMatrix'
+    }
+}
+
+Describe 'Get-TasksSections' {
+
+    BeforeAll {
+        $script:TestTasks = Join-Path $TestDrive 'TASKS.md'
+        $content = @(
+            '# TASKS'
+            ''
+            'Description line.'
+            ''
+            '## Manual Backlog'
+            ''
+            '1. [Priority:P1][Owner:Ops][Source:CI] old task'
+            ''
+            '## Auto Extracted From Agent Teams Matrix'
+            ''
+            '1. [Priority:P2][Owner:Ops][Source:AgentTeamsMatrix] worktree task'
+            ''
+        )
+        Set-Content -Path $script:TestTasks -Value ($content -join "`n") -Encoding UTF8
+    }
+
+    It 'parses sections correctly' {
+        $result = Get-TasksSections -TasksPath $script:TestTasks
+        $result.Sections.Keys | Should -Contain 'Manual Backlog'
+        $result.Sections.Keys | Should -Contain 'Auto Extracted From Agent Teams Matrix'
+    }
+
+    It 'preserves header lines' {
+        $result = Get-TasksSections -TasksPath $script:TestTasks
+        $result.Header | Should -Contain '# TASKS'
+    }
+
+    It 'preserves section order' {
+        $result = Get-TasksSections -TasksPath $script:TestTasks
+        $result.SectionOrder.Count | Should -Be 2
+        $result.SectionOrder[0] | Should -Be 'Manual Backlog'
+    }
+
+    It 'returns empty structure for missing file' {
+        $result = Get-TasksSections -TasksPath (Join-Path $TestDrive 'nonexistent.md')
+        $result.Header | Should -Contain '# TASKS'
+        $result.Sections.Count | Should -Be 0
+    }
+}
+
+Describe 'Sync-IssuesToTasks DryRun' {
+
+    BeforeAll {
+        $script:TestTasks2 = Join-Path $TestDrive 'TASKS2.md'
+        $content = @(
+            '# TASKS'
+            ''
+            '## Manual Backlog'
+            ''
+            '1. Manual task'
+            ''
+        )
+        Set-Content -Path $script:TestTasks2 -Value ($content -join "`n") -Encoding UTF8
+    }
+
+    It 'adds GitHub Issues Sync section with DryRun' {
+        Mock Get-GitHubIssues -ModuleName IssueSyncManager {
+            return @(
+                [pscustomobject]@{
+                    number    = 10
+                    title     = 'Test issue'
+                    labels    = @([pscustomobject]@{ name = 'enhancement' })
+                    state     = 'open'
+                    assignees = @()
+                }
+            )
+        }
+
+        $result = Sync-IssuesToTasks -Owner 'test' -Repo 'test' -TasksPath $script:TestTasks2 -DryRun
+        $result.IssueCount | Should -Be 1
+        $result.Content | Should -Contain '## GitHub Issues Sync'
+        $result.Content | Should -Contain '## Manual Backlog'
+    }
+}
+
+Describe 'Sync-TasksToIssues DryRun' {
+
+    BeforeAll {
+        $script:TestTasks3 = Join-Path $TestDrive 'TASKS3.md'
+        $content = @(
+            '# TASKS'
+            ''
+            '## Manual Backlog'
+            ''
+            '1. [Priority:P1][Owner:Ops][Source:CI] new task without issue'
+            '2. [DONE] [Priority:P1][Owner:Ops][Source:Manual] completed task'
+            '3. [Priority:P1][Owner:Ops][Source:GitHub#10] already linked'
+            ''
+        )
+        Set-Content -Path $script:TestTasks3 -Value ($content -join "`n") -Encoding UTF8
+    }
+
+    It 'identifies tasks that need GitHub Issues' {
+        $result = Sync-TasksToIssues -Owner 'test' -Repo 'test' -TasksPath $script:TestTasks3 -DryRun
+        $result.Count | Should -Be 1
+        $result.WouldCreate | Should -Contain 'new task without issue'
+    }
+
+    It 'skips DONE tasks' {
+        $result = Sync-TasksToIssues -Owner 'test' -Repo 'test' -TasksPath $script:TestTasks3 -DryRun
+        $result.WouldCreate | Should -Not -Contain 'completed task'
+    }
+
+    It 'skips tasks already linked to GitHub' {
+        $result = Sync-TasksToIssues -Owner 'test' -Repo 'test' -TasksPath $script:TestTasks3 -DryRun
+        $result.WouldCreate | Should -Not -Contain 'already linked'
+    }
+}


### PR DESCRIPTION
## Summary
- `IssueSyncManager.psm1` モジュール新規作成: GitHub Issues ↔ TASKS.md 双方向同期
- Pester テスト 16件（全合格、全210テスト回帰なし）

## 変更内容
| ファイル | 内容 |
|---|---|
| `scripts/lib/IssueSyncManager.psm1` | Sync-IssuesToTasks, Sync-TasksToIssues, Get-SyncStatus, ConvertTo/From-TaskLine |
| `tests/IssueSyncManager.Tests.ps1` | 16件のユニットテスト（Pester 5.x、Mock使用） |

## 機能詳細
- **GitHub → TASKS.md**: `Sync-IssuesToTasks` で Open Issues を TASKS.md の `GitHub Issues Sync` セクションに同期
- **TASKS.md → GitHub**: `Sync-TasksToIssues` で Manual Backlog の未リンク項目から GitHub Issues を自動作成
- **差分検出**: `Get-SyncStatus` で同期状態を比較、Missing/Stale を検出
- **DryRun**: 事前確認可能な安全設計

## テスト結果
- IssueSyncManager テスト: 16/16 合格
- 全テストスイート: 210/210 合格

## 影響範囲
- `scripts/lib/` に新モジュール追加（既存に影響なし）

## 残課題
- TASKS.md 更新の自動トリガー（CI/hooks統合）は今後の拡張

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)