### PR TITLE
fix(loops): improve-loop に Stop-Doing トリガー参照を復元

### DIFF
--- a/.claude/claudeos/loops/improve-loop.md
+++ b/.claude/claudeos/loops/improve-loop.md
@@ -43,6 +43,28 @@
 
 ---
 
+## Stop-Doing Check（四半期点検）
+
+Improve ループ開始時に以下を **先頭で** 判定する。期日未到来ならスキップ。
+
+### 発火条件
+
+```
+state.json.improvement.stop_doing_review_date <= today
+```
+
+state.json が存在しない、または `improvement` ブロックが欠損している場合は **点検しない**。
+
+### 実行手順（発火時のみ）
+
+1. `git log --since=90.days.ago --name-only` で最近触れたファイルを列挙
+2. `.claude/claudeos/` 配下の agents / skills / commands / hooks を Glob
+3. `state.json.learning.usage_history` の呼び出し履歴と照合
+4. 90 日以上未使用 + 猶予期間外の項目を `stale-candidate` として Issue 起票
+5. 点検完了後 `state.json.improvement.stop_doing_review_date` を `+90d` に更新
+
+---
+
 ## 5h Rule
 
 - 改善内容を記録


### PR DESCRIPTION
## Summary
- `f0e44ea` の refactor で `improve-loop.md` から Stop-Doing Check セクションが全削除され、`state.json.improvement.stop_doing_review_date` を参照する命令が存在しない Dead State になっていた
- 簡潔なトリガー参照（22 行）を復元し、Improve ループが四半期点検を適切に発火できるよう修正

## 変更内容

| ファイル | 変更 |
|---|---|
| `.claude/claudeos/loops/improve-loop.md` | Stop-Doing Check セクション（発火条件 + 手順）を 22 行で復元 |

## 根本原因

`f0e44ea` のコミットメッセージ「実装側（フック・ループ）への一元化」で削除が実施されたが、
実際には Stop-Doing の「実装」は improve-loop.md の命令テキスト自体であり、
独立したフックや実行スクリプトへの移管は行われていなかった。

## テスト結果

- 変更ファイル: improve-loop.md のみ（ドキュメント修正）
- CI 対象外（markdown のみ）
- 手動確認: 発火条件・実行手順が state.json の `improvement` ブロックと整合

## 影響範囲

- Improve ループの Stop-Doing Check 発火（次回 2026-07-15 以降）
- 実装動作への影響なし（ドキュメント追加のみ）

## 残課題

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * 改善ループプロセスに「Stop-Doing Check（四半期点検）」セクションを追加しました。定期的に90日以上使用されていないコンポーネントを特定し、管理するための新しい点検プロセスが文書化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->