### PR TITLE
chore: フェーズ別モデル制御設定を追加 (Development=opusplan, 他=sonnet)

### DIFF
--- a/.claude/claudeos/CLAUDE.md
+++ b/.claude/claudeos/CLAUDE.md
@@ -3,6 +3,17 @@
 /loop 1h  everything-claude-code Verify
 /loop 1h  everything-claude-code Improvement
 
+## フェーズ別モデル制御（Max 20x 最適化）
+
+各フェーズ開始時に以下のモデルを設定してください：
+
+| フェーズ | モデル指示 |
+|---|---|
+| Monitor | `/model sonnet` を実行してから開始 |
+| **Development** | **`/model opusplan` を実行してから開始** |
+| Verify | `/model sonnet` を実行してから開始 |
+| Improvement | `/model sonnet` を実行してから開始 |
+
 以降、日本語で対応・解説してください。
 
 5時間の時間内で Monitor、Development、Verify、Improvement をアイドル状態なしで N 回ループで進めてください。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,21 +15,32 @@
 このファイルを読んだ時点で、以下を即座に実行してください。
 ユーザーの最初のメッセージ内容に関わらず、このセクションを最優先で処理します。
 
-### ステップ 1: モデル設定 + ループコマンド登録
+### ステップ 1: ループコマンド登録
 
-最初にモデルを設定し、続けて 4 コマンドをこの順番で登録してください。
+以下の 4 コマンドをこの順番で登録してください。
 
 ```
-/model opusplan
 /loop 30m ClaudeOS Monitor
 /loop 2h ClaudeOS Development
-/loop 90m ClaudeOS Verify
-/loop 90m ClaudeOS Improvement
+/loop 1h ClaudeOS Verify
+/loop 1h ClaudeOS Improvement
 ```
 
-モデル設定 + 4 本すべての登録が完了するまで、通常の開発作業は開始しないでください。
+4 本すべての登録が完了するまで、通常の開発作業は開始しないでください。
 
-> **モデルポリシー**: `opusplan` モードにより、Plan フェーズは Opus 4.6、実装・ツール実行は Sonnet 4.6 を使用。週次 Opus 制限の節約と高品質な設計判断を両立する。
+### ステップ 1.5: フェーズ別モデル制御（Max 20x 最適化）
+
+各フェーズ開始時に以下のモデルを設定してください：
+
+| フェーズ | モデル | 理由 |
+|---|---|---|
+| Monitor | `/model sonnet` | 状態確認・軽量判断はSonnetで十分 |
+| **Development** | **`/model opusplan`** | **設計・アーキテクチャ判断にOpusを使用** |
+| Verify | `/model sonnet` | CI確認・テスト検証はSonnetで十分 |
+| Improvement | `/model sonnet` | リファクタリング実行はSonnetで十分 |
+
+> **モデルポリシー**: Development フェーズのみ opusplan（Plan=Opus 4.6、実行=Sonnet 4.6）。  
+> Max (20x) 週次 Opus 制限を Development 設計判断に集中投入する。
 
 ### ステップ 2: Codex セットアップ
 


### PR DESCRIPTION
## 変更内容

Max (20x) プランの週次 Opus 使用量を最適化するため、フェーズ別モデル制御ポリシーを設定ファイルに追加。

### フェーズ別モデル設定

| フェーズ | モデル | 理由 |
|---|---|---|
| Monitor | `/model sonnet` | 状態確認・軽量判断はSonnetで十分 |
| **Development** | **`/model opusplan`** | **設計・アーキテクチャ判断にOpusを使用** |
| Verify | `/model sonnet` | CI確認・テスト検証はSonnetで十分 |
| Improvement | `/model sonnet` | リファクタリング実行はSonnetで十分 |

### 変更ファイル

- `CLAUDE.md` — ステップ 1.5「フェーズ別モデル制御」セクションを追加
- `.claude/claudeos/CLAUDE.md` — フェーズ別モデル制御テーブルを追加

## テスト結果

設定ファイルの変更のみ（コード変更なし）

## 影響範囲

セッション開始時のモデル選択ポリシーに影響。実装・CI には影響なし。

## 残課題

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * フェーズ別モデル制御の運用ルールを文書化。開発フェーズでは専用モデル、その他フェーズでは別モデルを使用する手順を明確化。
  * 初期化プロセスを簡潔化し、各フェーズ開始時のモデル切り替え手順を追加。
  * 検証・改善ループの実行時間を調整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->