### PR TITLE
feat(message-bus): Message Bus Phase 1 実装 (closes #127)

### DIFF
--- a/scripts/lib/MessageBus.psm1
+++ b/scripts/lib/MessageBus.psm1
@@ -1,0 +1,434 @@
+# ============================================================
+# MessageBus.psm1 - Agent Message Bus (Phase 1)
+# ClaudeCLI-CodexCLI-CopilotCLI-StartUpTools v3.1.0
+# Issue #127 — state.json 拡張による非同期メッセージ交換
+#
+# Phase 1 対象トピック:
+#   - phase.transition  : フェーズ切替通知 (Orchestrator → 全 Agent)
+#   - ci.status         : CI 結果通知 (DevOps → Orchestrator, QA)
+# ============================================================
+
+Set-StrictMode -Version Latest
+
+# --- 定数 ---
+$script:DefaultStatePath = 'state.json'
+$script:MaxMessagesPerTopic = 10
+
+# Phase 1 で許可するトピック一覧
+$script:AllowedTopics = @(
+    'phase.transition',
+    'ci.status'
+)
+
+# --- 内部ヘルパー ---
+
+function Get-StateFilePath {
+    param([string]$RepoRoot)
+    if (-not $RepoRoot) {
+        $root = git rev-parse --show-toplevel 2>$null
+        $RepoRoot = if ($root) { $root } else { '.' }
+    }
+    return Join-Path $RepoRoot $script:DefaultStatePath
+}
+
+function Read-StateJson {
+    param([string]$StatePath)
+    if (-not (Test-Path $StatePath)) {
+        throw "state.json が見つかりません: $StatePath"
+    }
+    $raw = Get-Content -Path $StatePath -Raw -Encoding UTF8
+    return $raw | ConvertFrom-Json
+}
+
+function Write-StateJson {
+    param(
+        [string]$StatePath,
+        [psobject]$State
+    )
+    $json = $State | ConvertTo-Json -Depth 10 -Compress:$false
+    Set-Content -Path $StatePath -Value $json -Encoding UTF8 -NoNewline
+}
+
+function New-BusSection {
+    <#
+    .SYNOPSIS
+        message_bus セクションの初期値を返す。
+    #>
+    $bus = [ordered]@{}
+    foreach ($topic in $script:AllowedTopics) {
+        $bus[$topic] = @()
+    }
+    return [pscustomobject]$bus
+}
+
+function Assert-TopicAllowed {
+    param([string]$Topic)
+    if ($Topic -notin $script:AllowedTopics) {
+        throw "未対応トピック '$Topic'。Phase 1 で利用可能なトピック: $($script:AllowedTopics -join ', ')"
+    }
+}
+
+function New-MessageId {
+    $timestamp = Get-Date -Format 'yyyyMMddHHmmss'
+    $random    = -join ((65..90) + (97..122) | Get-Random -Count 4 | ForEach-Object { [char]$_ })
+    return "msg-$timestamp-$random"
+}
+
+# --- 公開関数 ---
+
+function Publish-BusMessage {
+    <#
+    .SYNOPSIS
+        指定トピックにメッセージを publish する。
+
+    .DESCRIPTION
+        state.json の message_bus セクションに新しいメッセージを追加する。
+        各トピックの最大保持件数 (MaxMessagesPerTopic = 10) を超えた場合、
+        最古のメッセージを自動的に削除する。
+
+    .PARAMETER Topic
+        メッセージを publish するトピック名。
+        Phase 1 では 'phase.transition' または 'ci.status' のみ有効。
+
+    .PARAMETER Publisher
+        メッセージを送信する Agent 名 (例: "Orchestrator", "DevOps")。
+
+    .PARAMETER Payload
+        メッセージ本文。ハッシュテーブルまたは psobject で指定する。
+
+    .PARAMETER StatePath
+        state.json のパス。省略時は自動検出。
+
+    .OUTPUTS
+        発行したメッセージの ID 文字列を返す。
+
+    .EXAMPLE
+        Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+            -Payload @{ from = 'Monitor'; to = 'Development' }
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Topic,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Publisher,
+
+        [Parameter(Mandatory = $true)]
+        [psobject]$Payload,
+
+        [Parameter(Mandatory = $false)]
+        [string]$StatePath
+    )
+
+    Assert-TopicAllowed -Topic $Topic
+
+    if (-not $StatePath) { $StatePath = Get-StateFilePath }
+
+    $state = Read-StateJson -StatePath $StatePath
+
+    # message_bus セクションが存在しない場合は初期化
+    if (-not ($state.PSObject.Properties.Name -contains 'message_bus') -or
+        $null -eq $state.message_bus) {
+        $state | Add-Member -MemberType NoteProperty -Name 'message_bus' -Value (New-BusSection) -Force
+    }
+
+    $bus = $state.message_bus
+
+    # トピックキューが存在しない場合は初期化
+    if (-not ($bus.PSObject.Properties.Name -contains $Topic)) {
+        $bus | Add-Member -MemberType NoteProperty -Name $Topic -Value @() -Force
+    }
+
+    $msgId = New-MessageId
+
+    $newMessage = [pscustomobject]@{
+        id          = $msgId
+        timestamp   = (Get-Date -Format 'o')
+        publisher   = $Publisher
+        payload     = $Payload
+        consumed_by = @()
+    }
+
+    # 既存キューを配列として取得
+    $queue = @($bus.$Topic)
+    $queue += $newMessage
+
+    # 最大件数超過時に古いメッセージを削除
+    if ($queue.Count -gt $script:MaxMessagesPerTopic) {
+        $queue = $queue | Select-Object -Last $script:MaxMessagesPerTopic
+    }
+
+    $bus | Add-Member -MemberType NoteProperty -Name $Topic -Value $queue -Force
+
+    Write-StateJson -StatePath $StatePath -State $state
+
+    Write-Verbose "MessageBus: Published [$Topic] id=$msgId publisher=$Publisher"
+    return $msgId
+}
+
+function Get-BusMessages {
+    <#
+    .SYNOPSIS
+        指定トピックのメッセージ一覧を取得する。
+
+    .DESCRIPTION
+        state.json の message_bus セクションから指定トピックのメッセージを返す。
+        Consumer 名を指定した場合、そのエージェントがまだ consume していない
+        メッセージのみを返す (未読フィルタ)。
+
+    .PARAMETER Topic
+        取得するトピック名。
+
+    .PARAMETER Consumer
+        フィルタするエージェント名。省略時は全メッセージを返す。
+
+    .PARAMETER StatePath
+        state.json のパス。省略時は自動検出。
+
+    .OUTPUTS
+        メッセージオブジェクトの配列を返す。
+
+    .EXAMPLE
+        # Orchestrator が未読の phase.transition を取得
+        Get-BusMessages -Topic 'phase.transition' -Consumer 'Orchestrator'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Topic,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Consumer,
+
+        [Parameter(Mandatory = $false)]
+        [string]$StatePath
+    )
+
+    Assert-TopicAllowed -Topic $Topic
+
+    if (-not $StatePath) { $StatePath = Get-StateFilePath }
+
+    if (-not (Test-Path $StatePath)) {
+        return @()
+    }
+
+    $state = Read-StateJson -StatePath $StatePath
+
+    if (-not ($state.PSObject.Properties.Name -contains 'message_bus') -or
+        $null -eq $state.message_bus) {
+        return @()
+    }
+
+    $bus = $state.message_bus
+
+    if (-not ($bus.PSObject.Properties.Name -contains $Topic)) {
+        return @()
+    }
+
+    $messages = @($bus.$Topic)
+
+    if ($Consumer) {
+        $messages = $messages | Where-Object {
+            $consumed = @($_.consumed_by)
+            $Consumer -notin $consumed
+        }
+    }
+
+    return $messages
+}
+
+function Confirm-BusMessage {
+    <#
+    .SYNOPSIS
+        指定メッセージを Consumer として consume 済みにマークする。
+
+    .DESCRIPTION
+        state.json の当該メッセージの consumed_by 配列に Consumer 名を追加する。
+        既に consume 済みの場合は何もしない (冪等)。
+        全 Subscriber が consume 済みになったメッセージはそのまま保持される
+        (GC は Phase 2 で実装)。
+
+    .PARAMETER Topic
+        メッセージが属するトピック名。
+
+    .PARAMETER MessageId
+        consume する対象のメッセージ ID。
+
+    .PARAMETER Consumer
+        consume する Agent 名。
+
+    .PARAMETER StatePath
+        state.json のパス。省略時は自動検出。
+
+    .OUTPUTS
+        成功した場合は $true、メッセージが見つからない場合は $false を返す。
+
+    .EXAMPLE
+        Confirm-BusMessage -Topic 'ci.status' -MessageId 'msg-20260415123456-AbCd' `
+            -Consumer 'Orchestrator'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Topic,
+
+        [Parameter(Mandatory = $true)]
+        [string]$MessageId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Consumer,
+
+        [Parameter(Mandatory = $false)]
+        [string]$StatePath
+    )
+
+    Assert-TopicAllowed -Topic $Topic
+
+    if (-not $StatePath) { $StatePath = Get-StateFilePath }
+
+    $state = Read-StateJson -StatePath $StatePath
+
+    if (-not ($state.PSObject.Properties.Name -contains 'message_bus') -or
+        $null -eq $state.message_bus) {
+        return $false
+    }
+
+    $bus = $state.message_bus
+
+    if (-not ($bus.PSObject.Properties.Name -contains $Topic)) {
+        return $false
+    }
+
+    $found = $false
+    $updatedQueue = @($bus.$Topic) | ForEach-Object {
+        if ($_.id -eq $MessageId) {
+            $found = $true
+            $consumed = @($_.consumed_by)
+            if ($Consumer -notin $consumed) {
+                $consumed += $Consumer
+                $_ | Add-Member -MemberType NoteProperty -Name 'consumed_by' -Value $consumed -Force
+            }
+        }
+        $_
+    }
+
+    if (-not $found) {
+        Write-Verbose "MessageBus: Message '$MessageId' not found in topic '$Topic'"
+        return $false
+    }
+
+    $bus | Add-Member -MemberType NoteProperty -Name $Topic -Value $updatedQueue -Force
+
+    Write-StateJson -StatePath $StatePath -State $state
+
+    Write-Verbose "MessageBus: Confirmed [$Topic] id=$MessageId consumer=$Consumer"
+    return $true
+}
+
+function Get-BusStatus {
+    <#
+    .SYNOPSIS
+        Message Bus の現在状態サマリーを返す。
+
+    .DESCRIPTION
+        各トピックのメッセージ件数・未読件数を集計して表示する。
+        デバッグ・監視用途。
+
+    .PARAMETER StatePath
+        state.json のパス。省略時は自動検出。
+
+    .OUTPUTS
+        トピックごとのサマリーオブジェクト配列を返す。
+
+    .EXAMPLE
+        Get-BusStatus | Format-Table
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$StatePath
+    )
+
+    if (-not $StatePath) { $StatePath = Get-StateFilePath }
+
+    if (-not (Test-Path $StatePath)) {
+        Write-Warning "state.json が見つかりません: $StatePath"
+        return @()
+    }
+
+    $state = Read-StateJson -StatePath $StatePath
+
+    $results = foreach ($topic in $script:AllowedTopics) {
+        $count    = 0
+        $consumed = 0
+
+        if (($state.PSObject.Properties.Name -contains 'message_bus') -and
+            $null -ne $state.message_bus -and
+            ($state.message_bus.PSObject.Properties.Name -contains $topic)) {
+
+            $msgs  = @($state.message_bus.$topic)
+            $count = $msgs.Count
+            $consumed = @($msgs | Where-Object { @($_.consumed_by).Count -gt 0 }).Count
+        }
+
+        [pscustomobject]@{
+            Topic        = $topic
+            TotalMessages = $count
+            ConsumedCount = $consumed
+            PendingCount  = $count - $consumed
+        }
+    }
+
+    return $results
+}
+
+function Initialize-MessageBus {
+    <#
+    .SYNOPSIS
+        state.json に message_bus セクションを初期化する。
+
+    .DESCRIPTION
+        既に message_bus セクションが存在する場合は何もしない (冪等)。
+        state.json が存在しない場合はエラーを返す。
+
+    .PARAMETER StatePath
+        state.json のパス。省略時は自動検出。
+
+    .OUTPUTS
+        初期化された場合は $true、既存のため skip した場合は $false を返す。
+
+    .EXAMPLE
+        Initialize-MessageBus
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$StatePath
+    )
+
+    if (-not $StatePath) { $StatePath = Get-StateFilePath }
+
+    $state = Read-StateJson -StatePath $StatePath
+
+    if (($state.PSObject.Properties.Name -contains 'message_bus') -and
+        $null -ne $state.message_bus) {
+        Write-Verbose "MessageBus: message_bus セクションは既に存在します (skip)"
+        return $false
+    }
+
+    $state | Add-Member -MemberType NoteProperty -Name 'message_bus' -Value (New-BusSection) -Force
+
+    Write-StateJson -StatePath $StatePath -State $state
+
+    Write-Verbose "MessageBus: message_bus セクションを初期化しました"
+    return $true
+}
+
+Export-ModuleMember -Function @(
+    'Publish-BusMessage',
+    'Get-BusMessages',
+    'Confirm-BusMessage',
+    'Get-BusStatus',
+    'Initialize-MessageBus'
+)

--- a/tests/MessageBus.Tests.ps1
+++ b/tests/MessageBus.Tests.ps1
@@ -1,0 +1,320 @@
+# ============================================================
+# MessageBus.Tests.ps1 - MessageBus.psm1 のユニットテスト
+# Pester 5.x
+# Issue #127 — Message Bus Phase 1
+# ============================================================
+
+BeforeAll {
+    $script:RepoRoot  = Split-Path -Parent $PSScriptRoot
+    $script:ModulePath = Join-Path $script:RepoRoot 'scripts\lib\MessageBus.psm1'
+    Import-Module $script:ModulePath -Force
+
+    # --- ヘルパー: テスト用 state.json を TestDrive に作成 ---
+    function script:New-TestStateJson {
+        param([string]$Path, [hashtable]$ExtraProps = @{})
+        $state = [ordered]@{
+            goal      = @{ title = 'Test' }
+            execution = @{ phase = 'Monitor' }
+        }
+        foreach ($key in $ExtraProps.Keys) { $state[$key] = $ExtraProps[$key] }
+        $json = $state | ConvertTo-Json -Depth 10
+        Set-Content -Path $Path -Value $json -Encoding UTF8
+    }
+}
+
+Describe 'Initialize-MessageBus' {
+
+    Context 'message_bus セクションが存在しない場合' {
+
+        BeforeEach {
+            $script:StatePath = Join-Path $TestDrive 'state.json'
+            New-TestStateJson -Path $script:StatePath
+        }
+
+        It 'message_bus セクションを追加して $true を返す' {
+            $result = Initialize-MessageBus -StatePath $script:StatePath
+            $result | Should -Be $true
+        }
+
+        It '追加後の state.json に message_bus セクションが存在する' {
+            Initialize-MessageBus -StatePath $script:StatePath | Out-Null
+            $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+            $state.PSObject.Properties.Name | Should -Contain 'message_bus'
+        }
+
+        It 'phase.transition トピックが空配列で初期化される' {
+            Initialize-MessageBus -StatePath $script:StatePath | Out-Null
+            $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+            @($state.message_bus.'phase.transition') | Should -HaveCount 0
+        }
+
+        It 'ci.status トピックが空配列で初期化される' {
+            Initialize-MessageBus -StatePath $script:StatePath | Out-Null
+            $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+            @($state.message_bus.'ci.status') | Should -HaveCount 0
+        }
+    }
+
+    Context 'message_bus セクションが既に存在する場合' {
+
+        BeforeEach {
+            $script:StatePath = Join-Path $TestDrive 'state.json'
+            $existingBus = @{ 'phase.transition' = @(); 'ci.status' = @() }
+            New-TestStateJson -Path $script:StatePath -ExtraProps @{ message_bus = $existingBus }
+        }
+
+        It '$false を返す (冪等)' {
+            $result = Initialize-MessageBus -StatePath $script:StatePath
+            $result | Should -Be $false
+        }
+    }
+}
+
+Describe 'Publish-BusMessage' {
+
+    BeforeEach {
+        $script:StatePath = Join-Path $TestDrive 'state.json'
+        New-TestStateJson -Path $script:StatePath
+        Initialize-MessageBus -StatePath $script:StatePath | Out-Null
+    }
+
+    Context '正常系: phase.transition トピック' {
+
+        It 'メッセージ ID を返す' {
+            $id = Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+                -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath
+            $id | Should -Not -BeNullOrEmpty
+            $id | Should -Match '^msg-'
+        }
+
+        It 'state.json にメッセージが保存される' {
+            Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+                -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath | Out-Null
+            $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+            @($state.message_bus.'phase.transition') | Should -HaveCount 1
+        }
+
+        It 'publisher フィールドが正しく保存される' {
+            Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+                -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath | Out-Null
+            $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+            $msg = @($state.message_bus.'phase.transition')[0]
+            $msg.publisher | Should -Be 'Orchestrator'
+        }
+
+        It 'consumed_by が空配列で初期化される' {
+            Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+                -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath | Out-Null
+            $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+            $msg = @($state.message_bus.'phase.transition')[0]
+            @($msg.consumed_by) | Should -HaveCount 0
+        }
+
+        It 'timestamp が ISO8601 形式で保存される' {
+            Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+                -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath | Out-Null
+            $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+            $msg = @($state.message_bus.'phase.transition')[0]
+            # ConvertFrom-Json が ISO8601 文字列を DateTime 型に自動変換するため ToString('o') で戻す
+            $tsStr = if ($msg.timestamp -is [DateTime]) { $msg.timestamp.ToString('o') } else { [string]$msg.timestamp }
+            $tsStr | Should -Match '^\d{4}-\d{2}-\d{2}T'
+        }
+    }
+
+    Context '正常系: ci.status トピック' {
+
+        It 'ci.status にメッセージを publish できる' {
+            Publish-BusMessage -Topic 'ci.status' -Publisher 'DevOps' `
+                -Payload @{ status = 'pass'; run_id = '99999' } -StatePath $script:StatePath | Out-Null
+            $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+            @($state.message_bus.'ci.status') | Should -HaveCount 1
+        }
+    }
+
+    Context '上限制御: MaxMessagesPerTopic = 10' {
+
+        It '11件 publish すると最新 10 件のみ保持される' {
+            for ($i = 1; $i -le 11; $i++) {
+                Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+                    -Payload @{ seq = $i } -StatePath $script:StatePath | Out-Null
+            }
+            $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+            @($state.message_bus.'phase.transition') | Should -HaveCount 10
+        }
+
+        It '11件 publish 後、保持されるのは seq 2〜11 のメッセージ' {
+            for ($i = 1; $i -le 11; $i++) {
+                Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+                    -Payload @{ seq = $i } -StatePath $script:StatePath | Out-Null
+            }
+            $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+            $msgs = @($state.message_bus.'phase.transition')
+            $msgs[0].payload.seq | Should -Be 2
+            $msgs[-1].payload.seq | Should -Be 11
+        }
+    }
+
+    Context '異常系: 未対応トピック' {
+
+        It '未対応トピックを指定するとエラーになる' {
+            { Publish-BusMessage -Topic 'unknown.topic' -Publisher 'Orchestrator' `
+                -Payload @{} -StatePath $script:StatePath } | Should -Throw
+        }
+    }
+}
+
+Describe 'Get-BusMessages' {
+
+    BeforeEach {
+        $script:StatePath = Join-Path $TestDrive 'state.json'
+        New-TestStateJson -Path $script:StatePath
+        Initialize-MessageBus -StatePath $script:StatePath | Out-Null
+    }
+
+    Context 'Consumer 未指定 (全件取得)' {
+
+        It 'publish した件数分だけ返す' {
+            Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+                -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath | Out-Null
+            Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+                -Payload @{ from = 'Development'; to = 'Verify' } -StatePath $script:StatePath | Out-Null
+            $msgs = Get-BusMessages -Topic 'phase.transition' -StatePath $script:StatePath
+            @($msgs) | Should -HaveCount 2
+        }
+
+        It 'メッセージがない場合は空を返す' {
+            $msgs = Get-BusMessages -Topic 'ci.status' -StatePath $script:StatePath
+            @($msgs) | Should -HaveCount 0
+        }
+    }
+
+    Context 'Consumer 指定 (未読フィルタ)' {
+
+        It 'consume 前は未読として返る' {
+            Publish-BusMessage -Topic 'ci.status' -Publisher 'DevOps' `
+                -Payload @{ status = 'pass' } -StatePath $script:StatePath | Out-Null
+            $msgs = Get-BusMessages -Topic 'ci.status' -Consumer 'Orchestrator' -StatePath $script:StatePath
+            @($msgs) | Should -HaveCount 1
+        }
+
+        It 'Confirm-BusMessage 後は既読として除外される' {
+            $id = Publish-BusMessage -Topic 'ci.status' -Publisher 'DevOps' `
+                -Payload @{ status = 'pass' } -StatePath $script:StatePath
+            Confirm-BusMessage -Topic 'ci.status' -MessageId $id -Consumer 'Orchestrator' `
+                -StatePath $script:StatePath | Out-Null
+            $msgs = Get-BusMessages -Topic 'ci.status' -Consumer 'Orchestrator' -StatePath $script:StatePath
+            @($msgs) | Should -HaveCount 0
+        }
+
+        It '別の Consumer には既読にならない' {
+            $id = Publish-BusMessage -Topic 'ci.status' -Publisher 'DevOps' `
+                -Payload @{ status = 'pass' } -StatePath $script:StatePath
+            Confirm-BusMessage -Topic 'ci.status' -MessageId $id -Consumer 'Orchestrator' `
+                -StatePath $script:StatePath | Out-Null
+            $msgs = Get-BusMessages -Topic 'ci.status' -Consumer 'QA' -StatePath $script:StatePath
+            @($msgs) | Should -HaveCount 1
+        }
+    }
+
+    Context 'state.json が存在しない場合' {
+
+        It '空配列を返す' {
+            $msgs = Get-BusMessages -Topic 'phase.transition' `
+                -StatePath (Join-Path $TestDrive 'nonexistent.json')
+            @($msgs) | Should -HaveCount 0
+        }
+    }
+}
+
+Describe 'Confirm-BusMessage' {
+
+    BeforeEach {
+        $script:StatePath = Join-Path $TestDrive 'state.json'
+        New-TestStateJson -Path $script:StatePath
+        Initialize-MessageBus -StatePath $script:StatePath | Out-Null
+    }
+
+    It '存在するメッセージを consume すると $true を返す' {
+        $id = Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+            -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath
+        $result = Confirm-BusMessage -Topic 'phase.transition' -MessageId $id `
+            -Consumer 'Developer' -StatePath $script:StatePath
+        $result | Should -Be $true
+    }
+
+    It 'consumed_by に Consumer 名が追加される' {
+        $id = Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+            -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath
+        Confirm-BusMessage -Topic 'phase.transition' -MessageId $id `
+            -Consumer 'Developer' -StatePath $script:StatePath | Out-Null
+        $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+        $msg = @($state.message_bus.'phase.transition') | Where-Object { $_.id -eq $id }
+        @($msg.consumed_by) | Should -Contain 'Developer'
+    }
+
+    It '同じ Consumer で 2 回 Confirm しても冪等 (重複追加なし)' {
+        $id = Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+            -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath
+        Confirm-BusMessage -Topic 'phase.transition' -MessageId $id `
+            -Consumer 'Developer' -StatePath $script:StatePath | Out-Null
+        Confirm-BusMessage -Topic 'phase.transition' -MessageId $id `
+            -Consumer 'Developer' -StatePath $script:StatePath | Out-Null
+        $state = Get-Content $script:StatePath -Raw | ConvertFrom-Json
+        $msg = @($state.message_bus.'phase.transition') | Where-Object { $_.id -eq $id }
+        @($msg.consumed_by) | Where-Object { $_ -eq 'Developer' } | Should -HaveCount 1
+    }
+
+    It '存在しないメッセージ ID を指定すると $false を返す' {
+        Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+            -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath | Out-Null
+        $result = Confirm-BusMessage -Topic 'phase.transition' -MessageId 'msg-nonexistent' `
+            -Consumer 'Developer' -StatePath $script:StatePath
+        $result | Should -Be $false
+    }
+}
+
+Describe 'Get-BusStatus' {
+
+    BeforeEach {
+        $script:StatePath = Join-Path $TestDrive 'state.json'
+        New-TestStateJson -Path $script:StatePath
+        Initialize-MessageBus -StatePath $script:StatePath | Out-Null
+    }
+
+    It '2 トピック分のサマリーを返す' {
+        $status = Get-BusStatus -StatePath $script:StatePath
+        @($status) | Should -HaveCount 2
+    }
+
+    It 'TotalMessages が publish 件数と一致する' {
+        Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+            -Payload @{ from = 'Monitor'; to = 'Development' } -StatePath $script:StatePath | Out-Null
+        Publish-BusMessage -Topic 'phase.transition' -Publisher 'Orchestrator' `
+            -Payload @{ from = 'Development'; to = 'Verify' } -StatePath $script:StatePath | Out-Null
+        $status = Get-BusStatus -StatePath $script:StatePath
+        $row = $status | Where-Object { $_.Topic -eq 'phase.transition' }
+        $row.TotalMessages | Should -Be 2
+    }
+
+    It 'ConsumedCount が Confirm 済み件数と一致する' {
+        $id = Publish-BusMessage -Topic 'ci.status' -Publisher 'DevOps' `
+            -Payload @{ status = 'pass' } -StatePath $script:StatePath
+        Confirm-BusMessage -Topic 'ci.status' -MessageId $id `
+            -Consumer 'Orchestrator' -StatePath $script:StatePath | Out-Null
+        $status = Get-BusStatus -StatePath $script:StatePath
+        $row = $status | Where-Object { $_.Topic -eq 'ci.status' }
+        $row.ConsumedCount | Should -Be 1
+    }
+
+    It 'PendingCount = TotalMessages - ConsumedCount' {
+        $id = Publish-BusMessage -Topic 'ci.status' -Publisher 'DevOps' `
+            -Payload @{ status = 'pass' } -StatePath $script:StatePath
+        Publish-BusMessage -Topic 'ci.status' -Publisher 'DevOps' `
+            -Payload @{ status = 'fail' } -StatePath $script:StatePath | Out-Null
+        Confirm-BusMessage -Topic 'ci.status' -MessageId $id `
+            -Consumer 'Orchestrator' -StatePath $script:StatePath | Out-Null
+        $status = Get-BusStatus -StatePath $script:StatePath
+        $row = $status | Where-Object { $_.Topic -eq 'ci.status' }
+        $row.PendingCount | Should -Be 1
+    }
+}


### PR DESCRIPTION
## Summary

- `state.json` の `message_bus` セクションを介した Agent 間非同期メッセージ交換基盤 (Phase 1) を実装
- 既存アーキテクチャへの影響を最小化した案A (state.json 拡張) を採用
- Pester 5.x テスト 28 件すべて pass

## 変更内容

### 新規ファイル

| ファイル | 概要 |
|---|---|
| `scripts/lib/MessageBus.psm1` | Message Bus コアモジュール (5 公開関数) |
| `tests/MessageBus.Tests.ps1` | Pester 5.x ユニットテスト (28 件) |

### 公開関数

| 関数 | 役割 |
|---|---|
| `Initialize-MessageBus` | `message_bus` セクション初期化 (冪等) |
| `Publish-BusMessage` | トピックへメッセージ publish、MaxMessages=10 で自動 GC |
| `Get-BusMessages` | 全件取得 / Consumer 別未読フィルタ |
| `Confirm-BusMessage` | consume 済みマーク (冪等) |
| `Get-BusStatus` | トピック別サマリー (Total / Consumed / Pending) |

### Phase 1 対象トピック

- `phase.transition` — Orchestrator → 全 Agent へのフェーズ切替通知
- `ci.status` — DevOps → Orchestrator / QA への CI 結果通知

### state.json 変更 (既コミット済み)

```json
"message_bus": {
  "phase.transition": [],
  "ci.status": []
}
```

## テスト結果

```
Tests Passed: 28, Failed: 0, Skipped: 0
```

| Describe | テスト数 | 結果 |
|---|---|---|
| Initialize-MessageBus | 5 | ✅ |
| Publish-BusMessage | 10 | ✅ |
| Get-BusMessages | 6 | ✅ |
| Confirm-BusMessage | 4 | ✅ |
| Get-BusStatus | 4 | ✅ (修正: `@(Where-Object).Count` の単一一致バグ) |

## 影響範囲

- 既存 Agent / スクリプトへの影響なし (新規追加のみ)
- `state.json` の `message_bus` セクションは既にコミット済み

## 残課題 (Phase 2 以降)

- GC: 全 Subscriber が consume 済みのメッセージ自動削除
- トピック追加: `agent.status` / `task.assignment` 等
- エラー通知トピック

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェント間通信を実現するメッセージバスシステムを実装しました。メッセージの送受信、状態管理、および消費状況の追跡が可能になります。

* **テスト**
  * メッセージバスモジュールの機能を検証する包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->