### PR TITLE
fix: ループ上限・Token閾値を明示化 — 無限ループ防止強化

### DIFF
--- a/Claude/templates/claude/START_PROMPT.md
+++ b/Claude/templates/claude/START_PROMPT.md
@@ -587,6 +587,14 @@ Goal解析 → KPI確認 → 優先順位AI判定 → Issue自動生成 → GitH
 | P2 | Quality / UX / Test / Review findings |
 | P3 | Minor improvement / docs / cleanup |
 
+## ループ上限（無限ループ防止）
+
+- 最大ループ回数: 10回（Monitor→Development→Verify→Improvementで1回）
+- 5時間到達で強制終了（ループ途中でも）
+- Token 95%到達で強制終了
+- STABLE達成かつ未処理Issueなしの場合は早期終了
+- 同一Issueで3ループ改善なし → Blocked判定 → ループ離脱
+
 ## Token管理
 
 | フェーズ | 配分 |
@@ -599,6 +607,12 @@ Goal解析 → KPI確認 → 優先順位AI判定 → Issue自動生成 → GitH
 | IssueFactory | 5% |
 | Release | 5% |
 
+| Token消費率 | 対応 |
+|---|---|
+| 70% | Improvement 停止 |
+| 85% | Verify 優先のみ |
+| 95% | 即終了処理（安全停止） |
+
 ## 時間管理
 
 最大実行時間：5時間
@@ -607,6 +621,7 @@ Goal解析 → KPI確認 → 優先順位AI判定 → Issue自動生成 → GitH
 |---|---|
 | < 30分 | Improvement 停止 |
 | < 15分 | Verify 縮退 |
+| < 10分 | 終了準備開始 |
 | < 5分 | 強制終了 |
 
 ## STABLE条件

--- a/Claude/templates/claude/instructions/08-operations.md
+++ b/Claude/templates/claude/instructions/08-operations.md
@@ -52,6 +52,14 @@ Goal解析 → KPI確認 → 優先順位AI判定 → Issue自動生成 → GitH
 | P2 | Quality / UX / Test / Review findings |
 | P3 | Minor improvement / docs / cleanup |
 
+## ループ上限（無限ループ防止）
+
+- 最大ループ回数: 10回（Monitor→Development→Verify→Improvementで1回）
+- 5時間到達で強制終了（ループ途中でも）
+- Token 95%到達で強制終了
+- STABLE達成かつ未処理Issueなしの場合は早期終了
+- 同一Issueで3ループ改善なし → Blocked判定 → ループ離脱
+
 ## Token管理
 
 | フェーズ | 配分 |
@@ -64,6 +72,12 @@ Goal解析 → KPI確認 → 優先順位AI判定 → Issue自動生成 → GitH
 | IssueFactory | 5% |
 | Release | 5% |
 
+| Token消費率 | 対応 |
+|---|---|
+| 70% | Improvement 停止 |
+| 85% | Verify 優先のみ |
+| 95% | 即終了処理（安全停止） |
+
 ## 時間管理
 
 最大実行時間：5時間
@@ -72,6 +86,7 @@ Goal解析 → KPI確認 → 優先順位AI判定 → Issue自動生成 → GitH
 |---|---|
 | < 30分 | Improvement 停止 |
 | < 15分 | Verify 縮退 |
+| < 10分 | 終了準備開始 |
 | < 5分 | 強制終了 |
 
 ## STABLE条件


### PR DESCRIPTION
## Summary
- ループ回数の明示的上限（最大10回）を追加
- Token消費率の具体的閾値（70%/85%/95%）をSTART_PROMPT側に追加
- 同一Issue 3ループ改善なし → Blocked判定ルールを追加

## テスト結果
- Build-StartPrompt.ps1 実行 → 761行の START_PROMPT.md 正常生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)