### PR TITLE
feat(loops): Improve ループに Stop-Doing 点検を追加 (Issue #103)

### DIFF
--- a/.claude/claudeos/loops/improve-loop.md
+++ b/.claude/claudeos/loops/improve-loop.md
@@ -27,6 +27,7 @@
 - リファクタリング
 - ドキュメント更新
 - テスト改善
+- **Stop-Doing Check (期日到来時のみ)** — 下記セクション参照
 
 ---
 
@@ -46,3 +47,78 @@
 ## 5h Rule
 
 - 改善内容を記録
+
+---
+
+## Stop-Doing Check（四半期点検）
+
+モデル進化により不要になったルール・フック・スクリプトを検出して削減候補を Issue 化する。
+Improve ループ開始時に以下を **常に先頭で** 判定する。期日未到来ならスキップし、
+通常の Improve 作業へ進む。
+
+### 発火条件
+
+`state.json.improvement.stop_doing_review_date` を読み取り、現在日付（UTC）がこの日付
+以降であれば点検を発火する。
+
+state.json が存在しない場合、または `improvement` ブロックが欠損している場合は
+**点検を実行しない**（初回は手動初期化または Issue #105 の棚卸し結果で設定する）。
+
+### 実行手順（発火時）
+
+点検フェーズは以下の tool 起動命令列で実行する:
+
+1. **使用履歴収集**（並列可）:
+   ```
+   Bash("git log --since=90.days.ago --name-only --pretty=format: | sort -u > /tmp/recent-touched.txt")
+   Glob(".claude/claudeos/agents/**/*.md")
+   Glob(".claude/claudeos/skills/**/*.md")
+   Glob(".claude/claudeos/commands/*.md")
+   Glob(".claude/claudeos/hooks/*.md")
+   Read("./state.json")  # learning.usage_history があれば使用
+   ```
+
+2. **分類**（各項目を以下のいずれかに割り当て）:
+
+   | 分類 | 条件 | 対応 |
+   |---|---|---|
+   | A. 90 日以上未呼び出し | `state.json.learning.usage_history[name].last_invoked < today - 90d` | 削除候補 |
+   | B. git blame で 30 日以内 | ファイル作成から 30 日未満 | 猶予期間として除外 |
+   | C. `seasonal: true` | フロントマターに明示 | 期間限定として除外 |
+   | D. 現モデルで代替可能 | Claude の自己評価（description から判定） | 削除候補（要議論） |
+
+3. **Issue 起票**: 分類 A + D の各項目について、以下を含む Issue を 1 件起票:
+   - 項目名とパス
+   - 追加された背景（`git blame` + `git log` で追加 PR を特定）
+   - 過去 90 日の呼び出し回数（`usage_history` から）
+   - 削除候補の根拠（分類 A なら使用実態なし、D なら Claude 内在知識で代替可能）
+   - ラベル: `stale-candidate`
+
+4. **state.json 更新**:
+   ```
+   state.json.improvement.stop_doing_last_run = today
+   state.json.improvement.stop_doing_review_date = today + interval_days
+   state.json.improvement.stop_doing_candidates_found = <Issue 件数>
+   ```
+
+### 誤検出防止
+
+- `learning.usage_history` が未存在または 30 日未満のデータしかない場合は、
+  分類 A の判定を無効化する（データ不足）
+- 分類 D の判定には低信頼度フラグを付け、Issue 本文に「Claude 自己評価による推定」
+  と明記する
+- 同一項目への再起票を避けるため、既存 `stale-candidate` Issue が open な場合は
+  スキップ
+
+### 運用コスト抑制
+
+- 点検自体が Improve ループの 20% を超えないよう、候補数が 50 件を超えた場合は
+  上位 10 件のみ Issue 化し、残りは次回に繰越
+- state.json が欠損したセッションでは一切実行しない（無害化）
+
+### 参考
+
+- Anthropic: [Harnessing Claude's Intelligence](https://claude.com/blog/harnessing-claudes-intelligence) パターン 2 "Ask what you can stop doing"
+- 関連 Issue: #108 (Dead weight 自動検出) — `learning.usage_history` の書き込み側を担当
+- 関連 Issue: #105 (カスタム Agent / Skill 棚卸し) — 初回の手動プロトタイプ
+- 関連 Issue: #109 (Frontier-Test 月次ループ) — より広範なモデル能力再評価の発展形

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,9 +108,18 @@ agents、skills、commands、rules、hooks、scripts、contexts、examples、mcp
   "automation": {
     "auto_issue_generation": true,
     "self_evolution": true
+  },
+  "improvement": {
+    "stop_doing_review_date": "2026-07-14",
+    "stop_doing_review_interval_days": 90,
+    "stop_doing_last_run": null,
+    "stop_doing_candidates_found": 0
   }
 }
 ```
+
+`improvement.stop_doing_review_date` は次回の Stop-Doing 点検期日（ISO 8601 日付）。
+`interval_days` は四半期点検を想定した 90 日。Improve ループが期日到来を検出すると点検が発火する。
 
 ## 5. 運用ループ
 
@@ -121,7 +130,7 @@ agents、skills、commands、rules、hooks、scripts、contexts、examples、mcp
 | Monitor | 30min | 要件・設計・README 差分確認、Git/CI 状態確認、タスク分解 | 実装・修復 |
 | Build | 2h | 設計メモ作成、実装、テスト追加、WorkTree 管理 | ついでの大規模整理、main 直接 push |
 | Verify | 1h15m | test / lint / build / security / CodeRabbit 確認、STABLE 判定 | 未テストの merge |
-| Improve | 1h15m | 命名整理、リファクタリング、README / docs 更新、再開メモ | 破壊的変更の無断実行 |
+| Improve | 1h15m | 命名整理、リファクタリング、README / docs 更新、再開メモ、**Stop-Doing 点検（期日到来時のみ）** | 破壊的変更の無断実行 |
 
 失敗時: `Verify → CI Manager → Auto Repair → 再 Verify`
 
@@ -143,6 +152,17 @@ agents、skills、commands、rules、hooks、scripts、contexts、examples、mcp
 - 厳密な時間切替より、フェーズ完了時の切替を優先
 - 小変更なら `Monitor → Build → Verify` だけでもよい
 - 大変更のときだけ `Improve` と Agent Teams を厚く使う
+
+### Improve ループの Stop-Doing 点検（四半期）
+
+Improve ループ実行時に `state.json.improvement.stop_doing_review_date` を確認し、
+期日到来時のみ **Stop-Doing 点検** を自動実行する。これは「モデル進化で不要になった
+ルール・フック・スクリプト」を定期棚卸しして削減候補 Issue を起票する仕組み。
+
+発火条件と手順は `.claude/claudeos/loops/improve-loop.md` の「Stop-Doing Check」
+セクションを参照。期日未到来時は通常の Improve 作業のみ実施し、点検はスキップする。
+
+参考: Anthropic「Harnessing Claude's Intelligence」パターン 2 "Ask what you can stop doing"。
 
 ### 完全無人ループフロー
 


### PR DESCRIPTION
## Summary

Anthropic「Harnessing Claude's Intelligence」パターン 2 "Ask what you can stop doing" を ClaudeOS v8 に組み込む。Improve ループに四半期単位の Stop-Doing 点検を追加し、モデル進化で不要になったルール・フック・スクリプトを自動で棚卸しする。

## 変更内容

### `CLAUDE.md`

- §4 state.json 構造に `improvement` ブロックを追加（`stop_doing_review_date` / `stop_doing_review_interval_days` / `stop_doing_last_run` / `stop_doing_candidates_found`）
- §5 Improve ループの責務欄に「**Stop-Doing 点検（期日到来時のみ）**」を追加
- §5 に「実運用のコツ」の後続として Stop-Doing 点検の概要セクションを追加

### `.claude/claudeos/loops/improve-loop.md`

既存構造を保持したまま、末尾に「Stop-Doing Check（四半期点検）」セクションを展開。発火条件・実行手順（4 段階）・誤検出防止・運用コスト抑制・関連 Issue 参照を網羅。

## 設計判断

### なぜ Improve ループに組み込んだか

Stop-Doing は「作業を減らす」性質上、Development / Verify とは責務が異なる。Improve ループが整理・改善を担うため自然な帰属先。

### なぜ期日管理方式（90 日周期）か

常時実行ではセッションコストが過大。四半期周期はモデルアップデートの典型サイクルとも整合する。`state.json.improvement.stop_doing_review_date` を読んで期日判定し、未到来ならスキップする構造で、無駄な実行を防ぐ。

### state.json 欠損時の無害化

state.json や `improvement` ブロックが存在しない場合は点検を **実行しない**。新規プロジェクトや初期化前のセッションで誤作動しないよう、defensive に設計。

### 関連 Issue との役割分担

| Issue | 役割 |
|---|---|
| **#103（本 PR）** | Stop-Doing 点検の **実行側** |
| #108 | `learning.usage_history` の **書き込み側**（本点検のデータ源） |
| #105 | 初回の **手動棚卸しプロトタイプ**（本点検の前身） |
| #109 | より広範な **Frontier-Test**（本点検の発展形） |

#108 が先行実装されると本点検の精度が大幅に向上する。#103 は #108 未実装でも手動 `usage_history` 付与で部分機能する。

## Test plan

- [x] CLAUDE.md §4 の state.json 構造に `improvement` ブロックが追加されている
- [x] CLAUDE.md §5 の Improve ループ責務欄に Stop-Doing 点検が記載されている
- [x] `improve-loop.md` に「Stop-Doing Check」セクションが追加され、既存構造は維持されている
- [x] state.json 欠損時に無害化される設計になっている
- [x] 関連 Issue（#105 / #108 / #109）が正しい番号で参照されている
- [ ] CI 通過
- [ ] 将来: state.json 実体生成後に期日到来シミュレーションで発火することを確認

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Improve ループに定期的な「Stop-Doing 点検」機能を追加。設定された日付に自動的に実行され、不要な項目を分類・検証します。四半期ごとのレビュープロセスが自動化されました。

* **ドキュメント**
  * `state.json` の設定構造を更新し、Stop-Doing レビュー日程・間隔・実行履歴の追跡機能を記載。Improve ループの新しい責務を明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->