### PR TITLE
chore: .gitignore に claude-mem 自動生成 CLAUDE.md を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,12 @@ Sample/
 
 # バックアッププロンプト
 Claude/templates/claude/START_PROMPT-backup*.md
+
+# claude-mem MCP が自動生成するコンテキストファイル（コミット不要・各ディレクトリに散在）
+# NOTE: CLAUDE.md at repo root and Claude/templates/ are intentional — only sub-directory auto-generated ones
+.github/issues/CLAUDE.md
+.github/workflows/CLAUDE.md
+.claude/claudeos/system/CLAUDE.md
+scripts/lib/CLAUDE.md
+scripts/main/CLAUDE.md
+tests/CLAUDE.md


### PR DESCRIPTION
## Summary

- `claude-mem` MCP が各サブディレクトリに自動生成する `CLAUDE.md` ファイルを `.gitignore` に追加
- 対象: `.github/issues/`, `.github/workflows/`, `.claude/claudeos/system/`, `scripts/lib/`, `scripts/main/`, `tests/`
- repo root の `CLAUDE.md` と `Claude/templates/` は意図的なもののため**除外しない**

## Problem

`claude-mem` MCP はセッション開始時にメモリコンテキストとして各ディレクトリへ `CLAUDE.md` を自動生成する。
これらがコミットされると:
- `tests/CLAUDE.md` → テストディレクトリの汚染
- `.github/workflows/CLAUDE.md` → CI/CDワークフロー管理領域への混入（セキュリティリスク）
- `.github/issues/CLAUDE.md` → Issue テンプレートへの混入

## Test plan

- [ ] `.gitignore` に追加後、対象 `CLAUDE.md` ファイルが `git status` で追跡されないことを確認
- [ ] repo root の `CLAUDE.md` は引き続き追跡されることを確認
- [ ] CI (lint/build) 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他（Chores）**
  * 開発環境の設定ファイルを更新し、自動生成されるファイルの除外ルールを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->