### PR TITLE
fix: Start-ClaudeCode.ps1 の unapproved verbs WARNING を修正

### DIFF
--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -16,10 +16,10 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-Import-Module (Join-Path $ScriptRoot 'scripts\lib\LauncherCommon.psm1') -Force
-Import-Module (Join-Path $ScriptRoot 'scripts\lib\Config.psm1') -Force
-Import-Module (Join-Path $ScriptRoot 'scripts\lib\McpHealthCheck.psm1') -Force
-Import-Module (Join-Path $ScriptRoot 'scripts\lib\AgentTeams.psm1') -Force
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\LauncherCommon.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\Config.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\McpHealthCheck.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\AgentTeams.psm1') -Force -DisableNameChecking
 
 $ScriptRoot = Get-StartupRoot -PSScriptRootPath $PSScriptRoot
 $ConfigPath = Get-StartupConfigPath -StartupRoot $ScriptRoot


### PR DESCRIPTION
## Summary
- `Start-ClaudeCode.ps1` の `Import-Module` 4行に `-DisableNameChecking` フラグを追加
- 他のスクリプト（Start-Menu, Start-All, Start-CodexCLI 等）では既に付与済みだったが、このファイルのみ欠落していた

## 変更内容
- `scripts/main/Start-ClaudeCode.ps1`: 4つの `Import-Module` 呼び出しに `-DisableNameChecking` を追加

## テスト結果
- 起動時の `WARNING: The names of some imported commands from the module 'LauncherCommon' include unapproved verbs` が表示されなくなる
- 機能への影響なし（フラグは警告抑制のみ）

## 影響範囲
- `Start-ClaudeCode.ps1` のモジュール読み込み部分のみ

## 残課題
- なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)