### PR TITLE
docs(readme): テスト数を 449件 → 477件 に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 | 項目 | 状態 |
 |------|------|
 | バージョン | **v3.0.0** (Phase 4 完了 / Release タグ準備中) |
-| テスト | **449件** — Unit: 311 / E2E: 138 (Pester, CI) |
+| テスト | **477件** — (Pester, CI) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | v8 (Harness Evolution / Progressive Disclosure / Frontier-Test / Dead-Weight 自動検出 / Stop-Doing 点検 / CodeRabbit 統合) |
 | Agents | **17体** の特化サブエージェント (2026Q2 棚卸しで最適化済み) |
@@ -202,7 +202,7 @@ flowchart TD
 | 🐍 PTY Bridge | 🔧 共通 | SSH経由の Claude Code 操作を堅牢にサポート |
 | ⚙️ 一元設定 | 🔧 共通 | `config/config.json` で対応ツールを一元管理 |
 | 🩺 診断ツール | 🔧 共通 | `Test-AllTools.ps1` で環境を一括チェック |
-| ⚡ CI/CD | 🔧 共通 | GitHub Actions による自動テスト (Pester 449件 — Unit:311 / E2E:138) |
+| ⚡ CI/CD | 🔧 共通 | GitHub Actions による自動テスト (Pester 477件 — 17 test files) |
 | 🧠 ClaudeOS カーネル | ⭐ Claude 専用 | 17体のエージェント + 4フック + 35コマンド (2026Q2 棚卸し済み) |
 | 🔌 MCP ヘルスチェック | ⭐ Claude 専用 | `McpHealthCheck.psm1` で4サーバーの起動・接続・状態診断 |
 | 🤖 Agent Teams ランタイム | ⭐ Claude 専用 | `AgentTeams.psm1` でタスク分析→Team自動構成→能力マトリクス→可視化 |
@@ -418,7 +418,7 @@ scripts/helpers/     PTY bridge 等のヘルパー
 scripts/templates/   各ツール向けテンプレート
 scripts/test/        診断スクリプト
 scripts/tools/       TASKS同期・バックログ管理
-tests/               Pester テスト (15 files / 307件)
+tests/               Pester テスト (17 files / 477件)
 Claude/              ClaudeOS 互換ポリシー群
 Codex/               Codex AGENTS.md
 .claude/claudeos/    ClaudeOS カーネル（204ファイル）


### PR DESCRIPTION
## Summary
- PR #132 (MessageBus Phase 1) で追加された 28テストが README に未反映だったため修正
- 3箇所の記述を CI 実績値 (477件 passed / 477 total) に統一

## Test plan
- [ ] docs のみ変更 — CI の lint/build への影響なし
- [ ] README.md の3箇所が全て 477件 になっていること

## Impact
- `README.md` line 27, 205, 421

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * テスト統計情報を更新しました。テスト総数が477件に増加し、テストファイル数も17ファイルとなりました。READMEの開発状況およびCI/CD説明セクションを最新の状況に合わせて更新しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->