### PR TITLE
docs(changelog): v2.9.0 STABLE 化 + v3.0.0 Phase 4 計画追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,71 @@
 
 # CHANGELOG
 
-## [v2.9.0-dev] - 2026-04-08
+## [v3.0.0] - Unreleased (Phase 4: v3.0.0 GA Release 準備中)
+
+### 🎯 コードネーム: Autonomous Runtime
+
+### Phase 4 残タスク (GA リリース前提条件)
+
+- [ ] **セキュリティ監査** (P1) — secrets 管理・権限設定の最終確認
+- [ ] **E2E テスト整備** (P2) — 全 Pester テスト + シナリオ E2E 検証
+- [ ] **v3.0.0 リリースノート最終版** (P2) — 本 CHANGELOG エントリの完成
+- [ ] **`v3.0.0` GitHub Release タグ作成** (P2) — バイナリ配布
+
+### Go/No-Go 基準
+
+以下をすべて満たすこと:
+
+- [x] 全 Pester テスト SUCCESS (311 件)
+- [x] CI 全ステップ SUCCESS
+- [x] README / docs 最新状態 (ClaudeOS v7.5)
+- [x] P1 Open Issue = 0
+- [ ] セキュリティ監査 合格
+- [ ] 対応レベル目標の 80% 以上達成
+
+---
+
+## [v2.9.0] - 2026-04-14 (STABLE)
+
+### ClaudeOS v7.5 — Boot Sequence 完全自動化 + CodeRabbit 統合
+
+#### 🚀 Boot Sequence Step 3/7/9 完全実装 (Issue #68, #70, #71)
+
+- **Step 3 Memory Restore** (PR #81): `McpHealthCheck.psm1` の `Get-McpHealthReport` でワイヤリング完了
+- **Step 7 Agent Init** (PR #80): `AgentTeams.psm1` の `Get-AgentTeamReport` でワイヤリング完了
+- **Step 9 Dashboard** (PR #82): `state.json` KPI / フェーズ統合 Dashboard 実装完了
+- MVP プレースホルダー状態 (Step 1/2/4/9) → 完全実装 (Step 1/2/3/4/7/9)
+
+#### 🐰 CodeRabbit Review 統合 (PR #83, v7.5 追加)
+
+- `/coderabbit:review` コマンド統合
+- 静的解析 (40+ 解析器) による Verify 補助
+- Codex レビューの代替ではなく、網羅性と深度の両立
+- STABLE 判定条件に CodeRabbit Critical/High = 0 を追加
+
+#### 👥 /team-onboarding コマンド (PR #88, v7.5 追加)
+
+- Agent Teams 新規メンバー向け自動オンボーディング
+- プロジェクト構造・運用ルール・ループ設計を段階的に案内
+
+#### ⏱ ループ時間最適化 (PR #88)
+
+- Development: 2h → 60m
+- Verify: 1h → 45m
+- Improve: 1h → 45m
+- Max 20x 週次制限下での効率最大化
+
+#### 🛡️ Issue Sync ワークフロー修正 (Issue #85, PRs #86 #87)
+
+- `issues` イベント自動トリガーを無効化し branch protection 競合を解消
+- push から PR 自動作成方式へ変更
+
+#### 🔧 その他改善 (PRs #77, #79, #84, #89)
+
+- PR #77: gitleaks workflow + Agent Teams Light mode
+- PR #79: フェーズ別モデル制御設定 (opusplan for Development)
+- PR #84: `.gitignore` に claude-mem 自動生成 `CLAUDE.md` を追加
+- PR #89: README + v3ロードマップ Phase 3 完了・Phase 4 着手反映
 
 ### Phase 3: Self Evolution & Architecture Check (Issue #49, #50)
 
@@ -31,8 +95,9 @@
 - 各種ドキュメント・設定テンプレート更新
 
 ### テスト・CI
-- テスト数: 269 (v2.8.0) → 304 (+35件)
-- CI: 全テスト PASS
+- テスト数: 269 (v2.8.0) → 311 (+42件)
+- CI: 全テスト PASS (14/14 SUCCESS)
+- CodeRabbit: 統合済み (Critical/High = 0)
 
 ### 変更ファイル (主要)
 - `scripts/lib/SelfEvolution.psm1` (新規)


### PR DESCRIPTION
## Summary

- **v2.9.0 セクションを STABLE 化** (`v2.9.0-dev` → `v2.9.0 (STABLE)`, 日付 2026-04-14)
- **ClaudeOS v7.5 の全成果を追記**: Boot Sequence Step 3/7/9 完全実装 / CodeRabbit 統合 / /team-onboarding / ループ時間最適化 / Issue Sync 修正
- **新規 v3.0.0 Unreleased セクション**: Phase 4 残タスクと Go/No-Go 基準を明文化

## 背景

Phase 3 は 2026-04-14 に完了済み (v2.9.0 STABLE 達成、CI 14/14 SUCCESS、311 Pester テスト全通過) だが、CHANGELOG 上は未だ `v2.9.0-dev` のままだった。Phase 4 への移行と v3.0.0 GA 準備開始を明文化する。

## 変更内容

### v3.0.0 Unreleased セクション (新規)
- コードネーム「Autonomous Runtime」
- Phase 4 残タスク: セキュリティ監査 (P1) / E2E テスト (P2) / リリースノート最終版 (P2) / Release タグ作成 (P2)
- Go/No-Go 基準 (6 項目、うち 4 項目達成済み)

### v2.9.0 セクション (STABLE 化)
- 日付: 2026-04-08 → 2026-04-14
- Boot Sequence Step 3/7/9 完全実装セクション追加
- CodeRabbit Review 統合セクション追加
- /team-onboarding コマンド追加
- ループ時間最適化 (Development 60m / Verify 45m / Improve 45m)
- Issue Sync ワークフロー修正 (Issue #85 → PRs #86 #87)
- その他改善 (PR #77, #79, #84, #89)
- テスト数: 304 → 311
- CI: 14/14 SUCCESS

## 影響範囲

- `CHANGELOG.md` のみ変更（ドキュメント）
- コード変更なし・破壊的変更なし
- テスト・CI に影響なし

## 残課題

Phase 4 で対応予定:
- セキュリティ監査 (P1)
- E2E テスト整備
- `v3.0.0` GitHub Release タグ作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * v2.9.0 STABLE リリース：ClaudeOS v7.5 ブートシーケンス完了、CodeRabbit レビュー統合、チームオンボーディングコマンド、ループ時間最適化が追加されました

* **改善**
  * ワークフロー調整とテスト/CI メトリクスが更新されました

* **予定**
  * v3.0.0「Autonomous Runtime」Phase 4 はセキュリティ監査と E2E テスト設定の準備中です

<!-- end of auto-generated comment: release notes by coderabbit.ai -->