### PR TITLE
fix(issue-sync): branch protection 対策 — TASKS.md 更新を PR 自動作成方式へ変更

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync-issues-to-tasks:
@@ -32,18 +33,40 @@ jobs:
         run: |
           .\scripts\tools\Sync-Issues.ps1 -Action check
 
-      - name: Commit and push if changed
+      - name: Commit and open PR if changed
         shell: pwsh
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           $status = git status --porcelain TASKS.md
-          if ($status) {
-            git add TASKS.md
-            git commit -m "chore: auto-sync GitHub Issues to TASKS.md [skip ci]"
-            git push
-            Write-Host "TASKS.md updated and pushed." -ForegroundColor Green
-          }
-          else {
+          if (-not $status) {
             Write-Host "TASKS.md is already up to date." -ForegroundColor Green
+            exit 0
           }
+
+          # Create a unique branch for this sync update
+          $sha = (git rev-parse --short HEAD)
+          $branch = "auto/tasks-sync-$sha"
+
+          # Skip if a PR branch for this commit already exists
+          $existing = gh pr list --head $branch --state open --json number | ConvertFrom-Json
+          if ($existing.Count -gt 0) {
+            Write-Host "PR already exists for branch $branch, skipping." -ForegroundColor Yellow
+            exit 0
+          }
+
+          git checkout -b $branch
+          git add TASKS.md
+          git commit -m "chore: auto-sync GitHub Issues to TASKS.md [skip ci]"
+          git push origin $branch
+
+          gh pr create `
+            --title "chore: auto-sync GitHub Issues to TASKS.md" `
+            --body "Automated TASKS.md sync triggered by issue event. Merges automatically after CI passes." `
+            --base main `
+            --head $branch
+
+          # Enable auto-merge so the PR merges once branch protection is satisfied
+          gh pr merge --auto --squash $branch
+
+          Write-Host "TASKS.md sync PR created and auto-merge enabled." -ForegroundColor Green


### PR DESCRIPTION
## Summary

- Issue Sync ワークフローが `main` へ直接 `git push` → branch protection で拒否される問題を修正
- TASKS.md に変更がある場合、`auto/tasks-sync-<sha>` ブランチを作成して PR を開き `--auto` マージを有効化する方式へ変更
- 冪等性のため既存 PR チェックを実装（同一コミットで複数回イベントが発火しても二重 PR を作らない）

## Changes

- `permissions`: `pull-requests: write` を追加
- "Commit and push if changed" → "Commit and open PR if changed" にリネーム
- `git push` → `git push origin $branch` + `gh pr create` + `gh pr merge --auto --squash`

## Test plan

- [ ] CI (test-and-validate) 通過確認
- [ ] Security Scan 通過確認
- [ ] マージ後に Issue イベント発火 → Issue Sync ワークフローが success になることを確認

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
  * タスク同期ワークフローが改善されました。変更内容は自動的にプルリクエストとして処理されるようになり、既存のプルリクエスト重複を防止するロジックが追加されました。条件を満たした場合、プルリクエストは自動的にマージされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->