### PR TITLE
fix(issue-sync): issues イベント自動トリガーを無効化（PR作成権限制限対応）

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -1,8 +1,8 @@
 name: Issue Sync
 
 on:
-  issues:
-    types: [opened, closed, reopened, edited, labeled, unlabeled, assigned, unassigned, deleted]
+  # Auto-trigger on issue events disabled: GitHub Actions cannot create or approve PRs in this repo.
+  # Issues are tracked directly in GitHub Issues. Run manually via workflow_dispatch only if needed.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Issue Sync ワークフローが `issues` イベントで毎回起動し、`gh pr create` が失敗し続けていた
- 根本原因: リポジトリの Actions 設定で「GitHub Actions による PR 作成/承認」が無効
- 解決策: `issues` トリガーを削除し `workflow_dispatch`（手動）のみに変更

## Why not enable Actions PR creation?

リポジトリ設定変更はコード変更では対応不可。また TASKS.md の内容は  
GitHub Issues の情報と完全に重複しており、Issues が主管理ツールとして確立済み。  
自動 CI ノイズを排除し、必要時のみ手動実行する方式が最適と判断。

## Impact

- `issue` イベント発火時の `Issue Sync` ワークフロー: 不実行（ノイズ排除）
- TASKS.md 手動更新: `workflow_dispatch` で引き続き可能

## Test plan

- [ ] CI 通過確認
- [ ] マージ後に Issue イベントが発火しても Issue Sync が **実行されない**ことを確認

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **メンテナンス**
  * GitHub ワークフロー トリガーを修正しました。GitHub の issue イベント（作成、クローズ、再度開くなど）による自動実行を削除し、手動トリガー機能のみに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->