### PR TITLE
feat(boot): Issue #70 — Step 3 Memory Restore を McpHealthCheck.psm1 でワイヤリング

### DIFF
--- a/scripts/main/Start-ClaudeOS.ps1
+++ b/scripts/main/Start-ClaudeOS.ps1
@@ -39,6 +39,7 @@ $ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\LauncherCommon.psm1') -Force -DisableNameChecking
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\Config.psm1') -Force
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\AgentTeams.psm1') -Force
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\McpHealthCheck.psm1') -Force
 
 function Write-BootStep {
     param(
@@ -132,6 +133,60 @@ function Invoke-StepSystemInit {
     }
 }
 
+function Invoke-StepMemoryRestore {
+    param([string]$Root)
+    Write-BootStep 3 'Memory Restore'
+    try {
+        $report = Get-McpHealthReport -ProjectRoot $Root
+        if (-not $report.configured) {
+            Write-Host '  [SKIP] .mcp.json not found' -ForegroundColor DarkGray
+            Write-Host ''
+            return @{ Step = 3; Name = 'Memory Restore'; Status = 'SKIP'; Detail = 'no mcp config' }
+        }
+
+        $memoryConn = @($report.connections | Where-Object { $_.kind -eq 'memory' }) | Select-Object -First 1
+        if (-not $memoryConn) {
+            Write-Host '  [SKIP] memory server not configured in .mcp.json' -ForegroundColor DarkGray
+            Write-Host ''
+            return @{ Step = 3; Name = 'Memory Restore'; Status = 'SKIP'; Detail = 'no memory server' }
+        }
+
+        $filePath = $env:CLAUDE_MEMORY_FILE_PATH
+        $entryCount = 0
+        if ($filePath -and (Test-Path $filePath)) {
+            try {
+                $data = Get-Content $filePath -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
+                $entryCount = if ($data.entities) { @($data.entities).Count } else { 0 }
+            }
+            catch { $entryCount = 0 }
+        }
+
+        $fileLabel = if ($filePath -and (Test-Path $filePath)) {
+            'found ({0} entries)' -f $entryCount
+        }
+        elseif ($filePath) {
+            'configured (file not yet created)'
+        }
+        else {
+            'CLAUDE_MEMORY_FILE_PATH not set'
+        }
+        Write-Host ('  [OK] Memory MCP : configured' ) -ForegroundColor Green
+        Write-Host ('  Memory file      : {0}' -f $fileLabel) -ForegroundColor Cyan
+        Write-Host ''
+        return @{
+            Step   = 3
+            Name   = 'Memory Restore'
+            Status = 'OK'
+            Detail = @{ entryCount = $entryCount; filePath = $filePath; configured = $true }
+        }
+    }
+    catch {
+        Write-Host ('  [FAIL] Memory Restore: {0}' -f $_.Exception.Message) -ForegroundColor Red
+        Write-Host ''
+        return @{ Step = 3; Name = 'Memory Restore'; Status = 'FAIL'; Detail = $_.Exception.Message }
+    }
+}
+
 function Invoke-StepPlaceholder {
     param([int]$Number, [string]$Name, [string]$Reason)
     Write-BootStep $Number $Name 'SKIP'
@@ -190,8 +245,7 @@ Write-BootBanner
 $results = @()
 $results += Invoke-StepEnvironmentCheck
 $results += Invoke-StepProjectDetection -Root $ScriptRoot
-$results += Invoke-StepPlaceholder -Number 3 -Name 'Memory Restore' `
-    -Reason 'Memory MCP persistence not yet integrated'
+$results += Invoke-StepMemoryRestore -Root $ScriptRoot
 $results += Invoke-StepSystemInit
 $results += Invoke-StepPlaceholder -Number 5 -Name 'Executive Init' `
     -Reason 'Runtime CTO / Strategy Engine is a conceptual layer (Claude itself)'

--- a/tests/StartScripts.Tests.ps1
+++ b/tests/StartScripts.Tests.ps1
@@ -191,14 +191,21 @@ Describe 'Start-*.ps1 dry-run flows' {
         $output | Should -Match '\[DRY RUN\] No side effects will be applied'
     }
 
-    It 'Start-ClaudeOS.ps1 の Step 3/5/6/8 がプレースホルダー SKIP になること' {
+    It 'Start-ClaudeOS.ps1 の Step 5/6/8 がプレースホルダー SKIP になること' {
         $scriptPath = Join-Path $script:RepoRoot 'scripts\main\Start-ClaudeOS.ps1'
         $output = & $script:PowerShellExe -NoProfile -File $scriptPath -NonInteractive 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
-        $output | Should -Match '\[Step 3\].*Memory Restore.*SKIP'
         $output | Should -Match '\[Step 5\].*Executive Init.*SKIP'
         $output | Should -Match '\[Step 6\].*Management Init.*SKIP'
         $output | Should -Match '\[Step 8\].*Loop Engine Start.*SKIP'
+    }
+
+    It 'Start-ClaudeOS.ps1 の Step 3 が Memory Restore として実行されること (Issue #70)' {
+        $scriptPath = Join-Path $script:RepoRoot 'scripts\main\Start-ClaudeOS.ps1'
+        $output = & $script:PowerShellExe -NoProfile -File $scriptPath -NonInteractive 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $output | Should -Match '\[Step 3\].*Memory Restore'
+        $output | Should -Not -Match '\[Step 3\].*Memory Restore.*SKIP'
     }
 
     It 'Start-ClaudeOS.ps1 の Step 7 が Agent Init として実行されること (PR-B)' {


### PR DESCRIPTION
## Summary

- `Start-ClaudeOS.ps1` に `McpHealthCheck.psm1` を追加インポート
- `Invoke-StepMemoryRestore` 関数を新規実装 (Step 3)
  - `.mcp.json` 未設定 → `SKIP`
  - `memory` kind サーバー未設定 → `SKIP`
  - 設定あり → `OK`（エントリ数・ファイルパスをレポート）
  - 例外発生 → `FAIL`
- Step 3 プレースホルダー (`Invoke-StepPlaceholder`) を `Invoke-StepMemoryRestore` に置換
- `StartScripts.Tests.ps1`: Step 3 を SKIP リストから除外し、Memory Restore 専用テストを追加

## Test plan

- [ ] `StartScripts.Tests.ps1` — `Step 3 が Memory Restore として実行されること` が PASS
- [ ] `StartScripts.Tests.ps1` — `Step 5/6/8 がプレースホルダー SKIP` が PASS
- [ ] `.mcp.json` あり / `memory` サーバー設定あり → Step 3 = OK
- [ ] `.mcp.json` なし / `memory` サーバーなし → Step 3 = SKIP
- [ ] CI (Linux Pester) 全テスト PASS

## 影響範囲

- `scripts/main/Start-ClaudeOS.ps1` — Step 3 ロジック変更
- `tests/StartScripts.Tests.ps1` — テスト更新

## 残課題

- `CLAUDE_MEMORY_FILE_PATH` 環境変数が未設定の場合は「configured (file not yet created)」表示（正常動作）

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メモリ復元ステップが実装されました。システムはメモリファイルの存在を確認し、保存されたエンティティを読み込むようになりました。
  * ヘルスチェック機能が統合され、システムが正しく構成されているかを検証するようになりました。

* **テスト**
  * メモリ復元機能の動作確認テストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->