### PR TITLE
refactor: role-contracts.md 導入と Orchestrator-Subagent 契約層整備

### DIFF
--- a/.claude/claudeos/loops/build-loop.md
+++ b/.claude/claudeos/loops/build-loop.md
@@ -1,13 +1,26 @@
 # Build Loop
 
 ## Role
-設計・実装を行う開発フェーズ。
+設計・実装を行う開発フェーズ。**実装専用** (検証は Verify に委ねる)。
 
 ---
 
-## Steps
+## 明示チェックリスト (Verify との境界固定)
 
-1. Design
+Build は以下を満たしたらループを抜けて Verify へ渡す。Build 内で最終検証は行わない。
+
+- [ ] 対象ファイル境界が宣言済み (並列時は排他)
+- [ ] 担当外ファイルに触っていない
+- [ ] 1 論理変更 = 1 コミット (論理的完了単位コミット)
+- [ ] 新規コードに対応するテスト or 既存テストでカバー
+- [ ] ローカルで build が通る
+- [ ] main 直接 push なし
+
+---
+
+## Steps (light/full 共通)
+
+1. Design (full のみ / light はスキップ)
 2. Foundation
 3. Core Implementation
 4. Integration
@@ -15,18 +28,27 @@
 
 ---
 
+## 並列実行時の安全ルール
+
+並列起動時の規約 (担当ファイル境界 / 共有ファイルの単独 writer / 終了条件 3 系統) は
+`system/role-contracts.md §4` を **唯一の真実** とする。
+本ファイルはルールを複製せず、上記契約に従うことのみ規定する。
+
+---
+
 ## Rules
 
-- 各ステップでcommit
-- WorkTreeで作業
-- mainへ直接push禁止
+- **論理的完了単位でコミット** (ステップ単位ではなく論理単位)
+- WorkTree で作業
+- main へ直接 push 禁止
+- 1修復 = 1仮説 (CI 失敗対応でも守る)
 
 ---
 
 ## Trigger
 
-- Monitor正常時
-- Verify OK後
+- Monitor 正常時
+- Verify OK 後のフォロー実装
 
 ---
 
@@ -41,16 +63,18 @@
 ## Output
 
 - code changes
-- commits
+- commits (論理的完了単位)
 
 ---
 
 ## Next
 
-- Verify Loopへ
+- Verify Loop へ
 
 ---
 
 ## 5h Rule
 
-- 未完でもcommitを残す
+- 未完でも commit を残す
+- 「次に書くべき 1 関数」は `state.json.execution.pending` に追記する
+  (Build Loop は `.loop-handoff-report.md` を直接書かない。writer は Loop Guard のみ)

--- a/.claude/claudeos/loops/improve-loop.md
+++ b/.claude/claudeos/loops/improve-loop.md
@@ -1,24 +1,40 @@
 # Improve Loop
 
 ## Role
-品質改善・最適化。
+品質改善・最適化。**条件付きループ** (必須ではない)。
+
+---
+
+## 起動条件 (必須ではない)
+
+以下の **すべて** を満たした時のみ起動する。1 つでも欠けたらスキップ。
+
+- [ ] Verify Loop が PASS
+- [ ] 残時間 ≥ 30 分
+- [ ] Token 使用率 < 70%
+- [ ] `no_progress_streak == 0`
+- [ ] モードが **full** (light モードでは Improvement をスキップする)
+
+条件を満たさない場合は即座に Monitor Loop へ戻る。
 
 ---
 
 ## Targets
 
-- refactoring
-- documentation
-- naming
-- error handling
-- performance
+- refactoring (小さく)
+- documentation 整備
+- naming 改善
+- error handling 整理
+- performance (計測根拠がある場合のみ)
 
 ---
 
-## Trigger
+## 禁止事項
 
-- Verify成功後
-- STABLE前
+- 破壊的変更の無断実行
+- テストカバレッジを下げるリファクタ
+- 変更理由のないリネーム連鎖
+- light モードでの起動
 
 ---
 
@@ -33,16 +49,17 @@
 ## Output
 
 - improved code
-- docs
+- docs 差分
 
 ---
 
 ## Next
 
-- Monitor Loopへ戻る
+- Monitor Loop へ戻る
 
 ---
 
 ## 5h Rule
 
 - 改善内容を記録
+- 残時間 < 30 分で中断し、進行中の差分は WIP コミットを残す

--- a/.claude/claudeos/loops/monitor-loop.md
+++ b/.claude/claudeos/loops/monitor-loop.md
@@ -1,7 +1,22 @@
 # Monitor Loop
 
 ## Role
-システム状態と品質の監視。
+システム状態と品質の監視。**観測専用** (判定は Verify, 実装は Build の責務)。
+
+---
+
+## 最初に行うこと (Resume Protocol)
+
+セッション冒頭 or ループ冒頭で、以下を **先頭に** 出力する:
+
+1. **条件付き実行**: `.loop-handoff-report.md` が **存在する場合のみ** 以下を行う
+   - 「前回の停止理由」を読み上げる
+   - 「次の第一手」を宣言する
+   - `state.json.execution.last_stop_reason` を参照する
+2. **新規セッション (handoff 不在) の場合**: Resume Protocol をスキップし、
+   「前回停止理由: N/A (新規セッション)」と 1 行だけ出力する。
+   架空の停止理由を捏造してはならない (`state.json.execution.last_stop_reason` には何も書かない)
+3. その後で通常の Monitor チェックに進む
 
 ---
 
@@ -14,6 +29,8 @@
 - security warnings
 - token usage
 - retry count
+- no_progress_streak
+- same_diff_streak
 
 ---
 
@@ -21,7 +38,7 @@
 
 - ループ開始時
 - 各フェーズ終了後
-- CI実行後
+- CI 実行後
 
 ---
 
@@ -29,13 +46,13 @@
 
 - 状態収集
 - 異常検知
-- リスク判定
+- **リスク検知** (判定・結論は書かない。「要検証フラグ」を state.json に立てて Verify へ引き渡すのみ)
 
 ---
 
 ## Output
 
-`.loop-monitor-report.md`
+`.loop-monitor-report.md` — **観測専用**。判定結論は書かない。
 
 ---
 
@@ -49,3 +66,4 @@
 ## 5h Rule
 
 - 状態ログを必ず保存
+- 残時間 < 30 分なら Improvement スキップ宣言

--- a/.claude/claudeos/loops/verify-loop.md
+++ b/.claude/claudeos/loops/verify-loop.md
@@ -1,24 +1,48 @@
 # Verify Loop
 
 ## Role
-品質検証とCI確認。
+品質検証と CI 確認。**判定専用** (観測は Monitor ループの責務)。
 
 ---
 
-## Checks
+## 明示チェックリスト (Build との境界固定)
 
-- code review
-- unit tests
-- integration tests
-- lint
-- build
-- CI stability
+Verify は文章ではなく以下チェックリストで判定する。全項目に明示的な PASS/FAIL を付けること。
+
+### 基本チェック (light/full 共通)
+
+- [ ] unit tests: 全件 PASS
+- [ ] lint: 新規指摘 0
+- [ ] build: exit 0
+- [ ] typecheck: 新規エラー 0
+- [ ] error 0
+- [ ] security critical/high issue 0
+
+### Full モード追加チェック (full モードでは常に必須)
+
+差分サイズに依らず、full モードに入ったタスクはすべて以下を実行する。
+(role-contracts §1 により full モードは認証・権限・DB 変更・並列同期などサイズ以外の理由でも発動するため、サイズでゲートしない)
+
+- [ ] **integration tests: PASS**
+- [ ] code review (Codex): severity high 指摘なし
+- [ ] adversarial-review: 認証 / 権限 / DB / 並列 / リリース直前時は必須
+- [ ] CI success (GitHub Actions)
+
+### 変更理由との整合性チェック (必須・Verify 固有)
+
+テスト成功だけで完了としない。以下を明示的に確認する:
+
+- [ ] **変更の目的と修正内容が一致しているか** (例: バグ修正のつもりが挙動変更になっていないか)
+- [ ] **受入条件との対応**: Issue / PR 記載の受入条件が満たされているか
+- [ ] **削除や移動が意図的か** (不要な副作用ではないか)
+
+1 項目でも不整合があれば Verify は FAIL 扱い。
 
 ---
 
 ## Trigger
 
-- Build後
+- Build 後
 - 修正後
 
 ---
@@ -26,37 +50,65 @@
 ## Actions
 
 - テスト実行
-- CI確認
+- CI 確認
 - 品質評価
+- 変更理由 ↔ 差分の整合性評価
 
 ---
 
 ## Output
 
-`.loop-verify-report.md`
+`.loop-verify-report.md` — **判定専用**。観測ログは書かない (観測は Monitor へ)。
+
+### フォーマット
+
+```markdown
+## Summary
+- mode: light|full
+- result: PASS|FAIL
+- reason: {一行}
+
+## Checklist
+- [x/~] unit tests
+- [x/~] lint
+- [x/~] build
+- [x/~] typecheck
+- [x/~] intent consistency
+- [x/~] (full) integration tests
+- [x/~] (full) CI success (GitHub Actions)
+- [x/~] (full) codex review: severity high 指摘なし
+- [x/~] (full) adversarial-review (認証/権限/DB/並列/リリース直前時のみ必須)
+
+## Risks
+- {未確認点}
+
+## Next Action
+- {PASS なら Improvement or 終了処理 / FAIL なら CI Manager or Debugger へ}
+```
 
 ---
 
 ## Next
 
-- 成功 → Improve Loop
-- 失敗 → CI Manager / Auto Repair
+- 全項目 PASS → Improve Loop (余力時のみ) or 終了処理
+- 1 項目でも FAIL → CI Manager / Auto Repair → Debugger (Codex Rescue)
 
 ---
 
 ## STABLE Check
 
-以下を評価：
+Verify のチェックリストが全 PASS かつ連続成功回数が変更規模に応じた N に到達した場合のみ STABLE。
 
-- test success
-- CI success
-- lint success
-- build success
-- error 0
-- security issue 0
+| 変更規模 | 連続成功回数 |
+|---|---|
+| 小規模 | N=2 |
+| 通常 | N=3 |
+| 重要 (認証/DB/security) | N=5 |
 
 ---
 
 ## 5h Rule
 
 - 未完でも評価を残す
+- 「Verify 中の未判定項目」は `state.json.execution.pending_verify` に追記する
+  (Verify Loop は `.loop-handoff-report.md` を直接書かない。writer は Loop Guard のみ)

--- a/.claude/claudeos/system/loop-guard.md
+++ b/.claude/claudeos/system/loop-guard.md
@@ -1,31 +1,138 @@
 # Loop Guard
+
 ## Role
 無限ループ防止と強制停止。全システムに対して最優先で適用される。
+Priority: Loop Guard > 全システム (CTO / Architect / Developer の判断より優先)。
 
-## Monitoring（プロジェクトごとに独立管理）
+## Monitoring (プロジェクトごとに独立管理)
+
 - セッション開始時刻・経過時間
-- retry回数（PR単位）
+- retry 回数 (PR 単位)
 - 同一エラーの連続発生回数
-- CI失敗数（PR単位）
-- Blockedステータス継続時間
+- **no-progress 回数** (同一原因で進展なしが連続した回数)
+- **same-diff 再生成検知** (同じ差分を繰り返し生成しているか)
+- CI 失敗数 (PR 単位)
+- **CI 失敗カテゴリ別集計** (エラー文字列でなくカテゴリで clustering)
+- Blocked ステータス継続時間
 
 ## Stop Conditions
-- 5時間到達：セッション開始からの経過時間
-- same error 連続3回：直前3回のループで同一エラー文字列が一致
-- CI retry 同一PR 5回：同一PRへのActions再実行が5回到達
-- security issue：severity critical / high の検知（件数不問）
-- Blocked継続30分：Blockedステータスが30分以上継続
 
-## Actions（実行順序厳守）
+| # | 条件 | 閾値 | 備考 |
+|---|---|---|---|
+| 1 | 5時間到達 | elapsed ≥ 300m | セッション開始からの経過時間 |
+| 2 | same error 連続 | 3 回 | 直前 3 回のループで同一エラー文字列が一致 |
+| 3 | **no-progress 連続** | **2 回** | 修正してもテスト・CI・検証結果が改善しない (新規) |
+| 4 | **same-diff regeneration** | 2 回 | 同一ファイルに対し同一差分を再生成 (新規) |
+| 5 | CI retry 同一 PR | 5 回 | 同一 PR への Actions 再実行 |
+| 6 | rescue 連続失敗 | 3 回 | Codex rescue が同一原因で 3 回失敗 |
+| 7 | security issue | critical/high 検知 | 件数不問 |
+| 8 | Blocked 継続 | 30 分 | Blocked ステータスが 30 分以上継続 |
+
+**進展判定 (no-progress の定義)**:
+
+次のすべてを満たす場合のみ「進展なし」とカウントする (AND 判定):
+
+- 失敗数 (test + lint 合計) が減っていない
+- CI 失敗カテゴリが同一
+- 差分が実質空 (コメント・空白のみ、または同一範囲の再生成)
+
+ひとつでも **数量的改善** があれば「進展あり」と判定し、`no_progress_streak` をリセットする。
+(例: unit test 失敗 20 件 → 1 件は失敗カテゴリが同一でも「進展あり」なので streak は増えない)
+
+## CI 失敗カテゴリ (clustering 基準)
+
+エラー文字列は揺らぐため、以下カテゴリで clustering する:
+
+- `dependency`
+- `lint`
+- `type`
+- `unit_test`
+- `integration_test`
+- `build`
+- `config`
+- `security`
+- `flaky`
+- `infra`
+- `unknown`
+
+同一カテゴリ 3 回連続 → Blocked。
+
+## Actions (実行順序厳守)
+
 1. 新規ループ発火の禁止
-2. 実行中SubAgentへの停止通知（完了待ち）
-3. git commit（WIPラベル付き）
-4. .loop-stop-report.md 出力
-5. GitHub Projects Status を実態に合わせて更新
-6. CTO通知（GitHub Issue コメント）
+2. 実行中 SubAgent への停止通知 (完了待ち)
+3. git commit (WIP ラベル付き)
+4. `.loop-stop-report.md` 出力
+5. `.loop-handoff-report.md` 更新 (再開用 / 次セクション参照)
+6. GitHub Projects Status を実態に合わせて更新
+7. CTO 通知 (GitHub Issue コメント)
 
 ## Output
-`.loop-stop-report.md`（プロジェクトルートに配置、フォーマット固定）
 
-## Priority
-Loop Guard > 全システム（CTO・Architect・Developerの判断より優先）
+- `.loop-stop-report.md` — プロジェクトルートに配置、フォーマット固定
+- `.loop-handoff-report.md` — 再開時の「前回の停止理由」と「次の第一手」を必ず先頭に記載
+  **本ファイルの単独 writer は Loop Guard**。Build / Verify / Improve は直接書き込まず、未完了情報を `state.json.execution.pending` と `state.json.execution.pending_verify` に追記するだけ。Loop Guard が停止時に state.json を読んで本レポートを合成する。
+
+### .loop-handoff-report.md テンプレート
+
+```markdown
+## 前回の停止理由
+- category: {stop_condition_id}
+- reason: {具体的な理由}
+- elapsed: {H時間M分}
+
+## 次の第一手 (最優先)
+- action: {次に踏むべき1手}
+- file: {触るべきファイル}
+- expected: {成功判定}
+
+## 未完了の担当分 (ロール別)
+- [ ] ...
+
+## 調査済みで棄却した仮説
+- ...
+```
+
+## state.json 拡張スキーマ (Loop Guard 連携)
+
+Loop Guard は以下の state.json フィールドを読み書きする。
+**既存の `docs/common/schemas/state.schema.json` および既存 `state.json` のキー名・enum 値を保持した上で、optional な新フィールドのみ追加する** (backward compatible)。
+
+```json
+{
+  "execution": {
+    "start_time": "ISO8601",
+    "elapsed_minutes": 0,
+    "remaining_minutes": 300,
+    "phase": "Monitor|Development|Verify|Improvement|Debug|Release|STABLE",
+    "mode": "light|full",
+    "retry_count_by_cause": {},
+    "no_progress_streak": 0,
+    "same_diff_streak": 0,
+    "last_stop_reason": "none",
+    "pending": [],
+    "pending_verify": []
+  },
+  "debug": {
+    "same_error_retry_count": 0,
+    "rescue_retry_count": 0,
+    "failure_count_by_category": {},
+    "last_failure_category": "none",
+    "last_root_cause": "",
+    "last_fix_strategy": "none"
+  }
+}
+```
+
+- `execution.phase` は既存 enum (capitalized) を維持する (`current_phase` にリネームしない)
+- `last_failure_category` は **debug** 配下 (既存の通り)。execution 配下には置かない
+- 新しい optional フィールドは `state.schema.json` にも同時追加する必要がある
+
+**更新タイミング**:
+- ループ開始: `execution.phase` 更新
+- ループ終了: `elapsed_minutes`, `remaining_minutes` 更新
+- 失敗検出: `debug.last_failure_category`, `debug.failure_count_by_category` 更新
+- 進展判定: `execution.no_progress_streak` 加算 / リセット
+- 差分判定: `execution.same_diff_streak` 加算 / リセット
+- 停止時: `execution.last_stop_reason` 保存
+- Build/Verify の未完了記録: `execution.pending` / `execution.pending_verify` への追記 (Build/Verify ループが書き、Loop Guard が停止時に読む)

--- a/.claude/claudeos/system/orchestrator.md
+++ b/.claude/claudeos/system/orchestrator.md
@@ -2,67 +2,98 @@
 
 Responsible for coordinating all ClaudeOS layers.
 
-- 5時間タイマー起動
-- ループごとに残時間評価
+**第一原則** (Anthropic multi-agent coordination より):
+
+> **最も単純に動く形から始め、詰まった地点でのみ複雑化する。**
+
+既定パターンは **Orchestrator-Subagent** のみ。Message Bus / Shared State / Event-driven などは「必要に迫られた時だけ」段階導入する。
+
+詳細な役割契約は `system/role-contracts.md` を **唯一の真実** として参照する。
+
+---
+
+## 最初の判断: Light / Full モード
+
+すべての新タスク受領時、Orchestrator は **最初にモードを宣言する**。
+発動条件・起動チェーン・禁止事項の定義は `system/role-contracts.md §1` を **唯一の真実** として参照する。
+
+- 既定は **light**。
+- 本ファイルには判定表を持たない (ドリフト防止)。
+- 昇格時は `role-contracts.md §1` の条件に照らし理由を明示する。
+
+---
 
 ## Execution Order
 
-1. Environment Check
-2. Project Switch
-3. Executive Layer
-4. Management Layer
-5. Agent Teams Activation
-6. Triple Loop Engine
+1. Environment Check (5h 残, Token 残, Loop Guard 状態)
+2. Resume Check (`.loop-handoff-report.md` を先頭から読む → 前回の停止理由と次の第一手を宣言)
+3. Project Switch
+4. **モード宣言 (light / full)**
+5. Subagent Activation (role-contracts に従う)
+6. Triple Loop Engine (Monitor → Build → Verify → Improve)
 
 ## Output Dashboard
 
 - project
+- mode (light/full)
 - loop status
 - token usage
+- remaining time
+- **前回の停止理由** (ある場合)
+- **次の第一手** (ある場合)
+
+---
 
 # Agent Orchestrator
 
 ## Role
-Agent Teamsの統括・制御。
+Agent Teams の統括・制御。役割定義の真実は `role-contracts.md`。本文は実行プロトコルのみ扱う。
 
 ## Responsibilities
-- タスク割当
+- モード宣言 (light/full)
+- タスク分解と担当ファイル境界の事前宣言
+- サブエージェント返却の4セクション検証: **Summary → Risks → Findings → Next Action** の順序固定 (role-contracts.md §2 に従う)
 - 進行管理
-- 状態管理
+- 状態管理 (state.json 書き込み、scoped ownership は role-contracts.md §5.1)
 - 5時間制御
 
 ## Actions
-- Agent呼び出し
+- Agent 呼び出し
 - 状態遷移管理
-- Project同期
+- Project 同期
+- 並列実行時の境界検証 (重複禁止)
 
 ## Constraints
-- 無限ループ禁止
+- 無限ループ禁止 (Loop Guard 参照)
 - 状態不整合禁止
+- 返却 4 セクション未充足の受領禁止
+- light モードで Architect / Security / Analyst / EvolutionManager を呼ばない
 
-## 5h Rule（最重要）
+## 5h Rule (最重要)
 - 開始時刻を記録
 - 経過時間監視
-- 5時間到達で全Agent停止
-- 終了処理を強制実行
+- 5時間到達で全 Agent 停止
+- 終了処理を強制実行 (最終判断は Orchestrator 自身が行う。role-contracts §3.1 により CTO 権限は Orchestrator に統合済み)
 
 ## Collaboration
-- CTOと連携
-- 全Agent統制
+- 全 Agent 統制
+- 外部との最終判断のやり取りも Orchestrator が担う (CTO を別ロールとして連携しない)
 
-# ClaudeOS Orchestrator
+---
+
+# ClaudeOS Orchestrator (詳細制御層)
 
 ## Role
-ClaudeOS全体の統制・制御。
+ClaudeOS 全体の統制・制御。
 
 ---
 
 ## Responsibilities
 
 - 全レイヤー統合
-- Agent制御
-- Loop制御
-- Project同期
+- Agent 制御
+- Loop 制御
+- Project 同期
 - 5時間制御
 
 ---
@@ -79,11 +110,11 @@ ClaudeOS全体の統制・制御。
 
 ## Execution Cycle
 
-1. 状態取得（Monitor）
-2. タスク割当（Management）
-3. 実行（Build）
-4. 検証（Verify）
-5. 改善（Improve）
+1. 状態取得 (Monitor)
+2. タスク割当 (Management)
+3. 実行 (Build)
+4. 検証 (Verify)
+5. 改善 (Improve) — **余力時のみ条件付き**
 6. 再評価
 
 ---
@@ -93,9 +124,11 @@ ClaudeOS全体の統制・制御。
 管理する状態：
 
 - current project
+- current mode (light/full)
 - loop status
 - CI status
 - retry count
+- no_progress_streak
 - token usage
 - time elapsed
 
@@ -104,35 +137,36 @@ ClaudeOS全体の統制・制御。
 ## Trigger
 
 - 各ループ開始時
-- CI結果更新時
+- CI 結果更新時
 - 状態変化時
 
 ---
 
 ## Actions
 
-- Agent呼び出し
+- Agent 呼び出し
 - 状態遷移管理
-- Project更新
-- Loop制御
+- Project 更新
+- Loop 制御
 
 ---
 
-## 5h Rule（最重要）
+## 5h Rule (最重要)
 
 - 経過時間監視
 - 5時間到達で全停止
-- CTOへ最終判断依頼
+- **Orchestrator 自身が最終判断を行う** (CTO 権限は role-contracts §3.1 により統合済み)
 - 終了処理実行
 
 ---
 
 ## Stop Flow
 
-1. Loop Guard発動
-2. 全Agent停止
+1. Loop Guard 発動
+2. 全 Agent 停止
 3. 状態保存
-4. レポート生成
+4. `.loop-handoff-report.md` 更新 (前回停止理由 + 次の第一手を先頭に)
+5. レポート生成
 
 ---
 
@@ -140,3 +174,4 @@ ClaudeOS全体の統制・制御。
 
 - 無限ループ禁止
 - 状態不整合禁止
+- 「最も単純に動く形から始める」を常に優先する

--- a/.claude/claudeos/system/role-contracts.md
+++ b/.claude/claudeos/system/role-contracts.md
@@ -1,0 +1,232 @@
+# Role Contracts (Orchestrator-Subagent)
+
+このファイルは ClaudeOS における全ロールの **契約** を定義する唯一のソースである。
+Anthropic の multi-agent coordination 原則に従い、既定パターンは **Orchestrator-Subagent** のみとし、他の協調パターン (Message Bus / Shared State / Event-driven) は「詰まった地点でのみ」追加する。
+
+優先順位: 本ファイル > 個別 agent 定義 > 本文説明。
+
+---
+
+## 0. 基本方針 (Anthropic 原則)
+
+1. 最も単純に動く形から始め、詰まった地点でのみ複雑化する。
+2. Orchestrator-Subagent を既定とする。message bus は CI/Issue/PR イベントから段階導入する。
+3. 全エージェントを最初からイベント駆動にしない。
+4. 役割が多いほど中央要約の情報欠落対策が重要になる → 返却を構造化する。
+5. 共有状態を使う場合は「終了条件」と「truth source」を先に定義する。
+
+---
+
+## 1. 運用モード (Light / Full)
+
+小タスクで Full Orchestration を走らせない。モード選択は **Orchestrator の最初の判断** とする。
+
+| モード | 発動条件 | 起動ロール | 最大コンテキスト |
+|---|---|---|---|
+| **light** | 1ファイル修正 / lint / doc / 既知バグ / 差分 < 50行 | Developer のみ (+ 必要時 Reviewer) | 10% |
+| **full** | 新機能 / 認証権限変更 / DBスキーマ / 並列同期 / 差分 ≥ 50行 or 3ファイル以上 | role chain 全員 | 上限まで |
+
+- 既定は **light**。full への昇格は Orchestrator が理由付きで宣言する。
+- light モードでは Architect / Security / Analyst / EvolutionManager を呼ばない。
+- Improvement ループは light の時に省略してよい。
+
+---
+
+## 2. 返却フォーマット (全サブエージェント共通・必須)
+
+サブエージェントの返却は **自由記述ではなく以下4セクション固定、順序固定**。長文禁止、各セクション箇条書き。
+
+```markdown
+## Summary
+- 1〜3行の結論 (最も重要なリスクから書き始める。賞賛から始めない)
+
+## Risks
+- 未確認点・前提破れ・副作用候補を列挙する (空なら "none")
+- 重大度 (high / medium / low) を付与する
+
+## Findings
+- 観測事実のみ (根拠ファイル:行番号を添える)
+
+## Next Action
+- Orchestrator が次に踏むべき1手 (候補1〜3)
+```
+
+**順序は全役割共通で固定** (Reviewer も同じ)。Risks が Findings より前に置かれているのは、重要な論点が埋もれないようにするため。
+Orchestrator はこの 4 セクションが揃っていない返却を受領しない。
+
+---
+
+## 3. ロール契約 (I/O / 完了条件 / 禁止事項 / 参照許可)
+
+各ロールは **入力・出力・完了条件・禁止事項・参照許可ファイル群** を必ず持つ。
+未定義のロールを起動しないこと。
+
+### 3.1 Orchestrator (CTO 兼)
+
+| 項目 | 定義 |
+|---|---|
+| 入力 | TASKS.md 先頭タスク, state.json, Loop Guard 状態 |
+| 出力 | モード宣言 (light/full), 起動するサブエージェント名, タスク分解 |
+| 完了条件 | サブエージェントから4セクション返却を受領、または Loop Guard 停止 |
+| 禁止事項 | 自身でコード編集を行う (分解と統制に専念), 理由なし full 昇格 |
+| 参照許可 | リポジトリ全域 (読み取り), `state.json` (書き込み) |
+
+### 3.2 Architect
+
+| 項目 | 定義 |
+|---|---|
+| 入力 | 変更要求, 影響範囲候補 |
+| 出力 | 責務分離案, 境界提案, 差分スコープ |
+| 完了条件 | full モードかつ差分 ≥ 50行 or 3ファイル以上の時のみ呼ばれる。それ以外はスキップ |
+| 禁止事項 | light モードでの呼び出し, コード実装 |
+| 参照許可 | `docs/`, `README.md`, `src/` 読み取り |
+
+### 3.3 Developer
+
+| 項目 | 定義 |
+|---|---|
+| 入力 | 1つの論理修正対象 + 完了判定 |
+| 出力 | コード差分 + 論理的完了単位コミット |
+| 完了条件 | 自分の担当ファイル境界内でテスト追加 or 既存テスト実行成功 |
+| 禁止事項 | 担当外ファイルへの変更, 1コミットに複数論理変更, `main` 直 push |
+| 参照許可 | Orchestrator が与えた担当ファイル群のみ (並列実行時は重複禁止) |
+
+### 3.4 Reviewer (Codex Plugin 経由)
+
+| 項目 | 定義 |
+|---|---|
+| 入力 | PR 差分 or ローカル差分 |
+| 出力 | §2 の共通4セクション (Summary → Risks → Findings → Next Action)。Summary の冒頭は最も重大なリスクで始める |
+| 完了条件 | `/codex:review` 完了 + Risks セクションに severity 判定 |
+| 禁止事項 | Claude 単独レビュー (必ず Codex Plugin を使う), Summary を賞賛・謝辞から始めること, §2 と異なる順序や節構成で返却すること |
+| 参照許可 | 差分対象ファイル + 直接依存ファイル |
+
+### 3.5 Debugger (Codex Rescue 経由)
+
+| 項目 | 定義 |
+|---|---|
+| 入力 | 1つの仮説 + 1つの失敗カテゴリ |
+| 出力 | 原因候補, 最小修正案 |
+| 完了条件 | 1 rescue = 1 仮説で判定可能になった時点 |
+| 禁止事項 | 大規模書換え, 深追い (同一原因 3 回超), 推測修正 |
+| 参照許可 | 失敗ログ関連ファイルのみ |
+
+### 3.6 QA
+
+| 項目 | 定義 |
+|---|---|
+| 入力 | 変更範囲 + 受入条件 |
+| 出力 | 検証結果表 (test / lint / build / typecheck) |
+| 完了条件 | 「変更理由」と「テスト意図」の整合確認を含む |
+| 禁止事項 | テスト成功だけで完了宣言 (意図整合を必ず見る) |
+| 参照許可 | test/, spec/, e2e/ |
+
+### 3.7 Security
+
+| 項目 | 定義 |
+|---|---|
+| 入力 | 差分 |
+| 出力 | 重大度付き指摘 (critical/high/medium/low) |
+| 完了条件 | **以下の差分がある時のみ深く起動**: 認証, 権限, 外部公開 API, secrets, 依存追加/更新 |
+| 禁止事項 | 上記差分なしでの full 起動, severity 判断なしの指摘 |
+| 参照許可 | 差分対象 + 依存マニフェスト (package.json 等) |
+
+### 3.8 DevOps (Ops)
+
+| 項目 | 定義 |
+|---|---|
+| 入力 | CI 状態, Projects 状態 |
+| 出力 | ライトチェック or フルチェック結果 |
+| 完了条件 | ライト: CI status + 最新 run 番号のみ / フル: logs + failure category 分類 |
+| 禁止事項 | 毎回フル確認 (light モード時はライトチェックのみ) |
+| 参照許可 | `.github/`, CI ログ |
+
+### 3.9 Analyst / EvolutionManager
+
+full モード時のみ起動。light モードでは呼ばない。
+
+---
+
+## 4. 並列実行の安全ルール
+
+Agent Teams を並列起動する場合、以下を **先に** 決めること:
+
+1. **担当ファイル境界**: エージェントごとに触ってよいファイル/ディレクトリを排他的に割り当てる。
+2. **共有ファイルの書き込み権限は 1 エージェントのみ**: README.md, CLAUDE.md, state.json などは Orchestrator だけが書く。
+3. **終了条件の3系統**: `時間 (max duration)` / `収束 (no-change N回)` / `担当判定 (Orchestrator の強制終了)` のいずれかで必ず終わる。
+4. **Shared State を使う場合は truth source を明文化**: どのファイルが唯一の真実か、更新順序はどうかを先に書く。
+
+---
+
+## 5. Truth Source 一覧
+
+| 情報 | Truth Source | Writer |
+|---|---|---|
+| タスクキュー | `TASKS.md` (唯一。他の場所にキューを作らない) | 人間 + Issue Factory |
+| 実行状態 | `state.json` | **scoped ownership** (下記 §5.1 参照) |
+| 進行中の観測 | `.loop-monitor-report.md` (観測専用、判定結論を書かない) | Monitor Loop |
+| 検証結果 | `.loop-verify-report.md` (判定専用) | Verify Loop |
+| 引継ぎ情報 | `.loop-handoff-report.md` (再開専用) | **Loop Guard のみ** |
+| 長期記憶 | Memory MCP | Orchestrator |
+| 作業規約 | 本ファイル (`role-contracts.md`) | 人間 |
+| 運用規約 | `CLAUDE.md` | 人間 |
+
+### 5.1 `state.json` の scoped ownership
+
+`state.json` は唯一の実行状態ソースだが、単一 writer にすると各ループが handoff 情報を残せなくなるため、**キー単位で書き込み権限を分割** する (append-only セマンティクス):
+
+| キー範囲 | Writer | アクセス |
+|---|---|---|
+| `execution.phase`, `execution.elapsed_minutes`, `execution.remaining_minutes`, `execution.mode`, `execution.last_stop_reason` | Orchestrator | 上書き可 |
+| `execution.no_progress_streak`, `execution.same_diff_streak`, `execution.retry_count_by_cause`, `debug.*` | Loop Guard | 上書き可 |
+| `execution.pending` | Build Loop | **append-only** (既存要素を消さない) |
+| `execution.pending_verify` | Verify Loop | **append-only** (既存要素を消さない) |
+| それ以外 (`project`, `goal`, `kpi`, `token`, `stable`, `session`, `codex`, `automation`, `learning`, `github`, `status`) | Orchestrator | 上書き可 |
+
+**原則**:
+- Build / Verify は自分の担当キーのみ append する (他のキーを読み書きしない)
+- Loop Guard は Build/Verify が追記した `pending` / `pending_verify` を読み、停止時に `.loop-handoff-report.md` を合成する
+- 同時書き込みの整合性は Orchestrator が管理する (並列起動時は role-contracts §4 の並列ルールに従う)
+
+### 5.2 その他の原則
+
+- 同じ情報を 2 箇所に書かない。分裂した時は truth source を信じる。
+- **`.loop-handoff-report.md` は Loop Guard 単独 writer**。Build / Verify / Improve ループはこのファイルを直接書かず、未完了情報を上記 §5.1 の `state.json.execution.pending` / `pending_verify` へ追記する。Loop Guard が停止時に `state.json` を読んで handoff レポートを生成する。
+- 観測ファイル (`.loop-monitor-report.md`) と判定ファイル (`.loop-verify-report.md`) の責務を混ぜない。Monitor は判定結論を書かない。
+
+---
+
+## 6. Orchestrator の判断フロー
+
+```text
+新タスク受領
+  ↓
+TASKS.md の先頭を確認
+  ↓
+差分スコープ推定 → light / full 決定
+  ↓
+light: Developer 単独起動 → 返却受領 → commit → Verify (最小)
+full:  role chain 起動 → 返却受領 → Reviewer → Verify (完全) → Improvement
+  ↓
+Loop Guard 判定 → 次ループ or 停止
+```
+
+---
+
+## 7. 禁止事項 (総則)
+
+- 本契約を満たさないサブエージェントの起動
+- 返却4セクションを欠いた受領の承認
+- light モードで Architect / Security / Analyst / EvolutionManager を呼ぶこと
+- 担当ファイル境界を宣言せずに並列起動
+- Improvement を必須扱いにすること (余力時のみ条件付きで起動)
+- 自動生成タスクを triage 無しで即実行すること (3件上限 + 根拠ファイル + 再現条件が必須)
+
+---
+
+## 8. 参照
+
+- `system/orchestrator.md` — Orchestrator の実行サイクル
+- `system/loop-guard.md` — 停止条件と拡張 state スキーマ
+- `loops/*-loop.md` — 各ループの責務チェックリスト
+- `AGENTS.md` — Codex `exec/review/resume/fork` 使い分け表

--- a/.claude/claudeos/system/token-budget.md
+++ b/.claude/claudeos/system/token-budget.md
@@ -1,8 +1,6 @@
 # Token Budget Manager
 
-Weekly token management.
-
-## Budget Zones
+## Budget Zones (週次の俯瞰)
 
 | Zone   | Range    | Status                  |
 | ------ | -------- | ----------------------- |
@@ -11,37 +9,56 @@ Weekly token management.
 | Orange | 75–90%   | Monitor priority        |
 | Red    | 90–100%  | Development stopped     |
 
+---
 
-# Token Budget Manager
+## Per-Task Budget (タスク単位の監視・必須)
 
-## Role
-トークン使用量制御。
+週次 zone だけでは「1 タスクで Token を吸い尽くす事故」を防げないため、**タスク単位の予算** も同時に監視する。
+
+| モード | 1 タスクあたり上限 | 超過時の対応 |
+|---|---|---|
+| **light** | セッション残量の 10% | light 継続 or 中断 |
+| **full**  | セッション残量の 35% | full 継続可能、ただし残量 < 50% なら light へ降格 |
+| Debug (rescue) | セッション残量の 15% | 超過で rescue 打ち切り |
+| Improvement | セッション残量の 10% | 超過で即スキップ |
+
+**監視ポイント**:
+
+- エージェント 1 起動ごとに使用量を記録する
+- 返却受領時に累計を `state.json.token.current_phase_used` に加算する
+- 1 タスクの累計が上限の 80% を超えたら次エージェント起動前に warning
+- 上限到達で即中断。残件は `state.json.execution.pending` に追記する
+  (`.loop-handoff-report.md` は Loop Guard 単独 writer のため直接書かない。
+  Loop Guard が停止時に state.json から合成する)
 
 ---
 
-## Zones
+## Role
 
-（既存でOK）
+トークン使用量制御。週次 zone とタスク単位予算の両方を使う。
 
 ---
 
 ## Actions
 
-- 使用量監視
+- 使用量監視 (週次 + タスク単位)
 - 制限適用
+- エージェントごとの最大コンテキスト予算チェック
+- タスク単位予算の超過検知
 
 ---
 
 ## Behavior
 
 - Green → 通常
-- Yellow → 軽量化
-- Orange → Monitor優先
-- Red → 開発停止
+- Yellow → 軽量化 (light モード優先)
+- Orange → Monitor 優先 (新規 full 禁止)
+- Red → 開発停止 (Verify と終了処理のみ)
 
 ---
 
 ## Integration
 
-- Orchestratorと連携
-- Loop制御に反映
+- Orchestrator と連携 (モード降格の判断材料)
+- Loop 制御に反映
+- Loop Guard の停止条件 (Token 枯渇) と連動

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,4 +169,45 @@ Small change         / Test everything
 Stable first         / Deploy safely
 Improve continuously / Stop at 5 hours safely
 Think within budget  / Use tokens wisely
+Simplest first       / Complicate only where stuck
 ```
+
+## Codex コマンド使い分け表
+
+| コマンド | 用途 | 使うタイミング | 禁止 |
+|---|---|---|---|
+| `exec` | 新規実装・修正を Codex に委ねる | light モードの 1 ファイル修正, full モードの Developer 担当分 | Orchestrator 自身の分解作業 |
+| `review` | 差分レビュー | PR 作成前 / PR 更新時 (必須) | Claude 単独レビューで代替 |
+| `adversarial-review` | 対抗レビュー | 認証・権限・DB スキーマ・並列同期・リリース直前 | 軽微な差分への無条件起動 |
+| `rescue` | 原因調査・最小修正案 | CI 失敗 / test 失敗 / unknown / 3 ファイル以上の regressions | 深追い (1 rescue = 1 仮説) |
+| `resume` | 中断中の job 再開 | 前回セッションからの継続作業 | 結果未確認のまま再投入 |
+| `fork` | 並列な別仮説を試す | 同一問題への複数仮説検証 | 担当ファイル境界未宣言 |
+
+## 返却フォーマット (全サブエージェント共通・順序固定)
+
+自由記述禁止。以下4セクションを**固定順序**で返却する (全役割共通・Reviewer 含む):
+
+```markdown
+## Summary
+- 1〜3行の結論 (最も重要なリスクから書き始める。賞賛から始めない)
+
+## Risks
+- 未確認点・副作用候補 (空なら "none")
+- 重大度 (high / medium / low) を付与
+
+## Findings
+- 観測事実のみ (根拠ファイル:行番号)
+
+## Next Action
+- Orchestrator の次の1手候補
+```
+
+順序は **Summary → Risks → Findings → Next Action** 固定。
+Risks を Findings より前に配置するのは、重要な論点が埋もれないようにするため。
+Orchestrator はこの順序を満たさない返却を受領しない。
+
+## 関連ドキュメント
+
+- `.claude/claudeos/system/role-contracts.md` — 唯一の役割契約 (優先)
+- `.claude/claudeos/system/loop-guard.md` — 停止条件と拡張 state スキーマ
+- `CLAUDE.md` — プロジェクト運用規約

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,9 +1,21 @@
 # TASKS
 
+## ⚠️ 唯一の作業キュー宣言
+
+**このファイルは ClaudeOS における唯一の作業キュー (single truth source for work queue) です。**
+
+- 他の場所 (README, Issue コメント, state.json 等) に並行キューを作らないこと
+- Orchestrator は毎ループ冒頭でこのファイルの先頭タスクを参照すること
+- 状態遷移は最小限に固定: `pending → in_progress → DONE` (または `Blocked`)
+- 自動生成タスクは必ず triage (根拠ファイル + 再現条件を添付) を通してからこのキューに入れること
+- 自動生成の一回あたり上限は **3 件**
+
+## セクション構成
+
 このファイルは `手動管理セクション` と `自動抽出セクション` に分かれます。
 
 - 手動管理: 人が直接追加・編集する backlog
-- 自動抽出: `docs/common/08_AgentTeams対応表.md` の `未実装機能` から `Sync-AgentTeamsBacklog.ps1` が同期する項目
+- 自動抽出: `docs/common/08_AgentTeams対応表.md` の `未実装機能` から `Sync-AgentTeamsBacklog.ps1` が同期する項目 (**Auto Extracted セクションは手動変更禁止**)
 
 ## Manual Backlog
 

--- a/docs/common/schemas/state.schema.json
+++ b/docs/common/schemas/state.schema.json
@@ -24,7 +24,14 @@
         "phase": { "type": "string", "enum": ["Monitor", "Development", "Verify", "Improvement", "Debug", "Release", "STABLE"] },
         "loop_number": { "type": "integer", "minimum": 1 },
         "auto_stop_threshold": { "type": "integer", "minimum": 1 },
-        "graceful_shutdown": { "type": "boolean" }
+        "graceful_shutdown": { "type": "boolean" },
+        "mode": { "type": "string", "enum": ["light", "full"], "description": "role-contracts.md §1 の運用モード (既定 light)" },
+        "retry_count_by_cause": { "type": "object", "description": "Loop Guard: 原因別リトライ回数" },
+        "no_progress_streak": { "type": "integer", "minimum": 0, "description": "Loop Guard: 連続進展なし回数 (閾値 2 で停止)" },
+        "same_diff_streak": { "type": "integer", "minimum": 0, "description": "Loop Guard: 同一差分再生成回数 (閾値 2 で停止)" },
+        "last_stop_reason": { "type": "string", "description": "Loop Guard: 直近の停止理由 (handoff レポート生成に使用)" },
+        "pending": { "type": "array", "items": { "type": "object" }, "description": "Build Loop が記録する未完了項目。Loop Guard が handoff レポート合成時に読む" },
+        "pending_verify": { "type": "array", "items": { "type": "object" }, "description": "Verify Loop が記録する未判定項目。Loop Guard が handoff レポート合成時に読む" }
       }
     },
     "token": {


### PR DESCRIPTION
## Summary (β アプローチ, 3 コミット構成)

Anthropic multi-agent coordination 原則に基づき、ClaudeOS を **Orchestrator-Subagent 既定 + 契約駆動** に refactor する。初回 PR は 7 コミットで Codex review の High×2 + Medium×2 に叩かれ、修正後も P1×2 + P2×1 の新指摘が出たため、**β 戦略 (最小構成への squash)** に切り替えた。

### β で除去した「詰めすぎ部分」

- `verify-loop.md` Full モード追加チェックの差分サイズゲーティング → 削除 (full は常にフル検証)
- `loop-guard.md` no-progress の OR 判定 → AND + 数量的改善ロジックに変更 (test 失敗 20 → 1 のような健全な反復を誤停止しない)
- `token-budget.md` の `.loop-handoff-report.md` 直接書き込み指示 → `state.json.execution.pending` 経由に変更 (Loop Guard 単独 writer 契約と整合)

## Commits

| # | sha | scope | summary |
|---|---|---|---|
| 1 | a067590 | `system/` | `role-contracts.md` 新規 (唯一の役割契約ソース) |
| 2 | efcfd7a | `system/` + `loops/` | 既存ファイルを role-contracts と整合 (重複排除、size gating 除去、no-progress AND 化、single writer 契約) |
| 3 | 903b645 | `AGENTS.md` + `TASKS.md` | Codex 使い分け表と単一キュー宣言 |

## 対応したベストプラクティス項目

- #1-5 Orchestrator-Subagent 既定、I/O/完了/禁止、返却 4 セクション固定
- #6-7 TASKS.md 単一キュー、Truth Source 明文化
- #8-11 state.json 拡張、no-progress 停止条件、CI failure category clustering
- #16-17 light / full 二段構え
- #20-22 論理単位 commit、担当ファイル境界、共有ファイル単独 writer
- #26-27 レポート役割分離 (observation / judgment / handoff)
- #28-30 参照許可ファイル群、コンテキスト予算、タスク単位 Token 監視
- #32 Verify の変更理由整合性チェック
- #37 same-diff regeneration 検知
- #43-44 Codex コマンド使い分け表、Resume Protocol
- #50 最も単純に動く形から始める (第一原則)

## 意図的に次段階へ見送り

- #18-19 daily focus 推奨化 (CLAUDE.md 全面改訂が必要)
- #41-42 message bus 段階導入 (原則 #50 に従い、詰まってから追加)
- #48-49 理念/運用ドキュメント分離 (CLAUDE.md 全面改訂が必要)

## Test plan

- [ ] CI が全て green
- [ ] Codex 再 review (β 版) で severity high / P1 指摘なし
- [ ] `role-contracts.md` の Truth Source 一覧と実ファイル配置が整合
- [ ] light/full モード判定が role-contracts §1 のみに存在 (orchestrator.md に重複なし)
- [ ] `.loop-handoff-report.md` の writer が Loop Guard のみ (loop-guard/build-loop/verify-loop/token-budget 整合)
- [ ] 返却 4 セクションの順序が全ファイルで `Summary → Risks → Findings → Next Action` で一致

## 補足

未ステージの `.claude/claudeos/agents/orchestrator.md` と `.claude/claudeos/worktree/branch-policy.md` は LF→CRLF の EOL のみの pre-existing noise で本 refactor と無関係のため、意図的に含めていません。

同期スクリプト (`.claude/claudeos/scripts/sync-role-contracts.ps1`) は本 PR の後、別 PR で追加予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)