### PR TITLE
feat(boot): Issue #68 PR-B — Step 7 Agent Init を AgentTeams.psm1 でワイヤリング

### DIFF
--- a/scripts/main/Start-ClaudeOS.ps1
+++ b/scripts/main/Start-ClaudeOS.ps1
@@ -38,6 +38,7 @@ $ErrorActionPreference = 'Stop'
 $ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\LauncherCommon.psm1') -Force -DisableNameChecking
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\Config.psm1') -Force
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\AgentTeams.psm1') -Force
 
 function Write-BootStep {
     param(
@@ -139,6 +140,32 @@ function Invoke-StepPlaceholder {
     return @{ Step = $Number; Name = $Name; Status = 'SKIP'; Detail = $Reason }
 }
 
+function Invoke-StepAgentInit {
+    param([string]$Root)
+    Write-BootStep 7 'Agent Init'
+    try {
+        $report = Get-AgentTeamReport -ProjectRoot $Root
+        if ($report.agentsDirExists) {
+            Write-Host ('  [OK] Agent definitions: {0} agents loaded' -f $report.agentCount) -ForegroundColor Green
+            Write-Host ('       Path: {0}' -f $report.agentsDir) -ForegroundColor DarkGray
+        }
+        else {
+            Write-Host ('  [WARN] Agent definitions directory not found: {0}' -f $report.agentsDir) -ForegroundColor Yellow
+        }
+        $rulesLabel = if ($report.rulesExist) { '[OK] found' } else { '[WARN] not found' }
+        $rulesColor = if ($report.rulesExist) { 'Green' } else { 'Yellow' }
+        Write-Host ('  Backlog rules : {0}' -f $rulesLabel) -ForegroundColor $rulesColor
+        Write-Host ''
+        $stepStatus = if ($report.agentsDirExists) { 'OK' } else { 'SKIP' }
+        return @{ Step = 7; Name = 'Agent Init'; Status = $stepStatus; Detail = $report }
+    }
+    catch {
+        Write-Host ('  [FAIL] Agent Init failed: {0}' -f $_.Exception.Message) -ForegroundColor Red
+        Write-Host ''
+        return @{ Step = 7; Name = 'Agent Init'; Status = 'FAIL'; Detail = $_.Exception.Message }
+    }
+}
+
 function Write-BootDashboard {
     param([array]$Results)
     Write-BootStep 9 'Dashboard'
@@ -170,8 +197,7 @@ $results += Invoke-StepPlaceholder -Number 5 -Name 'Executive Init' `
     -Reason 'Runtime CTO / Strategy Engine is a conceptual layer (Claude itself)'
 $results += Invoke-StepPlaceholder -Number 6 -Name 'Management Init' `
     -Reason 'Backlog / Scrum Master integration pending'
-$results += Invoke-StepPlaceholder -Number 7 -Name 'Agent Init' `
-    -Reason 'AgentTeams runtime wiring pending (PR-B)'
+$results += Invoke-StepAgentInit -Root $ScriptRoot
 $results += Invoke-StepPlaceholder -Number 8 -Name 'Loop Engine Start' `
     -Reason 'Loop orchestration handled by Claude Code /loop harness'
 

--- a/tests/StartScripts.Tests.ps1
+++ b/tests/StartScripts.Tests.ps1
@@ -191,15 +191,22 @@ Describe 'Start-*.ps1 dry-run flows' {
         $output | Should -Match '\[DRY RUN\] No side effects will be applied'
     }
 
-    It 'Start-ClaudeOS.ps1 の Step 3/5/6/7/8 がプレースホルダー SKIP になること' {
+    It 'Start-ClaudeOS.ps1 の Step 3/5/6/8 がプレースホルダー SKIP になること' {
         $scriptPath = Join-Path $script:RepoRoot 'scripts\main\Start-ClaudeOS.ps1'
         $output = & $script:PowerShellExe -NoProfile -File $scriptPath -NonInteractive 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $output | Should -Match '\[Step 3\].*Memory Restore.*SKIP'
         $output | Should -Match '\[Step 5\].*Executive Init.*SKIP'
         $output | Should -Match '\[Step 6\].*Management Init.*SKIP'
-        $output | Should -Match '\[Step 7\].*Agent Init.*SKIP'
         $output | Should -Match '\[Step 8\].*Loop Engine Start.*SKIP'
+    }
+
+    It 'Start-ClaudeOS.ps1 の Step 7 が Agent Init として実行されること (PR-B)' {
+        $scriptPath = Join-Path $script:RepoRoot 'scripts\main\Start-ClaudeOS.ps1'
+        $output = & $script:PowerShellExe -NoProfile -File $scriptPath -NonInteractive 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $output | Should -Match '\[Step 7\].*Agent Init'
+        $output | Should -Not -Match '\[Step 7\].*Agent Init.*SKIP'
     }
 }
 


### PR DESCRIPTION
## 変更内容

Issue #68 (Phase 3: Boot Sequence 完全自動化) の PR-B iteration。
Boot Sequence Step 7 (Agent Init) をプレースホルダーから実際の `AgentTeams.psm1` ワイヤリングに移行。

## 変更詳細

### `scripts/main/Start-ClaudeOS.ps1`

- `AgentTeams.psm1` を Import
- `Invoke-StepAgentInit` 関数を新規追加
  - `Get-AgentTeamReport -ProjectRoot $Root` でエージェント定義を読み込む
  - エージェント定義ディレクトリ存在確認・ロード数を表示
  - バックログルールの状態を表示
  - エージェント定義あり → `OK`、なし → `SKIP`、エラー → `FAIL`
- Step 7 の `Invoke-StepPlaceholder` 呼び出しを `Invoke-StepAgentInit` に置き換え

### `tests/StartScripts.Tests.ps1`

- Step 7 が SKIP になることを期待するテストを更新 (Step 3/5/6/8 のみ SKIP)
- Step 7 が Agent Init として実行されることを確認する新規テストを追加

## 動作確認

```
[Step 7] Agent Init                   [RUN]
  [OK] Agent definitions: 37 agents loaded
       Path: ...\.claude\claudeos\agents
  Backlog rules : [OK] found
```

## テスト結果

ローカル Pester: Windows AV ブロックのため CI 検証  
手動実行: ✅ Step 7 OK 確認済み

## 影響範囲

- `Start-ClaudeOS.ps1` の起動フロー (Step 7 のみ)
- 既存の他 Steps・ランチャーへの影響なし

## 関連

- Closes #68 (PR-B iteration)
- 親 Issue: #34 (v3.0.0 リリース計画)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブートプロセスにエージェントチーム初期化ステップを追加
  * エージェント設定の存在に基づいて条件付きで実行

* **改善**
  * スタートアップ検証フローがより包括的に

<!-- end of auto-generated comment: release notes by coderabbit.ai -->