### PR TITLE
fix: START_PROMPTテンプレを10回ループ+CTO全権委任に明確化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ DevTools-chrome-*
 # ClaudeOS ランタイム状態（セッション固有・コミット不要）
 state.json
 
+# テンプレート編集用バックアップ（作業中の退避先・コミット不要）
+Claude/templates/claude/START_PROMPT-backup/
+
 # Claude CLI ツール設定（API キーを含む可能性）
 Claude/settings.json
 Claude/settings.local.json

--- a/Claude/templates/claude/START_PROMPT.md
+++ b/Claude/templates/claude/START_PROMPT.md
@@ -76,8 +76,8 @@ LOOP_COMMANDS 登録・Codex セットアップ完了後、作業を開始する
 
 
 - 設定された時間から5時間作業を厳密に守る
-- Monitor、Development、Verify、Improvementを10回ループ（ループ回数はCTO判断）
-- 全ての準備が整ったら、CTO全権委任で自律開発を開始してください。
+- Monitor、Development、Verify、Improvement を最大10回ループ（早期停止・終了はCTO判断、STABLE達成・5時間到達・Token枯渇・Blocked判定で早期終了）
+- LOOP 登録 4 本・Codex セットアップ・確認チェックリストが全て完了したら、CTO全権委任で自律開発を開始してください。
 
 ### 1. AgentTeams活用ルール
 

--- a/Claude/templates/claude/START_PROMPT.md
+++ b/Claude/templates/claude/START_PROMPT.md
@@ -74,8 +74,10 @@ LOOP_COMMANDS 登録・Codex セットアップ完了後、作業を開始する
 
 ## 実行方針
 
+
 - 設定された時間から5時間作業を厳密に守る
-- Monitor、Development、Verify、ImprovementをN回ループ（ループ回数はCTO判断）
+- Monitor、Development、Verify、Improvementを10回ループ（ループ回数はCTO判断）
+- 全ての準備が整ったら、CTO全権委任で自律開発を開始してください。
 
 ### 1. AgentTeams活用ルール
 

--- a/Claude/templates/claude/instructions/01-session-startup.md
+++ b/Claude/templates/claude/instructions/01-session-startup.md
@@ -36,8 +36,8 @@
 ## 実行方針
 
 - 設定された時間から5時間作業を厳密に守ってください。
-- Monitor、Development、Verify、Improvementを10回ループ（ループ回数はCTO判断）としてください。
-- 全ての準備が整ったら、CTO全権委任で自律開発を開始してください。
+- Monitor、Development、Verify、Improvement を最大10回ループとしてください（早期停止・終了はCTO判断、STABLE達成・5時間到達・Token枯渇・Blocked判定で早期終了）。
+- LOOP 登録 4 本・Codex セットアップ・確認チェックリストが全て完了したら、CTO全権委任で自律開発を開始してください。
 
 ### 1. AgentTeams活用ルール
 

--- a/Claude/templates/claude/instructions/01-session-startup.md
+++ b/Claude/templates/claude/instructions/01-session-startup.md
@@ -35,8 +35,9 @@
 
 ## 実行方針
 
-- 設定された時間から5時間作業を厳密に守る
-- Monitor、Development、Verify、ImprovementをN回ループ（ループ回数はCTO判断）
+- 設定された時間から5時間作業を厳密に守ってください。
+- Monitor、Development、Verify、Improvementを10回ループ（ループ回数はCTO判断）としてください。
+- 全ての準備が整ったら、CTO全権委任で自律開発を開始してください。
 
 ### 1. AgentTeams活用ルール
 


### PR DESCRIPTION
## Summary
- ClaudeOS v7.4 の自律継続ルールに沿い、`START_PROMPT.md` と `instructions/01-session-startup.md` の「実行方針」節を「N回ループ（CTO判断）」から「10回ループ（CTO判断）」「CTO全権委任で自律開発を開始」に書き換え、ユーザー承認待ちに見える曖昧表現を排除
- `.gitignore` に `Claude/templates/claude/START_PROMPT-backup/` を追加し、テンプレート編集時の作業バックアップディレクトリが誤って追跡されないようにする

## Context
前回セッションの WIP クリーンアップを兼ねた小規模修正。main ブランチに残っていた未コミット差分（うち意味あるもののみ）を本 PR に集約。改行コードノイズ（`.claude/claudeos/*.md`）と `TASKS.md` 末尾空白ノイズは revert 済み。

## Test plan
- [ ] CI: lint / build / test 通過
- [ ] Codex review 指摘 0
- [ ] テンプレートを使用する新規セッションで「CTO全権委任」指示が読み込まれること
- [ ] `START_PROMPT-backup/` が `git status` に表示されなくなること

🤖 Generated with [Claude Code](https://claude.com/claude-code)