### PR TITLE
fix(lint): PSAvoidUsingEmptyCatchBlock 7件を修正 (closes #130)

### DIFF
--- a/scripts/lib/AgentTeams.psm1
+++ b/scripts/lib/AgentTeams.psm1
@@ -152,7 +152,7 @@ function Get-BacklogRuleMatch {
         }
     }
     catch {
-        # rules file parse error - use defaults
+        Write-Debug "Agent rules file parse error (using defaults): $_"
     }
 
     return $result

--- a/scripts/lib/LauncherCommon.psm1
+++ b/scripts/lib/LauncherCommon.psm1
@@ -821,6 +821,7 @@ function Get-LauncherMetadataEntries {
                 $entries.Add(($line | ConvertFrom-Json))
             }
             catch {
+                Write-Debug "Skipping malformed JSON history entry: $_"
             }
             if ($entries.Count -ge $MaxCount) {
                 break
@@ -1321,12 +1322,13 @@ public class LauncherWinMM {
             $localAlias = $alias
             $null = [System.Threading.Tasks.Task]::Run([Action]{
                 Start-Sleep -Milliseconds 8000
-                try { [void][LauncherWinMM]::mciSendString("close $localAlias", $null, 0, [IntPtr]::Zero) } catch {}
+                try { [void][LauncherWinMM]::mciSendString("close $localAlias", $null, 0, [IntPtr]::Zero) } catch { Write-Debug "Audio close failed for '$localAlias': $_" }
             })
         }
     }
     catch {
         # 音声再生の失敗はサイレントに無視（起動をブロックしない）
+        Write-Debug "Audio playback failed (suppressed to avoid blocking startup): $_"
     }
 }
 Export-ModuleMember -Function Invoke-LauncherNotificationSound

--- a/scripts/lib/LogManager.psm1
+++ b/scripts/lib/LogManager.psm1
@@ -76,7 +76,7 @@ function Stop-SessionLog {
     }
 
     # Transcript 停止
-    try { Stop-Transcript -ErrorAction SilentlyContinue } catch { }
+    try { Stop-Transcript -ErrorAction SilentlyContinue } catch { Write-Debug "Stop-Transcript skipped (no active transcript): $_" }
 
     $script:LoggingActive = $false
 

--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -421,7 +421,7 @@ finally {
     Invoke-LauncherNotificationSound -Tool 'claude' -Config $Config -Wait $true
     # インスタンスロック解放
     if ($null -ne $instanceMutex) {
-        try { $instanceMutex.ReleaseMutex() } catch { }
+        try { $instanceMutex.ReleaseMutex() } catch { Write-Debug "ReleaseMutex failed (mutex may already be released): $_" }
         $instanceMutex.Dispose()
     }
 }

--- a/scripts/test/Test-AllTools.ps1
+++ b/scripts/test/Test-AllTools.ps1
@@ -40,6 +40,7 @@ function Get-CommandVersionLine {
         }
     }
     catch {
+        Write-Debug "Version detection failed for '$Command': $_"
     }
 
     return $null


### PR DESCRIPTION
## Summary
- PSScriptAnalyzer の `PSAvoidUsingEmptyCatchBlock` 7件（5ファイル）を修正
- 空 catch に `Write-Debug` を追加し、通常動作を変えずに警告を解消

## 変更ファイル

| ファイル | 行 | 対応内容 |
|---|---|---|
| `scripts/lib/AgentTeams.psm1` | 154 | rules 解析失敗 → `Write-Debug` |
| `scripts/lib/LogManager.psm1` | 79 | Stop-Transcript 失敗 → `Write-Debug` |
| `scripts/lib/LauncherCommon.psm1` | 823 | JSON 不正行スキップ → `Write-Debug` |
| `scripts/lib/LauncherCommon.psm1` | 1324 | 音声クローズ失敗 → `Write-Debug` |
| `scripts/lib/LauncherCommon.psm1` | 1329 | 音声再生失敗 → `Write-Debug` |
| `scripts/main/Start-ClaudeCode.ps1` | 424 | Mutex 解放失敗 → `Write-Debug` |
| `scripts/test/Test-AllTools.ps1` | 42 | バージョン取得失敗 → `Write-Debug` |

## Test plan
- [x] PSScriptAnalyzer `PSAvoidUsingEmptyCatchBlock`: 0件
- [x] PSScriptAnalyzer Error severity: 0件
- [x] Pester 449/449 pass

## 設計判断
`Write-Debug` を採用した理由: `-Debug` フラグ使用時のみ出力され、通常実行では完全にサイレント。`Write-Error` や `throw` は意図的な握り潰し（Mutex 解放失敗・音声失敗等）に不適切。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **デバッグ機能**
  * スクリプト実行時のエラー処理をより詳細に記録するようにしました。JSONパース、メタデータ処理、オーディオ再生、トランスクリプト管理などで発生したエラーについて、デバッグログにて詳細情報が出力されるようになり、問題診断がしやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->