### PR TITLE
feat(commands): /team-onboarding を動的生成方式に変更

### DIFF
--- a/.claude/claudeos/commands/team-onboarding.md
+++ b/.claude/claudeos/commands/team-onboarding.md
@@ -1,117 +1,191 @@
 # /team-onboarding
 
-新しいメンバーが ClaudeOS プロジェクトに参加する際のオンボーディングガイドを対話的に提供するコマンドです。
+現在のプロジェクトを解析し、プロジェクト固有の `ONBOARDING.md` を動的生成するコマンドです。
 
-## 実行内容
+ClaudeOS フレームワーク全般の説明ではなく、**このリポジトリで実際に何をどう扱うか** を、
+実データ（`CLAUDE.md` / `state.json` / `.claude/claudeos/` / Git 履歴 / セッション学習履歴）から
+抽出して記述します。
 
-以下のステップをシーケンシャルに案内します。
+---
 
-### Step 1: 環境確認
+## 実行契約（Claude はこの順で tool を起動すること）
 
-```text
-以下の環境が揃っているか確認してください：
+以下は説明ではなく **Claude への命令列** です。ステップを飛ばさず、順に実行してください。
+各ステップの「入力」が揃わない場合は、該当ステップで代替動作に切り替え、生成物にその旨を明記します。
 
-- Claude Code CLI インストール済み
-- Git / GitHub CLI (gh) インストール済み
-- Node.js (LTS) インストール済み
-- リポジトリへのアクセス権限確認済み
-- GitHub Token 設定済み
-```
+### Phase A: プロジェクト判定
 
-### Step 2: ClaudeOS 設定ファイル配置
+1. **CWD 取得**: `Bash("pwd")` で現在のプロジェクトルートを取得する
+2. **Git 情報取得**: 並列で `Bash("git remote get-url origin")` と `Bash("git rev-parse --abbrev-ref HEAD")` を実行
+3. **CLAUDE.md 存在確認**: `Read("./CLAUDE.md")` — 存在しない場合は Phase B に進まず、以下のメッセージで中断:
+   ```
+   このプロジェクトには CLAUDE.md が存在しないため、/team-onboarding は実行できません。
+   先に ClaudeOS の初期化を実施してください。
+   ```
+4. **Project Switch Engine 判定**: `Glob(".loop-project-exclude.md")` と `Glob(".loop-project-override.md")` を並列実行
+   - `exclude` が存在 → 対象外プロジェクトとして中断（Onboarding 不要）
+   - `override` が存在 → 内容を読み取り、後続 Phase の判定に優先適用
 
-プロジェクトの CLAUDE.md を確認し、以下のファイルが正しく配置されているか検証します。
+### Phase B: 設定データ収集
 
-| ファイル | 場所 | 用途 |
+以下を **並列で** 実行する（Read / Glob / Bash の独立呼び出しは 1 メッセージで束ねること）:
+
+| 取得対象 | tool | 存在しない場合 |
 |---|---|---|
-| `CLAUDE.md` | リポジトリルート | プロジェクト運用ポリシー |
-| `state.json` | リポジトリルート | Goal / KPI / フェーズ管理 |
-| `.claude/claudeos/` | リポジトリ内 | エージェント定義・コマンド定義 |
-| `~/.claude/CLAUDE.md` | グローバル | 全プロジェクト共通設定 |
+| `./CLAUDE.md` | `Read` | Phase A で弾くので到達しない |
+| `./state.json` | `Read` | 動的生成前で未存在が通常。欠損時は `CLAUDE.md` §4 Goal Driven System から Goal / KPI の初期値テンプレを抽出 |
+| `./README.md` | `Read` | `README未整備` と記録 |
+| `.claude/claudeos/CLAUDE.md` | `Read` | 継承なし、グローバル設定のみとみなす |
+| `.claude/claudeos/agents/` | `Glob("**/*.md")` | Agent Teams 未整備として記録 |
+| `.claude/claudeos/commands/` | `Glob("*.md")` | コマンド未整備として記録 |
+| `.claude/claudeos/hooks/hooks.json` | `Read` | フック未設定として記録 |
 
-### Step 3: ループコマンド説明
+### Phase C: 禁止事項・運用規約の動的抽出
 
-ClaudeOS は以下の 4 つのループで自律開発を実行します：
+**ハードコード禁止。** 必ず現時点の CLAUDE.md から抽出する。
 
-| ループ | 時間 | 責務 |
-|---|---|---|
-| Monitor | 30m | GitHub / CI / Issue の状態確認・優先順位決定 |
-| Development | 60m | 設計・実装・WorkTree 管理 |
-| Verify | 45m | test / lint / build / CodeRabbit / CI 確認、STABLE 判定 |
-| Improvement | 45m | リファクタリング・ドキュメント更新・再開メモ |
+1. `Grep(pattern="^## .*禁止", path="./CLAUDE.md", output_mode="content", -A=30)` — `## 18. 禁止事項` セクションを取得
+2. リスト項目（`- ` で始まる行）を **すべて** 抽出し、件数を明示して ONBOARDING.md に転記
+3. CLAUDE.md のバージョン（例: `ClaudeOS v8`）も同様に先頭から抽出
 
-### Step 4: Agent Teams 説明
+### Phase D: state.json からの実践知抽出（存在時のみ）
 
-ClaudeOS の Agent Teams は以下のロールで構成されます：
+`state.json` が存在した場合、**10 ブロック構造** を前提に以下を読む:
 
-| ロール | 責務 |
+| ブロック | 抽出対象 |
 |---|---|
-| CTO | 最終判断・優先順位・継続可否 |
-| ProductManager | Issue 生成・要件整理 |
-| Architect | アーキテクチャ設計 |
-| Developer | 実装・修正・修復 |
-| Reviewer | Codex + CodeRabbit レビュー・コード品質 |
-| Debugger | 原因分析・rescue 実行 |
-| QA | テスト・回帰確認・品質評価 |
-| Security | secrets・権限・脆弱性確認 |
-| DevOps | CI/CD・PR・Deploy Gate |
-| Analyst | KPI 分析・メトリクス評価 |
-| EvolutionManager | 改善提案・自己進化管理 |
-| ReleaseManager | リリース管理・マージ判断 |
+| `project` | プロジェクト識別情報 |
+| `goal` | 現在の目標（title / description） |
+| `kpi` | 達成目標値と現在値 |
+| `execution` | `phase` / `remaining_minutes` — 進行中であれば再開ポイント扱い |
+| `automation` | `auto_issue_generation` / `self_evolution` フラグ |
+| `priority` | 優先順位リスト |
+| `learning` | `failure_patterns` / `success_patterns` — これが最重要。最大 5 件を「このプロジェクトでよくハマる点」として転記 |
+| `github` | Projects / Issues / PR の最新状態 |
+| `status` | ループ実行状態 |
+| `codex` | `last_review_status` / `blocking_issues` — 未解決の重大指摘があれば Onboarding 先頭で警告 |
 
-### Step 5: state.json の読み方
+ブロックが存在しない場合はスキップし、Phase E の該当セクションに「state.json に該当情報なし」と明記。
 
-`state.json` はセッションの単一の真実（Single Source of Truth）です：
+### Phase E: ONBOARDING.md 生成
 
-```json
-{
-  "goal": { "title": "プロジェクトの目標" },
-  "kpi": { "success_rate_target": 0.9 },
-  "execution": {
-    "phase": "Monitor | Development | Verify | Improvement",
-    "remaining_minutes": 300
-  },
-  "token": { "used": 0, "remaining": 100 }
-}
+出力先は **`./ONBOARDING.md`** 固定（プロジェクトルート）。既存ファイルがあれば上書きし、
+上書き前に先頭 10 行を読み取って「前回生成日時」と差分をログ出力する。
+
+`Write("./ONBOARDING.md", content)` で以下の構造を書き出す:
+
+```markdown
+# {プロジェクト名} Onboarding
+
+> このファイルは `/team-onboarding` により自動生成されます。
+> 手動編集は次回実行時に上書きされます。恒久的な記述は CLAUDE.md または docs/ に配置してください。
+
+**生成日時**: {ISO8601 UTC}
+**ClaudeOS バージョン**: {CLAUDE.md から抽出}
+**Git ブランチ**: {現在ブランチ}
+**リポジトリ**: {origin URL}
+
+## 1. このプロジェクトの Goal
+
+{state.json.goal があればそれ、無ければ CLAUDE.md §4 の state.json 構造例から推定}
+
+## 2. 現在の KPI 状態
+
+{state.json.kpi ブロックの転記、無ければ「未計測」}
+
+## 3. よくハマるポイント（実履歴からの抽出）
+
+{state.json.learning.failure_patterns 上位 5 件。無ければ「学習履歴なし、初回セッション後に蓄積される」}
+
+## 4. 過去の成功パターン
+
+{state.json.learning.success_patterns 上位 5 件。無ければ同上}
+
+## 5. 利用可能な Agent Teams
+
+{.claude/claudeos/agents/*.md を Glob し、ファイル名とフロントマターの description を表形式で列挙}
+
+## 6. 利用可能なスラッシュコマンド
+
+{.claude/claudeos/commands/*.md を列挙。各ファイルの先頭行（タイトル）と 2-3 行目を description として取得}
+
+## 7. 禁止事項（CLAUDE.md §18 の全項目を動的ミラー）
+
+{Phase C で抽出した全項目。N 件あれば N 件すべて}
+
+## 8. 直近の Git 活動
+
+{Bash("git log --oneline -20") の結果}
+
+## 9. 未解決の Codex 指摘（state.json.codex.blocking_issues があれば）
+
+{重大指摘リスト。無ければ「未解決指摘なし」または「state.json 未存在」}
+
+## 10. セッション開始手順
+
+CLAUDE.md §0 の 4 ループ登録コマンドを、**このプロジェクトの state.json から抽出した** 時間配分で生成:
+
+{state.json.execution.loop_distribution があればそれを優先、無ければ CLAUDE.md §0 デフォルト値}
+
+## 11. 再開ポイント（前回セッション未完了時）
+
+{state.json.execution.phase が Monitor/Development/Verify/Improvement のいずれかで残時間 > 0 なら、そのフェーズの再開手順}
 ```
 
-### Step 6: 開発フローの把握
+### Phase F: Verify ループ連動の登録
+
+STABLE 達成時に ONBOARDING.md を自動再生成するフックを提案する。
+
+1. `.claude/claudeos/hooks/hooks.json` に以下のエントリが存在しない場合、追記を **提案する**（勝手に編集しない。ユーザー確認後に Edit）:
+   ```json
+   {
+     "PostToolUse": [
+       { "name": "onboarding-refresh-on-stable", "description": "STABLE 判定成立時に /team-onboarding を再実行し ONBOARDING.md を更新" }
+     ]
+   }
+   ```
+2. 実フックスクリプトは別途 `.claude/claudeos/hooks/onboarding-refresh-on-stable.md` として配置する設計を提示（別 Issue 化を推奨）
+
+### Phase G: 完了報告
+
+最後に以下を表示する:
 
 ```
-Issue 起票 → Monitor で優先順位確認
-→ Development でブランチ作成・実装
-→ commit / push / PR 作成
-→ Verify で CI・レビュー確認
-→ STABLE 達成 → merge
-→ Improvement でドキュメント整備
-→ 次の Monitor へ
+✅ ONBOARDING.md を生成しました
+   - パス: ./ONBOARDING.md
+   - サイズ: {N} バイト
+   - 反映した禁止事項: {N} 件（CLAUDE.md §18 から動的抽出）
+   - 反映した失敗パターン: {N} 件（state.json.learning から）
+   - 反映した成功パターン: {N} 件
+   - 反映した Agent: {N} 件
+   - 反映した Command: {N} 件
+   - Verify 連動フック: 未登録（登録を提案済み / 既登録）
 ```
 
-### Step 7: 禁止事項の確認
+---
 
-- `main` への直接 push 禁止
-- Issue なし作業禁止
-- CI 未通過 merge 禁止
-- 無限修復（Auto Repair は最大 15 回）
-- Token 超過のまま深掘り継続禁止
+## 設計原則
 
-### Step 8: 最初のセッション開始
+- **静的記述を ONBOARDING.md に書かない**: CLAUDE.md や state.json が唯一の真実であり、このコマンドは抽出器
+- **欠損時の退避動作を必ず明示**: state.json が無い新規プロジェクトでも動作する
+- **Project Switch Engine 対応**: `.loop-project-exclude.md` / `.loop-project-override.md` を判定に組み込む
+- **禁止事項は動的ミラー**: CLAUDE.md §18 が更新されれば次回実行時に自動追従
+- **Verify 連動の自動更新**: STABLE 達成を契機に再実行される仕組みを提示
+- **出力先は固定**: `./ONBOARDING.md`（プロジェクトルート）
 
-準備完了後、以下を実行してセッションを開始します：
+## 既知の制約
 
-```text
-/loop 30min   ClaudeOS Monitor
-/loop 2h      ClaudeOS Development
-/loop 1h15m   ClaudeOS Verify
-/loop 1h15m   ClaudeOS Improvement
-```
+- state.json の 10 ブロック構造はプロジェクトにより差があるため、欠損ブロックはスキップする
+- `.loop-project-override.md` のスキーマは未確定 — 初期実装では「存在すれば対象」として扱い、将来拡張する
+- Verify 連動フックの実体スクリプトは本コマンドでは生成せず、登録提案に留める（権限境界の明確化）
 
 ## 参照先
 
-| ドキュメント | 場所 |
+| 対象 | 場所 |
 |---|---|
-| プロジェクト設定 | `CLAUDE.md` (リポジトリルート) |
-| グローバル設定 | `~/.claude/CLAUDE.md` |
-| 運用ループ詳細 | `.claude/claudeos/loops/` |
+| プロジェクト運用規約 | `./CLAUDE.md` |
+| グローバル運用規約 | `~/.claude/CLAUDE.md` |
+| state.json 構造定義 | `./CLAUDE.md` §4 |
+| 禁止事項の正 | `./CLAUDE.md` §18 |
 | Agent 定義 | `.claude/claudeos/agents/` |
-| CI Manager | `.claude/claudeos/ci/ci-manager.md` |
+| Hook 定義 | `.claude/claudeos/hooks/hooks.json` |

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,177 @@
+# ClaudeCLI-CodexCLI-CopilotCLI-StartUpTools-New Onboarding
+
+> このファイルは `/team-onboarding` により自動生成されます。
+> 手動編集は次回実行時に上書きされます。恒久的な記述は `CLAUDE.md` または `docs/` に配置してください。
+
+**生成日時**: 2026-04-14T00:00:00Z
+**ClaudeOS バージョン**: v8 (Weekly Optimized Loops + CodeRabbit 統合)
+**Git ブランチ**: main（生成時点。実作業は feature branch で実施）
+**リポジトリ**: https://github.com/Kensan196948G/ClaudeCLI-CodexCLI-CopilotCLI-StartUpTools-New
+
+---
+
+## 1. このプロジェクトの Goal
+
+`state.json` が未存在のため、CLAUDE.md §4 Goal Driven System のテンプレートから初期値を提示:
+
+| 項目 | 現在値 |
+|---|---|
+| Goal Title | 自律開発最適化（初期値） |
+| Goal Description | ClaudeOS v8 による完全無人運用の確立と Claude Code 中心の開発体験向上 |
+| 運用モード | Auto Mode + Agent Teams |
+| 最大作業時間 | 300 分（5 時間） |
+
+> 実運用では初回 Monitor ループ終了時に `state.json` が生成され、以降はその内容が正となります。
+
+## 2. 現在の KPI 状態
+
+| KPI | 目標値 | 現在値 |
+|---|---|---|
+| success_rate_target | 0.9 | 未計測（state.json 未存在） |
+
+## 3. よくハマるポイント（実履歴からの抽出）
+
+`state.json.learning.failure_patterns` が未存在のため、抽出できません。
+
+> 初回セッション後に自動蓄積され、次回 `/team-onboarding` 実行時に反映されます。
+> 代替として、Git ログから最近の修復系コミットを参照: `fix(issue-sync)` 系が 2 件連続しており、
+> Issue Sync 周りが直近のハマりどころだった可能性があります（#86, #87）。
+
+## 4. 過去の成功パターン
+
+`state.json.learning.success_patterns` が未存在のため、抽出できません（初回セッション後に蓄積）。
+
+## 5. 利用可能な Agent Teams
+
+`.claude/claudeos/agents/` 直下に **37 体** の特化サブエージェントが配置されています。
+
+| カテゴリ | Agent |
+|---|---|
+| 統括・計画 | `chief-of-staff` / `orchestrator` / `planner` / `loop-operator` |
+| 設計 | `architect` / `api-designer` |
+| 実装（言語別 resolver） | `build-error-resolver` / `cpp-build-resolver` / `go-build-resolver` / `java-build-resolver` / `kotlin-build-resolver` / `rust-build-resolver` / `pytorch-build-resolver` |
+| レビュー（言語別） | `code-reviewer` / `cpp-reviewer` / `go-reviewer` / `java-reviewer` / `kotlin-reviewer` / `python-reviewer` / `rust-reviewer` / `typescript-reviewer` / `database-reviewer` / `security-reviewer` |
+| 開発（領域別） | `dev-api` / `dev-ui` |
+| 品質 | `qa` / `tester` / `tdd-guide` / `e2e-runner` |
+| 運用 | `ops` / `release-manager` / `incident-triager` / `security` |
+| 改善・ドキュメント | `refactor-cleaner` / `doc-updater` / `docs-lookup` / `harness-optimizer` |
+
+> 各 Agent の詳細な description は、該当 Agent を呼び出した際にロードされるフロントマターから取得してください。
+> CLAUDE.md §6 に Agent Teams のロール対応表があります。
+
+## 6. 利用可能なスラッシュコマンド
+
+`.claude/claudeos/commands/` 直下に **34 個** のコマンドが配置されています。
+
+| カテゴリ | Command |
+|---|---|
+| オンボーディング | `/team-onboarding` |
+| 計画・オーケストレーション | `/plan` / `/orchestrate` / `/multi-plan` / `/multi-workflow` / `/multi-execute` |
+| レビュー | `/code-review` / `/go-review` / `/python-review` |
+| ビルド・テスト | `/build-fix` / `/go-build` / `/go-test` / `/verify` / `/test-coverage` |
+| マルチスタック | `/multi-backend` / `/multi-frontend` |
+| TDD・E2E | `/tdd` / `/e2e` |
+| セッション管理 | `/checkpoint` / `/sessions` / `/prune` |
+| 学習・進化 | `/learn` / `/learn-eval` / `/evolve` / `/eval` |
+| Instinct（直感記録） | `/instinct-export` / `/instinct-import` / `/instinct-status` |
+| ドキュメント | `/update-docs` / `/update-codemaps` |
+| 改善 | `/refactor-clean` |
+| プロジェクト管理 | `/pm2` / `/setup-pm` |
+| スキル作成 | `/skill-create` |
+
+## 7. 禁止事項（CLAUDE.md §18 の全項目を動的ミラー）
+
+CLAUDE.md §18 から抽出した **全 8 項目**:
+
+1. Issue なし作業
+2. main 直接 push
+3. CI 未通過 merge
+4. 無限修復（Auto Repair 制御に従う）
+5. 未検証 merge
+6. 原因不明修正
+7. Token 超過のまま深掘り継続
+8. 時間不足時の大規模変更
+
+> この一覧は CLAUDE.md §18 の動的ミラーです。§18 を更新すれば次回 `/team-onboarding` 実行時に自動追従します。
+
+## 8. 直近の Git 活動
+
+直近 20 コミット:
+
+| Hash | 概要 |
+|---|---|
+| 32ce37a | feat(claudeos): v8 Weekly Optimized Loops へアップグレード (#99) |
+| e698d21 | chore(deps): bump actions/checkout from 4 to 6 (#96) |
+| b4451e8 | security(ci): PSScriptAnalyzer lint ジョブを追加 (Issue #92 P1) (#98) |
+| 4db3e35 | security: SECURITY.md を追加 (Issue #92 P2 対応) (#97) |
+| f0db91b | chore: .gitignore に .github/CLAUDE.md と docs/CLAUDE.md を追加 (#95) |
+| 095c127 | security(deps): Dependabot 設定を追加 (Issue #92) (#94) |
+| 1e01bbf | security(ci): permissions ブロックを contents: read に絞る (Issue #92) (#93) |
+| 3a164dd | chore: .gitignore に docs/common/CLAUDE.md を追加 (#91) |
+| 2b7e049 | docs(changelog): v2.9.0 STABLE 化 + v3.0.0 Phase 4 計画追記 (#90) |
+| 7fe8b59 | docs: Phase 3 完了・Phase 4 着手を README と v3ロードマップに反映 (#89) |
+| 4bc39a6 | feat(templates): ClaudeOS v7.5 テンプレート更新・CodeRabbit 統合・/team-onboarding 実装 |
+| eef346f | fix(issue-sync): issues イベント自動トリガーを無効化 (#87) |
+| cfe98bd | fix(issue-sync): branch protection 対策 (#86) |
+| 8c736c2 | chore: .gitignore に claude-mem 自動生成 CLAUDE.md を追加 (#84) |
+| 214f098 | chore(claudeos): v7.4 → v7.5 — CodeRabbit 統合ポリシー追加 (#83) |
+| e3f38ef | feat(dashboard): Issue #71 Dashboard に state.json KPI/フェーズ統合 (#82) |
+| f8e8885 | feat(boot): Issue #70 Memory Restore を McpHealthCheck.psm1 でワイヤリング (#81) |
+| 752ef4a | feat(boot): Issue #68 Agent Init を AgentTeams.psm1 でワイヤリング (#80) |
+| 801264b | chore: フェーズ別モデル制御設定を追加 (#79) |
+| 083b16e | chore: gitleaks workflow + Agent Teams Light mode (#77) |
+
+## 9. 未解決の Codex 指摘
+
+`state.json.codex.blocking_issues` が未存在のため、未解決指摘の抽出はできません。
+
+> 直近で Codex レビューが実行されていない、または state.json がまだ生成されていない状態です。
+> 次回 Verify フェーズで `/codex:review` を実行すれば、結果が state.json.codex に記録されます。
+
+## 10. セッション開始手順
+
+CLAUDE.md §0 のデフォルト 4 ループ登録（state.json が未存在のため標準配分を使用）:
+
+```text
+/loop 30min   ClaudeOS Monitor
+/loop 2h      ClaudeOS Development
+/loop 1h15m   ClaudeOS Verify
+/loop 1h15m   ClaudeOS Improvement
+```
+
+配分内訳: Monitor 10% / Development 40% / Verify 25% / Improvement 25%（計 5 時間）。
+
+続いて Codex セットアップ:
+
+```text
+/codex:setup
+/codex:status
+```
+
+リリース直前のみ: `/codex:setup --enable-review-gate`
+
+## 11. 再開ポイント（前回セッション未完了時）
+
+`state.json.execution.phase` が未存在のため、前回セッション情報はありません。
+
+> 通常は Monitor フェーズから開始し、GitHub Projects / Issues / CI の状態を確認して次のアクションを決定します。
+
+---
+
+## 付録: このファイルの生成元
+
+- **コマンド定義**: `.claude/claudeos/commands/team-onboarding.md`
+- **データソース**:
+  - `./CLAUDE.md`（運用規約）
+  - `./state.json`（未存在）
+  - `./README.md`
+  - `.claude/claudeos/CLAUDE.md`（ClaudeOS 内部設定）
+  - `.claude/claudeos/agents/**/*.md`（Agent 定義）
+  - `.claude/claudeos/commands/*.md`（Command 定義）
+  - `git log --oneline -20`（直近コミット）
+
+## 付録: Verify 連動自動更新
+
+STABLE 達成時に本ファイルを自動再生成するフックは **Issue #100** として起票済みです。
+実装完了後、`.claude/claudeos/hooks/hooks.json` の PostToolUse にフックが登録され、
+Verify ループで STABLE が成立するたびに本ファイルが最新化されます。


### PR DESCRIPTION
## Summary

- `/team-onboarding` を静的テンプレートから **実行命令列 (Phase A-G)** に全面書き換え
- プロジェクトごとに異なる `ONBOARDING.md` を実データから動的抽出して生成
- 禁止事項・Agent 一覧・Command 一覧は CLAUDE.md / ファイルシステムから動的ミラー（ハードコード排除）

## 背景と狙い

レビュー指摘により、従来の `/team-onboarding` が以下の 8 点で公式 Claude Code の `/team-onboarding` と乖離していることが判明:

1. 静的テンプレートで実行するたびに同じ内容が出る
2. ClaudeOS フレームワーク説明に終始し対象プロジェクト固有情報が出ない
3. セッション履歴からの実践知抽出がない
4. Verify ループとの連動がない
5. 出力先が未定義
6. state.json 構造を簡略化しすぎており実体 (10 ブロック) と乖離
7. Project Switch Engine 非対応
8. 禁止事項の網羅不足 (5 項目 vs CLAUDE.md §18 の 8 項目)

本 PR はこれら全 8 点を解消。

## 主な変更

### `.claude/claudeos/commands/team-onboarding.md`

- **Phase A: プロジェクト判定** — CWD / Git remote / Git branch / CLAUDE.md 存在確認 / Project Switch Engine 判定
- **Phase B: 設定データ収集** — CLAUDE.md / state.json / README.md / agents/ / commands/ / hooks.json を並列取得
- **Phase C: 禁止事項の動的抽出** — `Grep(pattern="^## .*禁止")` で CLAUDE.md §18 をミラー
- **Phase D: state.json からの実践知抽出** — 10 ブロック構造 (project/goal/kpi/execution/automation/priority/learning/github/status/codex) を前提。learning.failure_patterns/success_patterns 上位 5 件を転記
- **Phase E: ONBOARDING.md 生成** — `./ONBOARDING.md` 固定出力。11 セクション構成
- **Phase F: Verify 連動フック提案** — hooks.json 登録は提案に留め、実体は #100 で分離
- **Phase G: 完了報告** — 反映した項目数を明示

### `ONBOARDING.md` (新規)

本プロジェクトに対して動作検証を実行した結果の生成物。
- 禁止事項 8 件（CLAUDE.md §18 から動的抽出）
- Agent 37 体（`.claude/claudeos/agents/` から Glob 取得）
- Command 34 個（`.claude/claudeos/commands/` から Glob 取得）
- Git 直近 20 コミット
- state.json 未存在時の退避動作込み（失敗/成功パターンは初回セッション後に蓄積予定の旨を明記）

## 設計原則

- **静的記述を ONBOARDING.md に書かない** — CLAUDE.md / state.json が唯一の真実
- **欠損時の退避動作を必ず明示** — 新規プロジェクト (state.json なし) でも動作する
- **禁止事項は動的ミラー** — CLAUDE.md §18 更新で次回自動追従
- **Verify 連動の自動更新** — STABLE 成立を契機に再実行される設計を提示

## 関連 Issue

- #100: Phase F のフック実体スクリプト `onboarding-refresh-on-stable.md` 実装（本 PR から分離）

## Test plan

- [x] `.claude/claudeos/commands/team-onboarding.md` の Phase A-G が tool 起動命令として明示されている
- [x] 禁止事項が CLAUDE.md §18 の 8 項目すべてを反映している（`ONBOARDING.md` §7 で検証）
- [x] state.json 未存在時でも退避動作で生成が完了する
- [x] Agent / Command の列挙が実ファイルシステムと一致する（Glob 結果と照合済み）
- [ ] CI (PowerShell lint / Pester / Dependabot / gitleaks) 通過
- [ ] 将来: #100 実装後に STABLE 成立で自動更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロジェクト固有のオンボーディングドキュメント（ONBOARDING.md）を自動生成
  * リポジトリ設定から動的にプロジェクト適応型ガイダンスを生成

* **ドキュメント**
  * 利用可能なエージェントとコマンドをONBOARDING.mdに自動リスト化
  * セッション開始手順とGit履歴情報を集約

<!-- end of auto-generated comment: release notes by coderabbit.ai -->