### PR TITLE
security(ci): PSScriptAnalyzer lint ジョブを追加 (Issue #92 P1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,3 +159,49 @@ jobs:
               throw "旧構成の参照が残っています: $pattern"
             }
           }
+
+  lint-powershell:
+    name: PSScriptAnalyzer
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module PSScriptAnalyzer -Force -SkipPublisherCheck -Scope CurrentUser
+
+      - name: Run PSScriptAnalyzer (Error severity only)
+        shell: pwsh
+        run: |
+          $results = Invoke-ScriptAnalyzer `
+            -Path . `
+            -Recurse `
+            -Severity Error `
+            -ExcludeRule PSAvoidUsingWriteHost,PSUseDeclaredVarsMoreThanAssignments `
+            -ErrorAction SilentlyContinue
+          if ($results) {
+            $results | Format-Table -AutoSize | Out-String | Write-Host
+            Write-Host "::error::PSScriptAnalyzer found $($results.Count) error-level issue(s)"
+            exit 1
+          }
+          Write-Host "::notice::PSScriptAnalyzer: no error-level issues found"
+
+      - name: Run PSScriptAnalyzer (Warning summary, non-blocking)
+        if: always()
+        shell: pwsh
+        run: |
+          $warnings = Invoke-ScriptAnalyzer `
+            -Path . `
+            -Recurse `
+            -Severity Warning `
+            -ExcludeRule PSAvoidUsingWriteHost,PSUseDeclaredVarsMoreThanAssignments `
+            -ErrorAction SilentlyContinue
+          if ($warnings) {
+            Write-Host "::notice::PSScriptAnalyzer warnings (non-blocking): $($warnings.Count) issue(s)"
+            $warnings | Group-Object RuleName | Sort-Object Count -Descending | Select-Object Count, Name | Format-Table -AutoSize | Out-String | Write-Host
+          } else {
+            Write-Host "::notice::PSScriptAnalyzer: no warning-level issues"
+          }


### PR DESCRIPTION
## Summary

Phase 4 P1 セキュリティ監査の残項目「PSScriptAnalyzer CI 統合」を実装。CodeQL が PowerShell を公式サポート外のため、代替 SAST として PSScriptAnalyzer を統合する。

Issue #92 の最後の P1 対応。

## 背景

Loop 13 のセキュリティ監査で以下を検出:
- CodeQL 未設定 (ただし PowerShell は公式サポート外)
- 静的解析による早期バグ検出が CI に組み込まれていない

## 変更内容

\`.github/workflows/ci.yml\` に新規 job \`lint-powershell\` を追加:

\`\`\`yaml
lint-powershell:
  name: PSScriptAnalyzer
  runs-on: windows-latest
  steps:
    - Checkout
    - Install PSScriptAnalyzer
    - Run PSScriptAnalyzer (Error severity only)   ← blocking
    - Run PSScriptAnalyzer (Warning summary)         ← non-blocking
\`\`\`

### 設計判断

- **独立 job として追加**: Pester と並列実行可能、context 名が明確 (\`PSScriptAnalyzer\`)
- **Error = blocking / Warning = report only**: 段階的厳格化の第一歩。既存コードベースへの影響を最小化
- **除外ルール**: \`PSAvoidUsingWriteHost\` と \`PSUseDeclaredVarsMoreThanAssignments\` を除外 (対話的 CLI ツールの特性上、正当な使用パターンが多い)

### 段階的厳格化ロードマップ

1. **今回**: Error = blocking / Warning = report only ← 本 PR
2. **次**: Warning の Top rules を特定 → 段階的に修正 → blocking へ
3. **最終**: Information 含む全厳格化

## 影響範囲

- \`.github/workflows/ci.yml\` のみ変更
- 新規 CI context \`PSScriptAnalyzer\` が追加される
- Pester テストには影響なし (並列 job)
- **このジョブが Error を検出した場合、CI 全体が失敗する**

### 動作確認予測

- 既存コードに Error severity の問題があれば本 PR の CI で露呈する
- 露呈した場合は本 PR 内で fix するか、一時的に例外ルールを追加
- Warning summary は Notice として情報表示のみ

## 残課題 (Issue #92 完了条件)

- [x] ci.yml permissions (PR #93 ✅)
- [x] Dependabot (PR #94 ✅)
- [x] SECURITY.md (PR #97 ✅)
- [x] **PSScriptAnalyzer 統合 (本 PR)**
- [ ] required_status_checks 強制化 ← **本 PR merge 後に branch protection API で対応**

🤖 Generated with [Claude Code](https://claude.com/claude-code)