### PR TITLE
chore: .gitignore に .github/CLAUDE.md と docs/CLAUDE.md を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,6 @@ tests/CLAUDE.md
 Claude/templates/claude/instructions/CLAUDE.md
 .claude/claudeos/commands/CLAUDE.md
 docs/common/CLAUDE.md
+.github/CLAUDE.md
+docs/CLAUDE.md
 Claude/templates/claude/Claude/


### PR DESCRIPTION
claude-mem MCP が .github/ と docs/ 直下にも自動生成 CLAUDE.md を展開することを検出。既存の除外パターン (PR #84, #91) と整合させる 2 行追加のみ。