### PR TITLE
chore: .gitignore に docs/common/CLAUDE.md を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,5 @@ scripts/main/CLAUDE.md
 tests/CLAUDE.md
 Claude/templates/claude/instructions/CLAUDE.md
 .claude/claudeos/commands/CLAUDE.md
+docs/common/CLAUDE.md
 Claude/templates/claude/Claude/


### PR DESCRIPTION
## Summary

claude-mem MCP が \`docs/common/\` 配下にも自動生成 \`CLAUDE.md\` を展開することが Loop 12 Monitor で判明。既存の除外パターンと整合させる。

## 背景

PR #84 で複数のサブディレクトリ (.github/issues, .github/workflows, scripts/lib, scripts/main, tests など) の自動生成 CLAUDE.md を .gitignore に追加済みだが、\`docs/common/\` は漏れていた。

## 変更内容

\`.gitignore\` に 1 行追加:

\`\`\`
+docs/common/CLAUDE.md
\`\`\`

## 影響範囲

- \`.gitignore\` のみ変更
- 既存のトラックされたファイルには影響なし
- テスト・CI・機能に影響なし

## 残課題

**構造的課題**: claude-mem MCP が新しいサブディレクトリに展開するたびに .gitignore 追加が必要になる。将来的には \`**/CLAUDE.md\` + ホワイトリスト方式への移行を検討する価値あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **保守**
  * リポジトリの管理設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->