### PR TITLE
feat(automation): Dead-Weight 自動検出を実装 (Issue #108)

### DIFF
--- a/.claude/claudeos/hooks/hooks.json
+++ b/.claude/claudeos/hooks/hooks.json
@@ -15,6 +15,11 @@
     {
       "name": "capture-result",
       "description": "主要ツール結果を次の判断に使える形へ整理する"
+    },
+    {
+      "name": "usage-history-recorder",
+      "description": "Agent / Skill / Command / Hook の呼び出しを state.json.learning.usage_history に記録",
+      "matcher": "Agent|Skill|Task"
     }
   ],
   "Stop": [

--- a/.claude/claudeos/hooks/usage-history-recorder.md
+++ b/.claude/claudeos/hooks/usage-history-recorder.md
@@ -1,0 +1,128 @@
+# usage-history-recorder
+
+PostToolUse の通常フックとして起動する使用履歴記録器。
+Agent / Skill / Command / Task ツールの呼び出し後に、対象項目を
+`state.json.learning.usage_history` に記録する。
+
+本ファイルは静的なドキュメントではなく、**呼び出された Claude への命令書** である。
+Claude Code の hook システムがこのフックを起動したとき、以下の実行契約を順に処理し、
+副作用（state.json 更新）を完了してから戻ること。
+
+---
+
+## 位置づけ
+
+| 項目 | 値 |
+|---|---|
+| フック種別 | PostToolUse |
+| 対象ツール | `Agent` / `Skill` / `Task`（matcher: `Agent\|Skill\|Task`） |
+| 対象外 | `Bash` / `Read` / `Glob` / `Grep` / `Edit` / `Write`（汎用ツール、個別記録の意味が薄い） |
+| 副作用 | `state.json.learning.usage_history` の更新（唯一の書き込み箇所） |
+| 参照元 Issue | #108 |
+| 関連フック | `capture-result`（先に動作、無干渉） |
+| データ消費側 | `.claude/claudeos/loops/improve-loop.md` の Dead-Weight 検出セクション |
+
+---
+
+## 実行契約（呼び出された Claude はこの順で処理すること）
+
+### Step 1: 対象ツール判定
+
+入力の `tool_name` を確認する。
+
+- `Agent`: `subagent_type` を項目名として抽出（例: `feature-dev:code-architect`）
+- `Skill`: `skill` パラメータを項目名として抽出（例: `loop`, `commit`）
+- `Task`: `description` または `prompt` 先頭 50 文字を項目名として抽出（生成物からの抽出）
+- それ以外: 記録対象外、即座に終了
+
+### Step 2: state.json の読み取り
+
+```
+Read("./state.json")
+```
+
+- state.json が存在しない → **何もせず終了**（新規プロジェクトで誤作動しない）
+- `learning.usage_history` ブロックが欠損 → 空オブジェクトを想定して後続処理（初回書き込み）
+
+### Step 3: 該当カテゴリのエントリ更新
+
+項目名と現在時刻（ISO 8601 UTC）を使って、以下のロジックで更新:
+
+```
+category = Step 1 で判定したカテゴリ（agents / skills / commands / hooks）
+name = Step 1 で抽出した項目名
+
+if usage_history[category][name] が存在:
+  usage_history[category][name].last_invoked = now
+  usage_history[category][name].total_count += 1
+else:
+  usage_history[category][name] = {
+    "last_invoked": now,
+    "total_count": 1,
+    "seasonal": false,
+    "first_invoked": now
+  }
+```
+
+### Step 4: state.json の書き戻し
+
+```
+Write("./state.json", 更新後の JSON 文字列)
+```
+
+書き戻し前に以下を検証:
+- JSON として valid か（parse エラーなら abort）
+- `learning.usage_history` 以外のブロックが破壊されていないか（diff 確認）
+
+### Step 5: 書き戻し失敗時の挙動
+
+- 書き込みエラー → 標準エラーにログ出力のみ（セッション継続）
+- 連続 3 回失敗 → state.json が破損している可能性、フックを一時無効化する旨を警告
+
+---
+
+## 猶予期間と seasonal フラグ
+
+### 猶予期間（grace period）
+
+新規項目は初回記録時に `first_invoked = now` が付与される。Dead-Weight 検出側は
+`state.json.learning.dead_weight.grace_period_days`（既定 30 日）以内の項目を
+検出対象から除外する。本フックは記録のみを担当し、grace period の判定はしない。
+
+### seasonal フラグ
+
+項目のフロントマター（Agent / Skill / Command の `.md` ファイル先頭）に
+`seasonal: true` が明示されている場合、本フックは `usage_history` 更新時に
+`seasonal: true` を付与する。Dead-Weight 検出側はこのフラグが立った項目を
+常に対象外とする（期間限定タスク用のため）。
+
+---
+
+## レート制限
+
+PostToolUse フックは頻繁に発火するため、過剰な state.json 書き込みを避ける:
+
+- 直近 10 秒以内に同一項目を記録した場合、`total_count` のみ加算し `last_invoked`
+  は更新しない（書き込み衝突回避）
+- セッション終了時（Stop フック）に集計した差分をまとめて書き込む方針も選択肢
+  （将来の最適化候補、本フック初版ではシンプルに即時書き込み）
+
+---
+
+## 想定される誤作動と対策
+
+| 誤作動 | 対策 |
+|---|---|
+| state.json が他プロセスと競合 | Write 前に `Read` で最新を取得し merge |
+| 項目名に特殊文字（JSON キーとして不正） | `name.replace(/[^\w\-:]/g, "_")` で sanitize |
+| total_count が整数オーバーフロー | JS Number として 2^53 未満に収まる想定、現実的には問題なし |
+| frontmatter の `seasonal` 読み取り失敗 | デフォルト false として扱う |
+
+---
+
+## 参考
+
+- Issue #108（本フックの実装対象）
+- Issue #103（Stop-Doing 点検 — 本フックが記録したデータを利用する側）
+- `.claude/claudeos/loops/improve-loop.md` の Dead-Weight Detection セクション
+- Anthropic ブログ: [Harnessing Claude's Intelligence](https://claude.com/blog/harnessing-claudes-intelligence) パターン 2 "Ask what you can stop doing"

--- a/.claude/claudeos/loops/improve-loop.md
+++ b/.claude/claudeos/loops/improve-loop.md
@@ -122,3 +122,109 @@ state.json が存在しない場合、または `improvement` ブロックが欠
 - 関連 Issue: #108 (Dead weight 自動検出) — `learning.usage_history` の書き込み側を担当
 - 関連 Issue: #105 (カスタム Agent / Skill 棚卸し) — 初回の手動プロトタイプ
 - 関連 Issue: #109 (Frontier-Test 月次ループ) — より広範なモデル能力再評価の発展形
+
+---
+
+## Dead-Weight Detection（日次・軽量）
+
+Stop-Doing Check が四半期の広範棚卸しなのに対し、Dead-Weight Detection は
+**毎 Improve ループでの軽量スキャン**。`learning.usage_history` を読んで
+未使用項目を自動抽出し、閾値到達で Issue 化する。
+
+### 前提データ
+
+`.claude/claudeos/hooks/usage-history-recorder.md` の PostToolUse フックが
+稼働していることが前提。このフックは Agent / Skill / Task 呼び出しのたびに
+`state.json.learning.usage_history` を更新する。
+
+フックが未稼働 / state.json が欠損している場合、**Dead-Weight Detection は
+スキップ**（無害化）。
+
+### 発火条件
+
+以下をすべて満たした場合に実行:
+
+1. `state.json.learning.usage_history` が存在し、少なくとも 1 カテゴリに 30 日以上
+   のデータが蓄積されている
+2. `state.json.learning.dead_weight.last_detection_run` が現在時刻 - 24 時間 より古い
+   （1 日 1 回まで）
+3. Improve ループの持ち時間に 10 分以上の余裕がある
+
+いずれかを満たさない場合はスキップ。
+
+### 実行手順
+
+1. **候補抽出**（並列可）:
+   ```
+   Read("./state.json")
+   Glob(".claude/claudeos/agents/**/*.md")
+   Glob(".claude/claudeos/skills/**/*.md")
+   Glob(".claude/claudeos/commands/*.md")
+   Glob(".claude/claudeos/hooks/*.md")
+   ```
+
+2. **判定ロジック**:
+   ```
+   stale_threshold = state.json.learning.dead_weight.stale_threshold_days (既定 90)
+   grace_period = state.json.learning.dead_weight.grace_period_days (既定 30)
+
+   for each file in Glob 結果:
+     name = ファイル名から拡張子を除いたもの
+     category = ファイルが属するディレクトリ（agents/skills/commands/hooks）
+     entry = state.json.learning.usage_history[category][name]
+
+     if entry is None:
+       # 記録なし → 2 パターン考えられる
+       if ファイルの git log 追加日時 < now - grace_period:
+         → 候補（"記録なし + 猶予期間外"）
+       else:
+         → 除外（"猶予期間内の新規項目"）
+
+     elif entry.seasonal == True:
+       → 除外（seasonal フラグ付き）
+
+     elif entry.last_invoked < now - stale_threshold:
+       → 候補（"閾値超過未使用"）
+
+     else:
+       → 除外（活性項目）
+   ```
+
+3. **Issue 起票前のフィルタ**:
+   - 既に `stale-candidate` ラベル付きの open Issue が該当項目に対して存在するなら除外
+   - `candidates_pending_issue` 配列に既に登録済みのものは除外
+   - 検出件数が 50 件超過なら上位 10 件のみ起票、残りは `candidates_pending_issue` に
+     繰越
+
+4. **Issue 起票**（最大 10 件）:
+   各候補について以下を含む Issue を 1 件起票:
+   - ラベル: `stale-candidate`
+   - タイトル: `chore: Dead-Weight 候補: {category}/{name} の存廃検討`
+   - 本文: 追加日、最終使用、total_count、grace period 適用状況、判定根拠
+
+5. **state.json 更新**:
+   ```
+   state.json.learning.dead_weight.last_detection_run = now
+   state.json.learning.dead_weight.candidates_pending_issue = 繰越リスト
+   ```
+
+### 誤検出防止
+
+- 判定は read-only ツール（Read / Glob / Grep）の使用状況は考慮しない
+- `learning.usage_history` の記録が 30 日未満しかない場合は実行しない（データ不足）
+- Frontier-Test（Issue #109）のような将来ループで「自動発火だが手動承認待ち」状態に
+  するため、Issue はあくまで候補であり自動削除は行わない
+
+### Stop-Doing Check との役割分担
+
+| 項目 | Stop-Doing Check | Dead-Weight Detection |
+|---|---|---|
+| 発火頻度 | 四半期 (90 日) | 日次（Improve ループごと） |
+| 粒度 | 広範棚卸し（A/B/C/D 4 分類） | 使用実態のみ（閾値超過 or 記録なし） |
+| データ源 | git log / 手動判定 + usage_history | usage_history 専用 |
+| 判定コスト | 高（Claude 自己評価を含む） | 低（期日と閾値のみ） |
+| 誤検出リスク | 中（Claude 判定が入る） | 低（数値比較のみ） |
+
+両者は共存する。Stop-Doing Check は「モデル進化で不要になったもの」を広く拾う
+網であり、Dead-Weight Detection は「日々の使用状況から機械的に拾える低コスト網」。
+片方で漏れたものを他方で拾える設計。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,12 +114,34 @@ agents、skills、commands、rules、hooks、scripts、contexts、examples、mcp
     "stop_doing_review_interval_days": 90,
     "stop_doing_last_run": null,
     "stop_doing_candidates_found": 0
+  },
+  "learning": {
+    "usage_history": {
+      "agents": {},
+      "skills": {},
+      "commands": {},
+      "hooks": {}
+    },
+    "dead_weight": {
+      "stale_threshold_days": 90,
+      "grace_period_days": 30,
+      "last_detection_run": null,
+      "candidates_pending_issue": []
+    }
   }
 }
 ```
 
 `improvement.stop_doing_review_date` は次回の Stop-Doing 点検期日（ISO 8601 日付）。
 `interval_days` は四半期点検を想定した 90 日。Improve ループが期日到来を検出すると点検が発火する。
+
+`learning.usage_history` は各カテゴリ別（Agent / Skill / Command / Hook）の使用履歴辞書。
+キーは項目名、値は `{ "last_invoked": ISO8601, "total_count": N, "seasonal": bool }` 形式。
+PostToolUse の `usage-history-recorder` フックがこのブロックを更新する。
+
+`learning.dead_weight` は Dead-Weight 検出の設定。`stale_threshold_days` を超えて
+未呼び出しの項目が検出対象。`grace_period_days` は新規追加項目の猶予期間。
+`candidates_pending_issue` は次回 Issue 化待ちの候補リスト。
 
 ## 5. 運用ループ
 


### PR DESCRIPTION
## Summary

Anthropic「Harnessing Claude's Intelligence」パターン 2 "Ask what you can stop doing" の日次実装。#103 Stop-Doing Check（四半期）の姉妹機能として、日々の使用実態から機械的に Dead-Weight を拾う仕組みを追加する。

## 変更内容

### `CLAUDE.md` §4 state.json 構造

- `learning.usage_history`: Agent / Skill / Command / Hook の使用履歴辞書
  - キー=項目名、値=`{ last_invoked, total_count, seasonal, first_invoked }`
- `learning.dead_weight`: 検出設定
  - `stale_threshold_days` (既定 90)
  - `grace_period_days` (既定 30)
  - `last_detection_run` / `candidates_pending_issue`

### `.claude/claudeos/hooks/usage-history-recorder.md` (新規)

PostToolUse フック実体として以下を命令列で定義:

- 対象ツール: `Agent` / `Skill` / `Task`（matcher: `Agent\|Skill\|Task`）
- 対象外: `Bash` / `Read` / `Glob` / `Grep` / `Edit` / `Write`（汎用ツールで個別記録の意味が薄い）
- Step 1-5 の実行契約: ツール判定 → state.json 読取 → エントリ更新 → 書き戻し → 失敗時挙動
- レート制限（直近 10 秒以内の同一項目は `total_count` のみ加算）
- state.json 欠損時は no-op（新規プロジェクトで誤作動しない）
- 猶予期間と seasonal フラグの取り扱い明文化

### `.claude/claudeos/hooks/hooks.json`

PostToolUse に `usage-history-recorder` エントリ追加。既存 `capture-result` は保持し、新規フックは matcher で対象限定。

### `.claude/claudeos/loops/improve-loop.md`

末尾に「Dead-Weight Detection（日次・軽量）」セクションを展開:

- 発火条件: usage_history 30 日以上蓄積 + 前回実行から 24h 経過 + ループ余裕 10 分以上
- 実行手順 5 段階: 候補抽出 → 判定ロジック → フィルタ → Issue 起票（最大 10 件） → state.json 更新
- Stop-Doing Check との役割分担を表形式で明示

## 設計判断

### なぜ Stop-Doing と Dead-Weight を分離したか

| 項目 | Stop-Doing Check (#103) | Dead-Weight Detection (本 PR) |
|---|---|---|
| 頻度 | 四半期（90 日） | 日次 |
| 粒度 | 広範棚卸し（A/B/C/D 4 分類） | 閾値超過 or 記録なしのみ |
| コスト | 高（Claude 自己評価含む） | 低（数値比較のみ） |

異なる性質の Dead Weight を異なる頻度で拾うため、共存させる設計。

### なぜ matcher を `Agent\|Skill\|Task` に限定したか

`Bash` / `Read` / `Glob` / `Grep` / `Edit` / `Write` は汎用ツールで、個別記録の意味が薄い（例: `git status` を 10 回呼んだからといって「活性」判定するのは誤り）。`Agent` / `Skill` / `Task` は明示的な呼び出しで、使用実態の強い信号になる。

### なぜ書き戻し失敗を警告のみにしたか

PostToolUse フックはツール実行の副産物であり、このフック自体の失敗でセッションを止めるのは不適切。state.json 破損時は警告のみ出し、検出ロジック側で「データ不足なら skip」の defensive 設計で対応。

### #103 との疎結合

Dead-Weight Detection は `usage_history` を読むだけ。#103 Stop-Doing Check も同じデータを読むが、両者は独立して動作する。片方が未稼働でも他方は機能する設計で、段階的導入を可能にしている。

## Test plan

- [x] CLAUDE.md §4 に `learning.usage_history` と `learning.dead_weight` が追加されている
- [x] `usage-history-recorder.md` が PostToolUse フック実体として命令列で記述されている
- [x] hooks.json に新規エントリが追加され、既存エントリが保持されている
- [x] improve-loop.md に Dead-Weight Detection セクションが追加されている
- [x] state.json 欠損時の無害化が明記されている
- [x] Stop-Doing (#103) と疎結合であり、どちらが先でも動作する
- [ ] CI 通過
- [ ] 将来: 実 state.json 生成後にフック発火でエントリが増えることを確認

Closes #108

## 次のステップ

本 PR merge 後の推奨順:

1. **#105 (P2)**: 初回手動棚卸し — 今回実装した usage_history の初期データ投入を兼ねる
2. **#107 (P2)**: キャッシング breakpoint — 独立・低コスト
3. **#106 (P2)**: Progressive disclosure — 本 PR と state.json スキーマ拡張の続編
4. **#109 (P3)**: Frontier-Test 月次ループ — #103/#108 が揃った上での発展形

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ツール使用履歴の自動追跡機能を追加しました。エージェント、スキル、タスクなどの呼び出し履歴が記録されるようになります。
  * 未使用ツールの自動検出機能を実装しました。定期的に使用状況を分析し、不要になった要素を特定します。

* **ドキュメント**
  * 学習・改善機能の状態管理に関する新しいスキーマ情報を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->