### PR TITLE
fix: SSH セッション20分フリーズを防止（keepalive追加）

### DIFF
--- a/scripts/lib/LauncherCommon.psm1
+++ b/scripts/lib/LauncherCommon.psm1
@@ -746,7 +746,9 @@ function Invoke-LauncherSshScript {
     }
     $sshArgList = @("-tt",
         "-o", "ConnectTimeout=$connectTimeout",
-        "-o", "StrictHostKeyChecking=accept-new") +
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ServerAliveInterval=60",
+        "-o", "ServerAliveCountMax=3") +
         $cmArgs +
         @($LinuxHost, $normalizedRunScript)
 

--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -132,7 +132,7 @@ function Invoke-ClaudeSshViaStdin {
     $psi.RedirectStandardInput = $true
     $psi.RedirectStandardOutput = $false
     $psi.RedirectStandardError = $false
-    $psi.Arguments = ('-T -o ConnectTimeout={0} -o StrictHostKeyChecking=accept-new {1} {2} "bash -s"' -f $connectTimeout, $sshControlArgs, $LinuxHost)
+    $psi.Arguments = ('-T -o ConnectTimeout={0} -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 {1} {2} "bash -s"' -f $connectTimeout, $sshControlArgs, $LinuxHost)
 
     $process = [System.Diagnostics.Process]::new()
     $process.StartInfo = $psi


### PR DESCRIPTION
## Summary

- SSH セッションが約20分後にフリーズする問題を修正
- 原因: SSH keepalive 未設定により、NAT/ファイアウォールが idle TCP 接続を切断
- 修正: `ServerAliveInterval=60` + `ServerAliveCountMax=3` を全 SSH 接続に追加

## Changes

| ファイル | 変更内容 |
|---|---|
| `scripts/lib/LauncherCommon.psm1` | `Invoke-LauncherSshScript` に keepalive オプション追加 |
| `scripts/main/Start-ClaudeCode.ps1` | `Invoke-ClaudeSshViaStdin` に keepalive オプション追加 |

## How it works

```
ServerAliveInterval=60  → 60秒ごとに SSH サーバーへ keepalive パケット送信
ServerAliveCountMax=3   → 3回連続無応答で接続を切断（=180秒で検知）
```

これにより NAT/FW の idle timeout（通常10〜30分）内に keepalive が送信され、TCP 接続が維持される。

## Test plan
- [x] 変更ファイルに関連するテスト（LauncherCommon, SSHHelper, StartScripts）は全て pre-existing failure で回帰なし
- [x] 他テスト（Config, TokenBudget, WorktreeManager）66/67 passed で回帰なし
- [ ] 実際の SSH セッションで 30分以上のフリーズが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)