### PR TITLE
feat: Token Budget Manager — Phase 3 自動制御モジュール

### DIFF
--- a/scripts/lib/TokenBudget.psm1
+++ b/scripts/lib/TokenBudget.psm1
@@ -1,0 +1,323 @@
+# ============================================================
+# TokenBudget.psm1 - Token Budget Manager
+# ClaudeCLI-CodexCLI-CopilotCLI-StartUpTools v2.8.0
+# Phase 3: Token Budget auto-control
+# ============================================================
+
+Set-StrictMode -Version Latest
+
+$script:DefaultStatePath = 'state.json'
+
+$script:Zones = @{
+    Green  = @{ Min = 0;  Max = 60;  Label = 'Green';  Status = 'Normal development' }
+    Yellow = @{ Min = 60; Max = 75;  Label = 'Yellow'; Status = 'Reduced build activity' }
+    Orange = @{ Min = 75; Max = 90;  Label = 'Orange'; Status = 'Monitor priority' }
+    Red    = @{ Min = 90; Max = 100; Label = 'Red';    Status = 'Development stopped' }
+}
+
+$script:DefaultAllocation = @{
+    monitor     = 10
+    development = 35
+    verify      = 25
+    improvement = 10
+    debug       = 20
+}
+
+function Get-StateFilePath {
+    param([string]$RepoRoot)
+    if (-not $RepoRoot) {
+        $RepoRoot = (git rev-parse --show-toplevel 2>$null)
+        if (-not $RepoRoot) { $RepoRoot = '.' }
+    }
+    return Join-Path $RepoRoot $script:DefaultStatePath
+}
+
+function Get-TokenState {
+    <#
+    .SYNOPSIS
+        Reads token budget state from state.json.
+    .PARAMETER StatePath
+        Path to state.json. Auto-detected if not provided.
+    #>
+    param([string]$StatePath)
+
+    if (-not $StatePath) { $StatePath = Get-StateFilePath }
+
+    if (-not (Test-Path $StatePath)) {
+        return New-TokenState
+    }
+
+    $state = Get-Content -Path $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    if (-not ($state.PSObject.Properties.Name -contains 'token') -or $null -eq $state.token) {
+        return New-TokenState
+    }
+
+    return $state.token
+}
+
+function New-TokenState {
+    <#
+    .SYNOPSIS
+        Creates a fresh token budget state with default allocation.
+    #>
+    return [pscustomobject]@{
+        total_budget         = 100
+        used                 = 0
+        remaining            = 100
+        allocation           = [pscustomobject]$script:DefaultAllocation
+        dynamic_mode         = $true
+        current_phase_budget = 0
+        current_phase_used   = 0
+    }
+}
+
+function Get-TokenZone {
+    <#
+    .SYNOPSIS
+        Determines the current budget zone based on usage percentage.
+    .PARAMETER UsedPercent
+        Usage percentage (0-100).
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [double]$UsedPercent
+    )
+
+    if ($UsedPercent -lt 60) {
+        return [pscustomobject]$script:Zones.Green
+    }
+    elseif ($UsedPercent -lt 75) {
+        return [pscustomobject]$script:Zones.Yellow
+    }
+    elseif ($UsedPercent -lt 90) {
+        return [pscustomobject]$script:Zones.Orange
+    }
+    else {
+        return [pscustomobject]$script:Zones.Red
+    }
+}
+
+function Get-PhaseAllowance {
+    <#
+    .SYNOPSIS
+        Returns which phases are allowed/restricted based on current zone.
+    .PARAMETER Zone
+        Current budget zone object.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Zone
+    )
+
+    $result = [ordered]@{
+        monitor     = $true
+        development = $true
+        verify      = $true
+        improvement = $true
+        debug       = $true
+    }
+
+    switch ($Zone.Label) {
+        'Yellow' {
+            $result.improvement = $false
+        }
+        'Orange' {
+            $result.improvement = $false
+            $result.development = $false
+        }
+        'Red' {
+            $result.improvement = $false
+            $result.development = $false
+            $result.debug       = $false
+        }
+    }
+
+    return [pscustomobject]$result
+}
+
+function Update-TokenUsage {
+    <#
+    .SYNOPSIS
+        Updates token usage in state.json and returns the new state.
+    .PARAMETER Phase
+        The phase that consumed tokens.
+    .PARAMETER Amount
+        Amount of tokens consumed (percentage points).
+    .PARAMETER StatePath
+        Path to state.json.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('monitor', 'development', 'verify', 'improvement', 'debug')]
+        [string]$Phase,
+
+        [Parameter(Mandatory)]
+        [double]$Amount,
+
+        [string]$StatePath
+    )
+
+    if (-not $StatePath) { $StatePath = Get-StateFilePath }
+
+    $state = $null
+    if (Test-Path $StatePath) {
+        $state = Get-Content -Path $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    }
+    else {
+        $state = [pscustomobject]@{}
+    }
+
+    $hasToken = $false
+    try { $hasToken = $null -ne $state.token } catch { $hasToken = $false }
+    if (-not $hasToken) {
+        $tokenState = New-TokenState
+        if ($state -is [hashtable]) {
+            $state = [pscustomobject]$state
+        }
+        $state | Add-Member -NotePropertyName 'token' -NotePropertyValue $tokenState -Force
+    }
+
+    $state.token.used = [math]::Min(100, $state.token.used + $Amount)
+    $state.token.remaining = [math]::Max(0, $state.token.total_budget - $state.token.used)
+    $state.token.current_phase_used = $state.token.current_phase_used + $Amount
+
+    $json = $state | ConvertTo-Json -Depth 10
+    [System.IO.File]::WriteAllText($StatePath, $json, [System.Text.UTF8Encoding]::new($false))
+
+    return $state.token
+}
+
+function Get-TokenBudgetStatus {
+    <#
+    .SYNOPSIS
+        Returns a comprehensive token budget status report.
+    .PARAMETER StatePath
+        Path to state.json.
+    #>
+    param([string]$StatePath)
+
+    $token = Get-TokenState -StatePath $StatePath
+    $usedPercent = if ($token.total_budget -gt 0) { ($token.used / $token.total_budget) * 100 } else { 0 }
+    $zone = Get-TokenZone -UsedPercent $usedPercent
+    $allowance = Get-PhaseAllowance -Zone $zone
+
+    return [pscustomobject]@{
+        Used           = $token.used
+        Remaining      = $token.remaining
+        TotalBudget    = $token.total_budget
+        UsedPercent    = [math]::Round($usedPercent, 1)
+        Zone           = $zone
+        Allowance      = $allowance
+        Allocation     = $token.allocation
+        DynamicMode    = $token.dynamic_mode
+        ShouldStop     = ($zone.Label -eq 'Red')
+        ShouldSkipImprovement = ($zone.Label -ne 'Green')
+        ShouldVerifyOnly = ($zone.Label -eq 'Orange' -or $zone.Label -eq 'Red')
+    }
+}
+
+function Invoke-DynamicReallocation {
+    <#
+    .SYNOPSIS
+        Dynamically reallocates phase budgets based on current conditions.
+    .PARAMETER Condition
+        The condition triggering reallocation: 'ci_failure', 'stable', 'time_pressure'
+    .PARAMETER StatePath
+        Path to state.json.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('ci_failure', 'stable', 'time_pressure')]
+        [string]$Condition,
+
+        [string]$StatePath
+    )
+
+    if (-not $StatePath) { $StatePath = Get-StateFilePath }
+
+    $state = $null
+    if (Test-Path $StatePath) {
+        $state = Get-Content -Path $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    }
+    else {
+        return $null
+    }
+
+    if (-not ($state.PSObject.Properties.Name -contains 'token') -or $null -eq $state.token -or -not $state.token.dynamic_mode) {
+        return $null
+    }
+
+    $alloc = $state.token.allocation
+
+    switch ($Condition) {
+        'ci_failure' {
+            # Shift budget from development to verify
+            $alloc.verify = [math]::Min(50, $alloc.verify + 20)
+            $alloc.development = [math]::Max(15, $alloc.development - 20)
+        }
+        'stable' {
+            # Shift budget from development to improvement
+            $alloc.improvement = [math]::Min(20, $alloc.improvement + 10)
+            $alloc.development = [math]::Max(25, $alloc.development - 10)
+        }
+        'time_pressure' {
+            # Remove improvement, minimize verify
+            $alloc.improvement = 0
+            $alloc.verify = [math]::Max(15, $alloc.verify - 10)
+            $alloc.development = $alloc.development + 10
+        }
+    }
+
+    $state.token.allocation = $alloc
+    $json = $state | ConvertTo-Json -Depth 10
+    [System.IO.File]::WriteAllText($StatePath, $json, [System.Text.UTF8Encoding]::new($false))
+
+    return $alloc
+}
+
+function Show-TokenBudgetStatus {
+    <#
+    .SYNOPSIS
+        Displays token budget status in formatted output.
+    .PARAMETER StatePath
+        Path to state.json.
+    #>
+    param([string]$StatePath)
+
+    $status = Get-TokenBudgetStatus -StatePath $StatePath
+
+    Write-Host "Token Budget Status:" -ForegroundColor Cyan
+    Write-Host "  Used: $($status.UsedPercent)% ($($status.Used)/$($status.TotalBudget))"
+    Write-Host "  Remaining: $($status.Remaining)"
+
+    $zoneColor = switch ($status.Zone.Label) {
+        'Green'  { 'Green' }
+        'Yellow' { 'Yellow' }
+        'Orange' { 'DarkYellow' }
+        'Red'    { 'Red' }
+    }
+    Write-Host "  Zone: $($status.Zone.Label) - $($status.Zone.Status)" -ForegroundColor $zoneColor
+
+    Write-Host "  Phases:" -ForegroundColor Cyan
+    $phases = @('monitor', 'development', 'verify', 'improvement', 'debug')
+    foreach ($phase in $phases) {
+        $allowed = $status.Allowance.$phase
+        $icon = if ($allowed) { '[OK]' } else { '[--]' }
+        $color = if ($allowed) { 'Green' } else { 'DarkGray' }
+        $budget = $status.Allocation.$phase
+        Write-Host "    $icon $phase`: ${budget}%" -ForegroundColor $color
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Get-TokenState'
+    'New-TokenState'
+    'Get-TokenZone'
+    'Get-PhaseAllowance'
+    'Update-TokenUsage'
+    'Get-TokenBudgetStatus'
+    'Invoke-DynamicReallocation'
+    'Show-TokenBudgetStatus'
+    'Get-StateFilePath'
+)

--- a/tests/TokenBudget.Tests.ps1
+++ b/tests/TokenBudget.Tests.ps1
@@ -1,0 +1,298 @@
+# ============================================================
+# TokenBudget.Tests.ps1 - TokenBudget.psm1 unit tests
+# Pester 5.x
+# Phase 3: Token Budget auto-control
+# ============================================================
+
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    Import-Module (Join-Path $script:RepoRoot 'scripts\lib\TokenBudget.psm1') -Force
+}
+
+Describe 'New-TokenState' {
+
+    It 'creates default state with correct budget' {
+        $state = New-TokenState
+        $state.total_budget | Should -Be 100
+        $state.used | Should -Be 0
+        $state.remaining | Should -Be 100
+        $state.dynamic_mode | Should -Be $true
+    }
+
+    It 'has correct default allocation' {
+        $state = New-TokenState
+        $state.allocation.monitor | Should -Be 10
+        $state.allocation.development | Should -Be 35
+        $state.allocation.verify | Should -Be 25
+        $state.allocation.improvement | Should -Be 10
+        $state.allocation.debug | Should -Be 20
+    }
+}
+
+Describe 'Get-TokenZone' {
+
+    It 'returns Green for 0%' {
+        $zone = Get-TokenZone -UsedPercent 0
+        $zone.Label | Should -Be 'Green'
+    }
+
+    It 'returns Green for 59%' {
+        $zone = Get-TokenZone -UsedPercent 59
+        $zone.Label | Should -Be 'Green'
+    }
+
+    It 'returns Yellow for 60%' {
+        $zone = Get-TokenZone -UsedPercent 60
+        $zone.Label | Should -Be 'Yellow'
+    }
+
+    It 'returns Yellow for 74%' {
+        $zone = Get-TokenZone -UsedPercent 74
+        $zone.Label | Should -Be 'Yellow'
+    }
+
+    It 'returns Orange for 75%' {
+        $zone = Get-TokenZone -UsedPercent 75
+        $zone.Label | Should -Be 'Orange'
+    }
+
+    It 'returns Orange for 89%' {
+        $zone = Get-TokenZone -UsedPercent 89
+        $zone.Label | Should -Be 'Orange'
+    }
+
+    It 'returns Red for 90%' {
+        $zone = Get-TokenZone -UsedPercent 90
+        $zone.Label | Should -Be 'Red'
+    }
+
+    It 'returns Red for 100%' {
+        $zone = Get-TokenZone -UsedPercent 100
+        $zone.Label | Should -Be 'Red'
+    }
+}
+
+Describe 'Get-PhaseAllowance' {
+
+    It 'allows all phases in Green zone' {
+        $zone = Get-TokenZone -UsedPercent 30
+        $allowance = Get-PhaseAllowance -Zone $zone
+        $allowance.monitor | Should -Be $true
+        $allowance.development | Should -Be $true
+        $allowance.verify | Should -Be $true
+        $allowance.improvement | Should -Be $true
+        $allowance.debug | Should -Be $true
+    }
+
+    It 'disables improvement in Yellow zone' {
+        $zone = Get-TokenZone -UsedPercent 65
+        $allowance = Get-PhaseAllowance -Zone $zone
+        $allowance.improvement | Should -Be $false
+        $allowance.development | Should -Be $true
+        $allowance.verify | Should -Be $true
+    }
+
+    It 'disables development and improvement in Orange zone' {
+        $zone = Get-TokenZone -UsedPercent 80
+        $allowance = Get-PhaseAllowance -Zone $zone
+        $allowance.improvement | Should -Be $false
+        $allowance.development | Should -Be $false
+        $allowance.verify | Should -Be $true
+        $allowance.monitor | Should -Be $true
+    }
+
+    It 'only allows monitor and verify in Red zone' {
+        $zone = Get-TokenZone -UsedPercent 95
+        $allowance = Get-PhaseAllowance -Zone $zone
+        $allowance.improvement | Should -Be $false
+        $allowance.development | Should -Be $false
+        $allowance.debug | Should -Be $false
+        $allowance.monitor | Should -Be $true
+        $allowance.verify | Should -Be $true
+    }
+}
+
+Describe 'Get-TokenState' {
+
+    It 'returns default state when file does not exist' {
+        $state = Get-TokenState -StatePath (Join-Path $TestDrive 'nonexistent.json')
+        $state.total_budget | Should -Be 100
+        $state.used | Should -Be 0
+    }
+
+    It 'reads token state from state.json' {
+        $statePath = Join-Path $TestDrive 'state-read.json'
+        $data = @{
+            token = @{
+                total_budget = 100
+                used = 45
+                remaining = 55
+                allocation = @{ monitor = 10; development = 35; verify = 25; improvement = 10; debug = 20 }
+                dynamic_mode = $true
+                current_phase_budget = 35
+                current_phase_used = 12
+            }
+        } | ConvertTo-Json -Depth 10
+        Set-Content -Path $statePath -Value $data -Encoding UTF8
+
+        $state = Get-TokenState -StatePath $statePath
+        $state.used | Should -Be 45
+        $state.remaining | Should -Be 55
+    }
+}
+
+Describe 'Update-TokenUsage' {
+
+    BeforeAll {
+        $script:TestState = Join-Path $TestDrive 'state-update.json'
+        $data = @{
+            token = @{
+                total_budget = 100
+                used = 30
+                remaining = 70
+                allocation = @{ monitor = 10; development = 35; verify = 25; improvement = 10; debug = 20 }
+                dynamic_mode = $true
+                current_phase_budget = 35
+                current_phase_used = 5
+            }
+        } | ConvertTo-Json -Depth 10
+        Set-Content -Path $script:TestState -Value $data -Encoding UTF8
+    }
+
+    It 'increments usage correctly' {
+        $result = Update-TokenUsage -Phase 'development' -Amount 10 -StatePath $script:TestState
+        $result.used | Should -Be 40
+        $result.remaining | Should -Be 60
+    }
+
+    It 'caps usage at 100' {
+        $statePath = Join-Path $TestDrive 'state-cap.json'
+        $data = @{
+            token = @{
+                total_budget = 100; used = 95; remaining = 5
+                allocation = @{ monitor = 10; development = 35; verify = 25; improvement = 10; debug = 20 }
+                dynamic_mode = $true; current_phase_budget = 0; current_phase_used = 0
+            }
+        } | ConvertTo-Json -Depth 10
+        Set-Content -Path $statePath -Value $data -Encoding UTF8
+
+        $result = Update-TokenUsage -Phase 'verify' -Amount 20 -StatePath $statePath
+        $result.used | Should -Be 100
+        $result.remaining | Should -Be 0
+    }
+
+    It 'creates token state if missing in state.json' {
+        $statePath = Join-Path $TestDrive 'state-empty.json'
+        Set-Content -Path $statePath -Value '{}' -Encoding UTF8
+
+        $result = Update-TokenUsage -Phase 'monitor' -Amount 5 -StatePath $statePath
+        $result.used | Should -Be 5
+        $result.remaining | Should -Be 95
+    }
+}
+
+Describe 'Get-TokenBudgetStatus' {
+
+    It 'returns comprehensive status for Green zone' {
+        $statePath = Join-Path $TestDrive 'state-status.json'
+        $data = @{
+            token = @{
+                total_budget = 100; used = 25; remaining = 75
+                allocation = @{ monitor = 10; development = 35; verify = 25; improvement = 10; debug = 20 }
+                dynamic_mode = $true; current_phase_budget = 0; current_phase_used = 0
+            }
+        } | ConvertTo-Json -Depth 10
+        Set-Content -Path $statePath -Value $data -Encoding UTF8
+
+        $status = Get-TokenBudgetStatus -StatePath $statePath
+        $status.UsedPercent | Should -Be 25
+        $status.Zone.Label | Should -Be 'Green'
+        $status.ShouldStop | Should -Be $false
+        $status.ShouldSkipImprovement | Should -Be $false
+        $status.ShouldVerifyOnly | Should -Be $false
+    }
+
+    It 'flags ShouldStop in Red zone' {
+        $statePath = Join-Path $TestDrive 'state-red.json'
+        $data = @{
+            token = @{
+                total_budget = 100; used = 95; remaining = 5
+                allocation = @{ monitor = 10; development = 35; verify = 25; improvement = 10; debug = 20 }
+                dynamic_mode = $true; current_phase_budget = 0; current_phase_used = 0
+            }
+        } | ConvertTo-Json -Depth 10
+        Set-Content -Path $statePath -Value $data -Encoding UTF8
+
+        $status = Get-TokenBudgetStatus -StatePath $statePath
+        $status.Zone.Label | Should -Be 'Red'
+        $status.ShouldStop | Should -Be $true
+        $status.ShouldVerifyOnly | Should -Be $true
+    }
+}
+
+Describe 'Invoke-DynamicReallocation' {
+
+    It 'shifts budget on ci_failure' {
+        $statePath = Join-Path $TestDrive 'state-realloc-ci.json'
+        $data = @{
+            token = @{
+                total_budget = 100; used = 40; remaining = 60
+                allocation = @{ monitor = 10; development = 35; verify = 25; improvement = 10; debug = 20 }
+                dynamic_mode = $true; current_phase_budget = 0; current_phase_used = 0
+            }
+        } | ConvertTo-Json -Depth 10
+        Set-Content -Path $statePath -Value $data -Encoding UTF8
+
+        $alloc = Invoke-DynamicReallocation -Condition 'ci_failure' -StatePath $statePath
+        $alloc.verify | Should -Be 45
+        $alloc.development | Should -Be 15
+    }
+
+    It 'shifts budget on stable' {
+        $statePath = Join-Path $TestDrive 'state-realloc-stable.json'
+        $data = @{
+            token = @{
+                total_budget = 100; used = 40; remaining = 60
+                allocation = @{ monitor = 10; development = 35; verify = 25; improvement = 10; debug = 20 }
+                dynamic_mode = $true; current_phase_budget = 0; current_phase_used = 0
+            }
+        } | ConvertTo-Json -Depth 10
+        Set-Content -Path $statePath -Value $data -Encoding UTF8
+
+        $alloc = Invoke-DynamicReallocation -Condition 'stable' -StatePath $statePath
+        $alloc.improvement | Should -Be 20
+        $alloc.development | Should -Be 25
+    }
+
+    It 'removes improvement on time_pressure' {
+        $statePath = Join-Path $TestDrive 'state-realloc-time.json'
+        $data = @{
+            token = @{
+                total_budget = 100; used = 80; remaining = 20
+                allocation = @{ monitor = 10; development = 35; verify = 25; improvement = 10; debug = 20 }
+                dynamic_mode = $true; current_phase_budget = 0; current_phase_used = 0
+            }
+        } | ConvertTo-Json -Depth 10
+        Set-Content -Path $statePath -Value $data -Encoding UTF8
+
+        $alloc = Invoke-DynamicReallocation -Condition 'time_pressure' -StatePath $statePath
+        $alloc.improvement | Should -Be 0
+        $alloc.development | Should -Be 45
+        $alloc.verify | Should -Be 15
+    }
+
+    It 'returns null when dynamic_mode is false' {
+        $statePath = Join-Path $TestDrive 'state-realloc-off.json'
+        $data = @{
+            token = @{
+                total_budget = 100; used = 40; remaining = 60
+                allocation = @{ monitor = 10; development = 35; verify = 25; improvement = 10; debug = 20 }
+                dynamic_mode = $false; current_phase_budget = 0; current_phase_used = 0
+            }
+        } | ConvertTo-Json -Depth 10
+        Set-Content -Path $statePath -Value $data -Encoding UTF8
+
+        $result = Invoke-DynamicReallocation -Condition 'stable' -StatePath $statePath
+        $result | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- `TokenBudget.psm1`: Token Budget 自動制御モジュール（Phase 3 Task 5）
  - 4ゾーン判定: Green (0-60%) / Yellow (60-75%) / Orange (75-90%) / Red (90-100%)
  - フェーズ許可/制限: ゾーンに応じて improvement, development, debug を自動制御
  - state.json ベースの使用量追跡と更新
  - 動的再配分: CI失敗時・安定時・時間不足時に自動リバランス
  - `Show-TokenBudgetStatus` でフォーマット済みステータス表示
- `TokenBudget.Tests.ps1`: 25テスト追加（全262テスト通過）

Phase 3 進捗: 1/6 (Token Budget Auto-control)

## Test plan
- [x] Pester テスト 262/262 通過（新規25テスト含む）
- [ ] CI パイプライン通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)