### PR TITLE
chore: gitleaks workflow + Agent Teams Light mode (eval report quick wins)

### DIFF
--- a/.claude/claudeos/system/agent-teams-light-mode.md
+++ b/.claude/claudeos/system/agent-teams-light-mode.md
@@ -1,0 +1,102 @@
+# Agent Teams — Light Mode (reference, non-normative)
+
+> **位置づけ**: 本書は ClaudeOS v7.4 / v8.0-β の Agent Teams 定義に対する **リファレンス** である。既存の運用規約を強制的に上書きしない。小規模タスク向けに「軽量召集」の選択肢を明示することが目的。
+>
+> **矛盾時の優先**: 本書と CLAUDE.md / v8-delta.md が矛盾した場合は **本書を無視** する。
+
+## なぜ Light モードが必要か
+
+v7.4 / v8.0-β の Agent Teams は 12 役割フルセット (CTO / ProductManager / Architect / Developer / Reviewer / Debugger / QA / Security / DevOps / Analyst / EvolutionManager / ReleaseManager) を想定する。以下の場面では全員召集はトークン浪費になる:
+
+- 1 ファイルの軽微なバグ修正
+- lint / format の自動修正
+- ドキュメントのタイプミス修正
+- README の小改訂
+- 依存関係の単純なバージョン更新
+
+こうした小規模タスクにはコアの 3 役割だけで十分なケースが多い。
+
+## Light モード定義
+
+### 構成
+
+```
+[CTO] → [Developer] → [QA]
+```
+
+| 役割 | 最低限の責務 |
+|---|---|
+| 🧠 CTO | 実行可否の判断、スコープ外に流れ出さない制御 |
+| 👨‍💻 Developer | 実装、最小差分の適用 |
+| 🧪 QA | test/lint/build のローカル検証、STABLE 判定（N=2） |
+
+**Reviewer / Security / Architect / Debugger は呼ばない**。必要になったら Full モードへ昇格する。
+
+### 適用判定フロー
+
+```
+タスク受領
+  │
+  ▼
+ 変更ファイル数 ≤ 2 ?
+  │  yes → 変更行数 ≤ 50 ?
+  │         │  yes → セキュリティ/認証/DB 変更を含まない ?
+  │         │         │  yes → Light モードで進める
+  │         │         │  no  → Full へ昇格 (Security 必須)
+  │         │  no  → Full へ昇格
+  │  no  → Full へ昇格
+```
+
+### Light → Full 昇格条件
+
+以下のいずれかに該当した時点で即 Full モードへ切替える:
+
+1. Codex review で severity: medium 以上の指摘が出た
+2. CI が失敗し、原因が 1 ファイルで閉じない
+3. セキュリティ / 認証 / 権限 / DB スキーマに触れる変更が発生した
+4. テスト失敗の原因切り分けに 3 回以上の rescue が必要と判断した
+5. スコープが拡張し、変更ファイル数 ≥ 3 または変更行数 ≥ 50 になった
+6. 複数 Issue に影響する変更であることが判明した
+
+## STABLE 判定の調整
+
+Light モードでは STABLE 連続成功回数を **N=2** に緩和する (v7.4 §9 の「小規模」定義と同じ)。
+
+| 項目 | Light | Full (通常) | Full (重要) |
+|---|---|---|---|
+| 連続成功回数 | N=2 | N=3 | N=5 |
+| Codex review | 省略可 | 必須 | 必須 |
+| adversarial-review | 省略 | 条件付き | 必須 |
+
+## Agent Teams 使用禁止場面 (再掲)
+
+以下は Light モードですら召集しない。**SubAgent 単独で処理する**:
+
+- Lint 修正のみ
+- フォーマット修正のみ
+- ドキュメントのタイプミス修正のみ
+- 明らかな一行バグ修正
+
+## トークン節約効果の目安
+
+| モード | 召集役割数 | 1 タスクあたりの概算トークン |
+|---|---|---|
+| SubAgent 単独 | 1 | 低 |
+| **Light** | 3 | 中 (Full の約 1/4) |
+| Full (通常) | 6〜8 | 高 |
+| Full (重要) | 12 | 最高 |
+
+Light モードは「ほぼ毎回 Full を召集している」状況に対する節約案として提案する。実測値ではなく設計意図上の目安。
+
+## 本書の採用条件
+
+- 本書は **リファレンス** である。既存の運用規約と共存し、強制しない
+- プロジェクトごとに採用する/しないを決められる
+- 採用する場合は `CLAUDE.md` の Agent Teams セクションから本書を参照する
+- 採用しない場合は本書の存在を無視してよい
+
+## 関連ドキュメント
+
+- `CLAUDE.md` §6 Agent Teams — 本書の上位規約
+- `.claude/claudeos/system/role-contracts.md` — 役割の I/O プロトコル
+- `.claude/claudeos/system/v8-delta.md` — §5 Event 専用 Agent 起動チェーン

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,30 @@
+name: Security Scan
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  schedule:
+    - cron: '23 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secrets-scan:
+    name: Secrets scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true


### PR DESCRIPTION
## Summary

2026-04-11 セッションで受領した外部評価レポートへの対応として、**検証可能で低リスク**な 2 ファイルを追加します。既存ファイルは一切変更せず、純粋な追加差分のみ。

### 追加ファイル

| ファイル | 行数 | 対応評価項目 |
|---|---|---|
| `.github/workflows/security-scan.yml` | 30 | #9 セキュリティスキャン具体化 |
| `.claude/claudeos/system/agent-teams-light-mode.md` | 102 | #7 Agent Teams Light モード定義 |

### 1. security-scan.yml (gitleaks)

- gitleaks 公式 Action v2 を使用した secrets スキャン
- トリガー: push to main/master / PR / 週次 (月曜 06:23 UTC) / 手動実行
- `ubuntu-latest` で実行 (既存 `ci.yml` は windows-latest で独立維持)
- `continue-on-error: true` で非ブロッキング (段階導入・警告のみ)
- `fetch-depth: 0` で履歴全体をスキャン対象に含める

### 2. agent-teams-light-mode.md

ClaudeOS v7.4 / v8.0-β の Agent Teams 12 役割フルセットに対する **軽量召集** の参照実装。

- 構成: `[CTO] → [Developer] → [QA]` の 3 役割のみ
- 適用判定フロー: 変更ファイル数 ≤ 2 かつ変更行数 ≤ 50 かつ セキュリティ関連なし
- Light → Full 昇格条件 6 項目を明示
- **non-normative reference**: 既存規約を強制的に上書きしない位置付け
- 矛盾時は CLAUDE.md / v8-delta.md 優先

## 対応しなかった項目 (評価レポートの主張別)

### ❌ False positive (既対応 or 誤認)

- #3 testResults.xml を .gitignore: **既に `.gitignore:111` に登録済み、git 追跡なし**
- #4 state.json schema 検証を CI に: **既に `ci.yml:123-131` で実装済み**
- CLAUDE.md 18KB 過大表記: 実測 13.3 KB / 465 行

### ⛔ 実在未確認の 2026年機能 (盲目的実装を回避)

- `/batch` スキル / Cloud Scheduled Tasks / Managed Agents / Focus View
- Voice Mode / Mobile Remote Control / WorktreeCreate hook / `type: agent` hook

### ⚠️ リスク大で保留

- CLAUDE.md モジュール分割 (#1): 未コミット作業中の競合リスク
- v8-delta.md 本文統合 (#10): 「共存」設計方針に反する
- cross-platform start.sh: 作業規模大、二重管理リスク

## Test plan

- [ ] security-scan.yml のシンタックスが GitHub Actions で valid
- [ ] PR 作成時に security-scan.yml が新 PR 上で実行される
- [ ] gitleaks が想定通り secrets を検出しない（現リポジトリは既に対応済）
- [ ] agent-teams-light-mode.md が既存 markdownlint で警告を出さない
- [ ] 既存 ci.yml / issue-sync.yml が影響を受けないことを確認

## 影響範囲

- **既存ファイル変更: なし** (純粋な追加のみ)
- **既存 CI への影響: なし** (security-scan は独立 workflow)
- **ドキュメント間依存: なし** (Light mode は non-normative reference)

## 残課題

評価レポートで実在確認が取れた以下の項目は本 PR の範囲外:

- #8 .mcp.json の条件付きサーバー拡張 (要: 環境変数フラグ設計)
- #11 ドキュメント重複検出 lint ルール (要: markdownlint 拡張またはカスタムスクリプト)
- #12 Pester カバレッジレポート (要: PowerShell coverage tool 選定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)