### PR TITLE
feat(v3.1.0): メニュー整理 + Cron 週次自動起動 + Session Info タブ + Statusline 全適用

### DIFF
--- a/Claude/templates/claudeos/commands/cron-cancel.md
+++ b/Claude/templates/claudeos/commands/cron-cancel.md
@@ -1,0 +1,22 @@
+---
+description: ID 指定または全指定で CLAUDEOS Cron エントリを解除する
+---
+
+# /cron-cancel — Cron エントリ解除
+
+引数:
+- `$1 = <id>` → その ID 1 件だけ削除
+- `$1 = "all"` または未指定で確認後 → 全 CLAUDEOS エントリを削除
+
+実行:
+
+```bash
+# ID 指定
+if [ -n "$1" ] && [ "$1" != "all" ]; then
+  bash /home/kensan/.claudeos/cron-cli.sh cancel --id "$1"
+else
+  bash /home/kensan/.claudeos/cron-cli.sh cancel --all
+fi
+```
+
+実行後、`/cron-list` を実行して現状を確認してください。

--- a/Claude/templates/claudeos/commands/cron-list.md
+++ b/Claude/templates/claudeos/commands/cron-list.md
@@ -1,0 +1,14 @@
+---
+description: 現在の CLAUDEOS Cron エントリ一覧を表示する
+---
+
+# /cron-list — Cron エントリ一覧
+
+```bash
+crontab -l 2>/dev/null | awk '
+  /^# CLAUDEOS:/ { print; getline; print; print "" }
+'
+```
+
+出力があれば表形式で整形してユーザーへ報告してください。
+出力が無ければ「登録済みの CLAUDEOS エントリはありません」と伝えてください。

--- a/Claude/templates/claudeos/commands/cron-register.md
+++ b/Claude/templates/claudeos/commands/cron-register.md
@@ -1,0 +1,27 @@
+---
+description: Linux crontab に CLAUDEOS 週次自動起動エントリを登録する
+---
+
+# /cron-register — Cron エントリ登録
+
+以下の手順で crontab を更新してください。
+
+1. 現在のセッションの `$CLAUDE_PROJECT` を取得（未設定なら session.json から読む）
+2. 引数が未指定なら対話で聞き取る:
+   - 曜日 (`0-6`、複数可): `$1`
+   - 時刻 (`HH:MM`): `$2`
+   - 作業時間 (分、省略時 300): `$3`
+3. Bash で以下を実行:
+
+```bash
+bash /home/kensan/.claudeos/cron-cli.sh register \
+  --project "${CLAUDE_PROJECT}" \
+  --day "$1" \
+  --time "$2" \
+  --duration "${3:-300}"
+```
+
+4. 実行結果（ID と cron 式）をユーザーへ報告
+
+`cron-cli.sh` が未配置の場合は、先に `/home/kensan/.claudeos/cron-launcher.sh` と合わせて
+スタートアップツール経由で配置されているか確認してください。

--- a/Claude/templates/claudeos/commands/session-info.md
+++ b/Claude/templates/claudeos/commands/session-info.md
@@ -1,0 +1,20 @@
+---
+description: 現セッションの session.json を整形表示する
+---
+
+# /session-info — セッション情報
+
+```bash
+SESSION_FILE="$HOME/.claudeos/sessions/${CLAUDE_SESSION_ID}.json"
+if [ ! -f "$SESSION_FILE" ]; then
+  echo "session 情報が見つかりません。手動起動（トリガ=manual）の場合は Windows 側の state/sessions を確認してください。"
+  exit 0
+fi
+if command -v jq >/dev/null 2>&1; then
+  jq . "$SESSION_FILE"
+else
+  cat "$SESSION_FILE"
+fi
+```
+
+表示後、残り時間と status から「このセッションがあとどれくらい走るか」をユーザーに分かりやすく要約してください。

--- a/Claude/templates/claudeos/commands/work-time-reset.md
+++ b/Claude/templates/claudeos/commands/work-time-reset.md
@@ -1,0 +1,13 @@
+---
+description: 現セッションの最大作業時間をデフォルト (300 分) に戻す
+---
+
+# /work-time-reset — 作業時間リセット
+
+デフォルト 300 分 (5 時間) に戻します。内部的には `/work-time-set 300` と等価です。
+
+```bash
+bash /home/kensan/.claudeos/cron-cli.sh worktime-reset --session "$CLAUDE_SESSION_ID"
+```
+
+`cron-cli.sh` が無い場合は `/work-time-set 300` を呼び出してください。

--- a/Claude/templates/claudeos/commands/work-time-set.md
+++ b/Claude/templates/claudeos/commands/work-time-set.md
@@ -1,0 +1,38 @@
+---
+description: 現セッションの最大作業時間 (max_duration_minutes) を変更する
+---
+
+# /work-time-set — 作業時間の変更
+
+引数:
+- `$1 = <minutes>` → その分数に設定（例: `/work-time-set 240` で 4 時間）
+
+実行:
+
+```bash
+NEW_MIN="${1:-300}"
+SESSION_FILE="$HOME/.claudeos/sessions/${CLAUDE_SESSION_ID}.json"
+
+if [ ! -f "$SESSION_FILE" ]; then
+  echo "[ERROR] session.json が見つかりません: $SESSION_FILE" >&2
+  exit 1
+fi
+
+python3 - "$SESSION_FILE" "$NEW_MIN" <<'PYEOF'
+import json, sys
+from datetime import datetime, timedelta
+path = sys.argv[1]
+new_min = int(sys.argv[2])
+with open(path) as f:
+    s = json.load(f)
+start = datetime.fromisoformat(s['start_time'].replace('Z', '+00:00'))
+s['max_duration_minutes'] = new_min
+s['end_time_planned'] = (start + timedelta(minutes=new_min)).isoformat()
+s['last_updated'] = datetime.now().astimezone().isoformat()
+with open(path, 'w') as f:
+    json.dump(s, f, ensure_ascii=False, indent=2)
+print(f'[OK] max_duration_minutes = {new_min}, end_time_planned 再計算済')
+PYEOF
+```
+
+情報タブは 1 秒 poll なので即時に表示が追従します。

--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# ============================================================
+# cron-launcher.sh - Linux 側で ClaudeCode を cron から起動するラッパ
+# ClaudeOS v3.1.0
+#
+# Usage: cron-launcher.sh <project> <duration-minutes>
+#
+# 責務:
+#   - /home/kensan/Projects/<project> に cd
+#   - timeout <Ns> 付きで claude を起動（auto mode）
+#   - session.json の生成・更新（start/end/status）
+#   - ログを /home/kensan/.claudeos/logs/ へ
+# ============================================================
+
+set -euo pipefail
+
+PROJECT="${1:-}"
+DURATION_MIN="${2:-300}"
+
+if [[ -z "$PROJECT" ]]; then
+  echo "[ERROR] project 引数がありません" >&2
+  echo "Usage: $0 <project> <duration-minutes>" >&2
+  exit 2
+fi
+
+CLAUDEOS_HOME="${CLAUDEOS_HOME:-$HOME/.claudeos}"
+SESSIONS_DIR="$CLAUDEOS_HOME/sessions"
+LOGS_DIR="$CLAUDEOS_HOME/logs"
+PROJECTS_BASE="${PROJECTS_BASE:-$HOME/Projects}"
+PROJECT_DIR="$PROJECTS_BASE/$PROJECT"
+
+mkdir -p "$SESSIONS_DIR" "$LOGS_DIR"
+chmod 700 "$CLAUDEOS_HOME" "$SESSIONS_DIR" "$LOGS_DIR" 2>/dev/null || true
+
+if [[ ! -d "$PROJECT_DIR" ]]; then
+  echo "[ERROR] プロジェクトディレクトリが存在しません: $PROJECT_DIR" >&2
+  exit 3
+fi
+
+DURATION_SEC=$((DURATION_MIN * 60))
+SAFE_PROJECT=$(echo "$PROJECT" | tr -c 'A-Za-z0-9_-' '_')
+STAMP=$(date +'%Y%m%d-%H%M%S')
+SESSION_ID="${STAMP}-${SAFE_PROJECT}"
+SESSION_FILE="$SESSIONS_DIR/${SESSION_ID}.json"
+LOG_FILE="$LOGS_DIR/cron-${STAMP}.log"
+
+START_TIME=$(date -Iseconds)
+END_TIME_PLANNED=$(date -Iseconds -d "+${DURATION_MIN} minutes")
+
+# --- session.json を初期化 ---
+cat > "$SESSION_FILE.tmp" <<EOF
+{
+  "sessionId": "$SESSION_ID",
+  "project": "$PROJECT",
+  "trigger": "cron",
+  "start_time": "$START_TIME",
+  "max_duration_minutes": $DURATION_MIN,
+  "end_time_planned": "$END_TIME_PLANNED",
+  "status": "running",
+  "pid": $$,
+  "last_updated": "$START_TIME"
+}
+EOF
+mv "$SESSION_FILE.tmp" "$SESSION_FILE"
+
+# 終了時に status を更新するトラップ
+finalize() {
+  local exit_code=$?
+  local final_status="completed"
+  if [[ $exit_code -eq 124 ]]; then
+    # timeout による終了
+    final_status="completed"
+  elif [[ $exit_code -ne 0 ]]; then
+    final_status="failed"
+  fi
+  local now
+  now=$(date -Iseconds)
+
+  if [[ -f "$SESSION_FILE" ]]; then
+    # jq があればそれで、無ければ sed で status と last_updated を書き換える
+    if command -v jq >/dev/null 2>&1; then
+      jq --arg s "$final_status" --arg t "$now" \
+        '.status = $s | .last_updated = $t' "$SESSION_FILE" > "$SESSION_FILE.tmp" \
+        && mv "$SESSION_FILE.tmp" "$SESSION_FILE"
+    else
+      sed -i \
+        -e "s/\"status\": \"running\"/\"status\": \"$final_status\"/" \
+        -e "s/\"last_updated\": \"[^\"]*\"/\"last_updated\": \"$now\"/" \
+        "$SESSION_FILE"
+    fi
+  fi
+
+  echo "[cron-launcher] session finished status=$final_status exit=$exit_code at $now" >> "$LOG_FILE"
+}
+trap finalize EXIT
+
+echo "[cron-launcher] $(date -Iseconds) project=$PROJECT duration=${DURATION_MIN}m session=$SESSION_ID" | tee -a "$LOG_FILE"
+
+cd "$PROJECT_DIR"
+
+export LANG=C.UTF-8 LC_ALL=C.UTF-8
+export CLAUDE_SESSION_ID="$SESSION_ID"
+export CLAUDE_PROJECT="$PROJECT"
+
+# START_PROMPT.md が存在すれば引数として渡し、ClaudeCode を auto mode で起動
+PROMPT_ARG=""
+if [[ -f "$PROJECT_DIR/.claude/START_PROMPT.md" ]]; then
+  PROMPT_ARG="$(cat "$PROJECT_DIR/.claude/START_PROMPT.md")"
+fi
+
+if [[ -n "$PROMPT_ARG" ]]; then
+  timeout "${DURATION_SEC}s" claude --dangerously-skip-permissions "$PROMPT_ARG" >> "$LOG_FILE" 2>&1
+else
+  timeout "${DURATION_SEC}s" claude --dangerously-skip-permissions >> "$LOG_FILE" 2>&1
+fi

--- a/README.md
+++ b/README.md
@@ -4,18 +4,16 @@
 
 `ClaudeOS v8` (Agent Teams / Boot Sequence / Self Evolution / Architecture Check / Issue Factory / CodeRabbit Review / Weekly Optimized Loops) をカーネルに据え、ローカル起動・SSH リモート起動・診断・Pester テスト・GitHub Issues / Projects / Actions 連携を一括提供します。
 
-> **📌 リポジトリ名について**
-> リポジトリ名 `ClaudeCLI-CodexCLI-CopilotCLI-StartUpTools-New` は当初の 3 ツール統合ランチャー構想に由来しますが、現在の開発投資・新機能 (ClaudeOS v8 / Phase 3 完了) はすべて **Claude Code** 側に集中しています。Codex CLI / GitHub Copilot CLI の起動スクリプトもリポジトリ内に併設してありますが、ClaudeOS フレームワークと統合されているのは Claude Code のみです。
+> **📌 v3.1.0 で Claude Code 専用ツールに整理**
+> v3.1.0 より、Codex CLI / GitHub Copilot CLI の起動メニュー (S2/S3/L2/L3) は削除されました。本ツールは **Claude Code 専用の自律開発ランチャー** として位置づけを明確化し、Linux crontab 連携・セッション情報タブ・Statusline グローバル適用などの新機能に投資が集中しています。
 
 ## 対応ツール
 
 | ツール | 提供元 | 位置付け | 主な用途 |
 |--------|--------|---------|---------|
-| 🌟 **Claude Code** | Anthropic | **主軸** — ClaudeOS v8 統合 / Agent Teams / Boot Sequence / 自律開発ループ | 大規模なコード修正、レビュー、自律開発、Issue/PR 自動化 |
-| Codex CLI | OpenAI | 併設 (基本起動のみ) | ターミナル中心のコード生成、シェル支援 |
-| GitHub Copilot CLI | GitHub | 併設 (基本起動のみ) | `copilot --yolo` によるシェル・GitHub 操作支援 |
+| 🌟 **Claude Code** | Anthropic | **唯一の起動対象** — ClaudeOS v8 統合 / Agent Teams / Boot Sequence / 自律開発ループ | 大規模なコード修正、レビュー、自律開発、Issue/PR 自動化、Linux cron による週次自律実行 |
 
-> Codex CLI / GitHub Copilot CLI は `Start-CodexCLI.ps1` / `Start-CopilotCLI.ps1` で起動可能ですが、Pre-Launch Diagnostics や AgentTeams ランタイムなどの ClaudeOS 拡張機能は Claude Code 専用です。
+> v3.1.0 以降、Codex CLI / GitHub Copilot CLI の起動メニューは提供しません。`Start-CodexCLI.ps1` / `Start-CopilotCLI.ps1` ファイル自体はリポジトリ内に残していますが、`config.json` の `tools.codex.enabled = false` / `tools.copilot.enabled = false` で無効化されています。
 
 ---
 
@@ -23,7 +21,7 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.0.0** (Phase 4 完了 / Release タグ準備中) |
+| バージョン | **v3.1.0** (Cron / Session Info Tab / Statusline 全適用 / Slash Commands 新設) |
 | テスト | **477件** — (Pester, CI) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | v8.1 (Harness Evolution / Progressive Disclosure / Frontier-Test / Dead-Weight 自動検出 / Stop-Doing 点検 / CodeRabbit 統合 / **Phase Compaction (`/compact` 標準化)**) |
@@ -84,28 +82,31 @@
 graph TD
     A["start.bat"] --> B["Start-Menu.ps1"]
     B --> C["Start-ClaudeCode.ps1"]
-    B --> D["Start-CodexCLI.ps1"]
-    B --> E["Start-CopilotCLI.ps1"]
     B --> F["Start-All.ps1"]
+    B --> NCS["🆕 New-CronSchedule.ps1"]
+    B --> SSL["🆕 Set-Statusline.ps1"]
     B --> G["Test-AllTools.ps1"]
-    B --> H["Test-McpHealth.ps1"]
-    B --> I["Test-AgentTeams.ps1"]
 
     C --> J{"Local or SSH?"}
-    D --> J
-    E --> J
+    C --> SIT["🆕 Show-SessionInfoTab.ps1"]
+    SIT --> WT["wt.exe new-tab"]
+    WT --> WSI["🆕 Watch-SessionInfo.ps1"]
+    WSI --> SJ["session.json (1s poll)"]
 
     J -->|Local| K["projectsDir"]
     J -->|SSH| L["linuxHost via SSH"]
     L --> M["claude_pty_bridge.py"]
 
+    NCS --> CMSSH["SSH crontab -l/-"]
+    CMSSH --> CRON["Linux crontab (CLAUDEOS:uuid)"]
+    CRON --> CL["cron-launcher.sh"]
+    CL --> SJ
+
     C --> PLD["Pre-Launch Diagnostics"]
     PLD --> MCP_CHK["MCP Health Check"]
     PLD --> AT_CHK["Agent Teams Check"]
 
-    C --> N["CLAUDE.md deploy"]
-    D --> O["AGENTS.md deploy"]
-    E --> P["copilot-instructions.md deploy"]
+    C --> N["CLAUDE.md / settings.json / commands/ deploy"]
 ```
 
 ## モジュール構成
@@ -276,34 +277,73 @@ start.bat
 
 | メニュー | 説明 |
 |----------|------|
-| `S1` | Claude Code を SSH 起動 |
-| `S2` | Codex CLI を SSH 起動 |
-| `S3` | GitHub Copilot CLI を SSH 起動 |
-| `L1` | Claude Code をローカル起動 |
-| `L2` | Codex CLI をローカル起動 |
-| `L3` | GitHub Copilot CLI をローカル起動 |
+| `S1` | Claude Code を SSH 起動 (自動で Session Info タブも生成) |
+| `L1` | Claude Code をローカル起動 (自動で Session Info タブも生成) |
 | `5` | ツール確認・診断 |
 | `6` | ドライブマッピング診断 |
 | `7` | Windows Terminal セットアップ |
 | `8` | MCP ヘルスチェック |
 | `9` | Agent Teams ランタイム |
 | `10` | Worktree Manager |
-| `11` | 🆕 Architecture Check |
+| `11` | Architecture Check |
+| `12` | 🆕 Cron 登録・編集・削除 (Linux crontab で週次自動起動) |
+| `13` | 🆕 Statusline 設定 (グローバル `~/.claude/settings.json` を Linux に一括適用) |
+
+> **v3.1.0 変更**: `S2` / `S3` / `L2` / `L3` (Codex CLI / GitHub Copilot CLI) は削除されました。
 
 ### PowerShell から直接起動
 
 ```powershell
-# AI CLI ツール起動
+# Claude Code 起動
 .\scripts\main\Start-All.ps1
 .\scripts\main\Start-ClaudeCode.ps1 -Project "my-project"
-.\scripts\main\Start-CodexCLI.ps1 -Project "my-project"
-.\scripts\main\Start-CopilotCLI.ps1 -Project "my-project" -Local
 
-# ClaudeOS Boot Sequence (MVP) 🆕
+# v3.1.0 新機能 🆕
+.\scripts\main\New-CronSchedule.ps1          # メニュー 12: Cron 登録・編集・削除
+.\scripts\main\Set-Statusline.ps1            # メニュー 13: Statusline グローバル適用
+.\scripts\main\Show-SessionInfoTab.ps1 -SessionId <sid>  # 情報タブを手動で開く
+
+# ClaudeOS Boot Sequence (MVP)
 .\scripts\main\Start-ClaudeOS.ps1                    # 9ステップ初期化
 .\scripts\main\Start-ClaudeOS.ps1 -DryRun            # 非破壊プレビュー
 .\scripts\main\Start-ClaudeOS.ps1 -NonInteractive    # CI / 自動実行向け
 ```
+
+### 🆕 v3.1.0 新機能の概要
+
+#### メニュー 12: Cron 登録・編集・削除
+
+Linux crontab に週次自動起動エントリを登録します。`CLAUDEOS:<uuid>` コメントで識別するため、他の cron エントリを壊さず安全に追加・削除できます。
+
+- 登録フロー: プロジェクト番号 → 曜日（複数可）→ 時刻（HH:MM）→ 作業時間（分、既定 300）
+- 起動は Linux 側 `~/.claudeos/cron-launcher.sh` が `timeout` 付き auto mode で ClaudeCode を実行
+- セッションログは `~/.claudeos/logs/` に保存
+
+#### Session Info タブ (Windows Terminal)
+
+S1 / L1 / Cron 起動時に自動で Windows Terminal の新規タブ「Claude Session Info」が開きます。`session.json` を 1 秒間隔で poll し、以下をリアルタイム表示:
+
+- 開始時刻 / 終了予定時刻
+- 作業時間（分）と経過時間
+- 残り時間（秒単位でカウントダウン）
+- セッション status (running / completed / exited / cancelled / failed)
+
+セッション中に `/work-time-set 240` 等で max_duration_minutes を変更すると、タブの残り時間も即追従します。
+
+#### メニュー 13: Statusline グローバル適用
+
+Windows 側 `~/.claude/settings.json` の `statusLine` セクションを Linux 側 `~/.claude/settings.json` へ一括同期します。バックアップを取ってから merge するため安全に巻き戻せます。
+
+#### Slash Commands (ClaudeCode 内)
+
+| Command | 用途 |
+|---------|------|
+| `/cron-register` | ClaudeCode 内から Cron 新規登録 |
+| `/cron-cancel [id|all]` | Cron 解除 |
+| `/cron-list` | 登録済みエントリ一覧 |
+| `/work-time-set <分>` | 現セッションの作業時間を変更 |
+| `/work-time-reset` | 作業時間をデフォルト 5h に戻す |
+| `/session-info` | 現セッションの session.json 整形表示 |
 
 ---
 

--- a/config/config.json.template
+++ b/config/config.json.template
@@ -1,6 +1,6 @@
 {
-  "_comment": "AI CLI スタートアップツール設定テンプレート v2.0.0 - コピーしてconfig.jsonとして使用",
-  "version": "2.0.0",
+  "_comment": "Claude Code スタートアップツール設定テンプレート v3.1.0 - コピーしてconfig.jsonとして使用",
+  "version": "3.1.0",
   "projectsDir": "X:\\",
   "sshProjectsDir": "auto",
   "projectsDirUnc": "\\\\<your-linux-host>\\Projects",
@@ -38,7 +38,8 @@
       "apiKeyEnvVar": "ANTHROPIC_API_KEY"
     },
     "codex": {
-      "enabled": true,
+      "enabled": false,
+      "_disabled_reason": "v3.1.0 で Codex CLI 連携は廃止。将来復活の保険としてフィールドは保持。",
       "displayName": "Codex CLI (OpenAI)",
       "command": "codex",
       "args": [
@@ -52,7 +53,8 @@
       "apiKeyEnvVar": "OPENAI_API_KEY"
     },
     "copilot": {
-      "enabled": true,
+      "enabled": false,
+      "_disabled_reason": "v3.1.0 で Copilot CLI 連携は廃止。将来復活の保険としてフィールドは保持。",
       "displayName": "GitHub Copilot CLI",
       "command": "copilot",
       "args": [
@@ -104,5 +106,29 @@
       "codex":   "D:\\アラートサウンドデザイン＃01.mp3",
       "copilot": "D:\\アラートサウンドデザイン＃01.mp3"
     }
+  },
+  "cron": {
+    "_comment": "v3.1.0 新設。Linux 側 crontab で ClaudeCode を週次自動起動する機能の設定。",
+    "enabled": true,
+    "defaultDurationMinutes": 300,
+    "launcherPath": "/home/kensan/.claudeos/cron-launcher.sh",
+    "sessionsDir": "/home/kensan/.claudeos/sessions",
+    "logsDir": "/home/kensan/.claudeos/logs",
+    "entryPrefix": "CLAUDEOS"
+  },
+  "sessionTabs": {
+    "_comment": "v3.1.0 新設。Windows Terminal に情報タブを 1 枚追加し、開始/終了/残り時間をリアルタイム表示する。",
+    "enabled": true,
+    "title": "Claude Session Info",
+    "pollIntervalSeconds": 1,
+    "autoCloseAfterExitSeconds": 10,
+    "localSessionsDir": "%USERPROFILE%\\.claudeos\\sessions"
+  },
+  "statusline": {
+    "_comment": "v3.1.0 新設。メニュー 13 で実行される、グローバル statusLine 設定を Linux 側に一括同期する設定。",
+    "enabled": true,
+    "sourceSettingsPath": "%USERPROFILE%\\.claude\\settings.json",
+    "remoteSettingsPath": "~/.claude/settings.json",
+    "backupBeforeApply": true
   }
 }

--- a/scripts/lib/CronManager.psm1
+++ b/scripts/lib/CronManager.psm1
@@ -1,0 +1,248 @@
+# ============================================================
+# CronManager.psm1 - Linux crontab 解析・編集ヘルパ
+# ClaudeOS v3.1.0 / メニュー 12 (Cron 登録・編集・削除) の中核
+#
+# 設計:
+#  - CLAUDEOS: <uuid> コメント行で自分が書いたエントリを識別する
+#  - crontab -l → パース → 編集 → crontab - で流し込む round-trip
+#  - 他のユーザー cron を破壊しないよう「CLAUDEOS: 行 + その直後の cron 式」のみ操作
+# ============================================================
+
+Set-StrictMode -Version Latest
+
+$script:EntryPrefix = 'CLAUDEOS'
+$script:LauncherPath = '/home/kensan/.claudeos/cron-launcher.sh'
+$script:LogsDir = '/home/kensan/.claudeos/logs'
+
+function Set-CronManagerConfig {
+    param(
+        [string]$EntryPrefix = '',
+        [string]$LauncherPath = '',
+        [string]$LogsDir = ''
+    )
+    if (-not [string]::IsNullOrWhiteSpace($EntryPrefix)) { $script:EntryPrefix = $EntryPrefix }
+    if (-not [string]::IsNullOrWhiteSpace($LauncherPath)) { $script:LauncherPath = $LauncherPath }
+    if (-not [string]::IsNullOrWhiteSpace($LogsDir)) { $script:LogsDir = $LogsDir }
+}
+
+function Invoke-RemoteCrontab {
+    <#
+    .SYNOPSIS Linux 側で crontab コマンドを実行する
+    .DESCRIPTION
+      Action='read'  → crontab -l の出力を文字列で返す (stderr は握りつぶす)
+      Action='write' → StdinContent を crontab - に流し込む
+    #>
+    param(
+        [Parameter(Mandatory)][string]$LinuxHost,
+        [Parameter(Mandatory)][ValidateSet('read', 'write')][string]$Action,
+        [string]$StdinContent = ''
+    )
+
+    $sshExe = if ($env:AI_STARTUP_SSH_EXE) { $env:AI_STARTUP_SSH_EXE } else { 'ssh' }
+
+    if ($Action -eq 'read') {
+        # crontab -l が空の場合 exit 1 なので、両方ハンドル
+        $result = & $sshExe -T -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new `
+            -o ControlMaster=no $LinuxHost "crontab -l 2>/dev/null || true"
+        if ($null -eq $result) { return '' }
+        return ($result -join "`n")
+    }
+
+    # write: StdinContent を "crontab -" に流し込む
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $sshExe
+    $psi.Arguments = "-T -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o ControlMaster=no $LinuxHost `"crontab -`""
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardInput = $true
+
+    $proc = [System.Diagnostics.Process]::new()
+    $proc.StartInfo = $psi
+    [void]$proc.Start()
+    $proc.StandardInput.NewLine = "`n"
+    $proc.StandardInput.Write($StdinContent.Replace("`r`n", "`n"))
+    if (-not $StdinContent.EndsWith("`n")) { $proc.StandardInput.WriteLine() }
+    $proc.StandardInput.Close()
+    $proc.WaitForExit()
+    return $proc.ExitCode
+}
+
+function Get-ClaudeOSCronEntries {
+    <#
+    .SYNOPSIS 現在の crontab から CLAUDEOS: 行と対応する cron 式を抽出
+    #>
+    param([Parameter(Mandatory)][string]$LinuxHost)
+
+    $raw = Invoke-RemoteCrontab -LinuxHost $LinuxHost -Action 'read'
+    if ([string]::IsNullOrWhiteSpace($raw)) { return @() }
+
+    $lines = $raw -split "`n"
+    $entries = @()
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i]
+        if ($line -match "^\s*#\s*$($script:EntryPrefix):([\w-]+)\s*(.*)$") {
+            $id = $matches[1]
+            $metaRaw = $matches[2]
+            $meta = @{}
+            foreach ($kv in ($metaRaw -split '\s+')) {
+                if ($kv -match '^(\w+)=(.+)$') {
+                    $meta[$matches[1]] = $matches[2]
+                }
+            }
+            $cronLine = if (($i + 1) -lt $lines.Count) { $lines[$i + 1] } else { '' }
+            $entries += [pscustomobject]@{
+                Id        = $id
+                Project   = if ($meta.ContainsKey('project')) { $meta['project'] } else { '' }
+                Duration  = if ($meta.ContainsKey('duration')) { [int]$meta['duration'] } else { 300 }
+                Created   = if ($meta.ContainsKey('created')) { $meta['created'] } else { '' }
+                CronExpr  = ($cronLine -split '\s+', 6)[0..4] -join ' '
+                CommentLine = $line
+                CronLine    = $cronLine
+            }
+        }
+    }
+    return $entries
+}
+
+function Format-CronExpression {
+    <#
+    .SYNOPSIS 曜日（0=日〜6=土、複数可）と HH:MM から cron 式を生成
+    #>
+    param(
+        [Parameter(Mandatory)][int[]]$DayOfWeek,
+        [Parameter(Mandatory)][string]$Time
+    )
+
+    if ($Time -notmatch '^(\d{1,2}):(\d{2})$') {
+        throw "時刻は HH:MM 形式で指定してください (例: 21:00)"
+    }
+    $hour = [int]$matches[1]
+    $minute = [int]$matches[2]
+    if ($hour -lt 0 -or $hour -gt 23) { throw "時間は 0-23 の範囲で指定してください" }
+    if ($minute -lt 0 -or $minute -gt 59) { throw "分は 0-59 の範囲で指定してください" }
+
+    $dowStr = ($DayOfWeek | Sort-Object -Unique | ForEach-Object { $_.ToString() }) -join ','
+    foreach ($d in $DayOfWeek) {
+        if ($d -lt 0 -or $d -gt 6) { throw "曜日は 0(日)〜6(土) の範囲で指定してください" }
+    }
+    return "$minute $hour * * $dowStr"
+}
+
+function New-CronEntryId {
+    return [Guid]::NewGuid().ToString('N').Substring(0, 8)
+}
+
+function Add-ClaudeOSCronEntry {
+    <#
+    .SYNOPSIS 新規 CLAUDEOS エントリを crontab 末尾に追加
+    #>
+    param(
+        [Parameter(Mandatory)][string]$LinuxHost,
+        [Parameter(Mandatory)][string]$Project,
+        [Parameter(Mandatory)][int[]]$DayOfWeek,
+        [Parameter(Mandatory)][string]$Time,
+        [int]$DurationMinutes = 300
+    )
+
+    $cronExpr = Format-CronExpression -DayOfWeek $DayOfWeek -Time $Time
+    $id = New-CronEntryId
+    $created = (Get-Date).ToString('yyyy-MM-ddTHH:mm:ss')
+    $logFilePattern = "$($script:LogsDir)/cron-`$(date +\%Y\%m\%d-\%H\%M\%S).log"
+    $command = "$($script:LauncherPath) $Project $DurationMinutes >> $logFilePattern 2>&1"
+
+    $commentLine = "# $($script:EntryPrefix):$id project=$Project duration=$DurationMinutes created=$created"
+    $cronLine = "$cronExpr $command"
+
+    $current = Invoke-RemoteCrontab -LinuxHost $LinuxHost -Action 'read'
+    if ($null -eq $current) { $current = '' }
+    $newContent = $current.TrimEnd("`n")
+    if (-not [string]::IsNullOrWhiteSpace($newContent)) { $newContent += "`n" }
+    $newContent += "$commentLine`n$cronLine`n"
+
+    $exitCode = Invoke-RemoteCrontab -LinuxHost $LinuxHost -Action 'write' -StdinContent $newContent
+    if ($exitCode -ne 0) {
+        throw "crontab 更新に失敗 (exit=$exitCode)"
+    }
+
+    return [pscustomobject]@{
+        Id = $id
+        Project = $Project
+        CronExpr = $cronExpr
+        Duration = $DurationMinutes
+        Created = $created
+    }
+}
+
+function Remove-ClaudeOSCronEntry {
+    <#
+    .SYNOPSIS ID 指定で CLAUDEOS エントリを削除（コメント行 + 直後の cron 式の 2 行セット）
+    #>
+    param(
+        [Parameter(Mandatory)][string]$LinuxHost,
+        [Parameter(Mandatory)][string]$Id
+    )
+
+    $raw = Invoke-RemoteCrontab -LinuxHost $LinuxHost -Action 'read'
+    if ([string]::IsNullOrWhiteSpace($raw)) { return 0 }
+
+    $lines = $raw -split "`n"
+    $result = @()
+    $removed = 0
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i]
+        if ($line -match "^\s*#\s*$($script:EntryPrefix):$([regex]::Escape($Id))\b") {
+            # skip comment line + next cron line
+            $i++  # 次の行もスキップ
+            $removed++
+            continue
+        }
+        $result += $line
+    }
+
+    $newContent = ($result -join "`n")
+    if (-not $newContent.EndsWith("`n")) { $newContent += "`n" }
+
+    $exitCode = Invoke-RemoteCrontab -LinuxHost $LinuxHost -Action 'write' -StdinContent $newContent
+    if ($exitCode -ne 0) {
+        throw "crontab 更新に失敗 (exit=$exitCode)"
+    }
+    return $removed
+}
+
+function Remove-AllClaudeOSCronEntries {
+    param([Parameter(Mandatory)][string]$LinuxHost)
+
+    $entries = Get-ClaudeOSCronEntries -LinuxHost $LinuxHost
+    $count = 0
+    foreach ($e in $entries) {
+        $count += Remove-ClaudeOSCronEntry -LinuxHost $LinuxHost -Id $e.Id
+    }
+    return $count
+}
+
+function Get-DayOfWeekLabel {
+    param([int]$Dow)
+    $labels = @('日', '月', '火', '水', '木', '金', '土')
+    if ($Dow -ge 0 -and $Dow -le 6) { return $labels[$Dow] }
+    return "?"
+}
+
+function Format-CronEntryForDisplay {
+    param([pscustomobject]$Entry)
+
+    $parts = $Entry.CronExpr -split '\s+'
+    $minute = $parts[0]; $hour = $parts[1]; $dow = $parts[4]
+    $dowLabel = ($dow -split ',' | ForEach-Object { Get-DayOfWeekLabel -Dow ([int]$_) }) -join '/'
+    return "[{0}] project={1}  {2} {3}:{4}  duration={5}m  (created {6})" -f `
+        $Entry.Id, $Entry.Project, $dowLabel, $hour, ("{0:00}" -f [int]$minute), $Entry.Duration, $Entry.Created
+}
+
+Export-ModuleMember -Function `
+    Set-CronManagerConfig, `
+    Get-ClaudeOSCronEntries, `
+    Add-ClaudeOSCronEntry, `
+    Remove-ClaudeOSCronEntry, `
+    Remove-AllClaudeOSCronEntries, `
+    Format-CronExpression, `
+    Format-CronEntryForDisplay, `
+    New-CronEntryId, `
+    Get-DayOfWeekLabel

--- a/scripts/lib/SessionTabManager.psm1
+++ b/scripts/lib/SessionTabManager.psm1
@@ -1,0 +1,148 @@
+# ============================================================
+# SessionTabManager.psm1 - セッション状態 (session.json) 管理
+# ClaudeOS v3.1.0 / 情報タブ表示の single source of truth
+# ============================================================
+
+Set-StrictMode -Version Latest
+
+function Get-SessionDir {
+    param([string]$ConfigSessionsDir = '')
+
+    if (-not [string]::IsNullOrWhiteSpace($ConfigSessionsDir)) {
+        return [Environment]::ExpandEnvironmentVariables($ConfigSessionsDir)
+    }
+    return (Join-Path $env:USERPROFILE '.claudeos\sessions')
+}
+
+function New-SessionId {
+    param(
+        [Parameter(Mandatory)][string]$Project
+    )
+    $safe = $Project -replace '[^A-Za-z0-9_-]', '_'
+    $stamp = (Get-Date -Format 'yyyyMMdd-HHmmss')
+    return "$stamp-$safe"
+}
+
+function New-SessionInfo {
+    param(
+        [Parameter(Mandatory)][string]$Project,
+        [int]$DurationMinutes = 300,
+        [ValidateSet('manual', 'cron')]
+        [string]$Trigger = 'manual',
+        [int]$Pid = 0,
+        [string]$ConfigSessionsDir = ''
+    )
+
+    $sessionId = New-SessionId -Project $Project
+    $start = Get-Date
+    $end = $start.AddMinutes($DurationMinutes)
+
+    $session = [pscustomobject]@{
+        sessionId            = $sessionId
+        project              = $Project
+        trigger              = $Trigger
+        start_time           = $start.ToString('o')
+        max_duration_minutes = $DurationMinutes
+        end_time_planned     = $end.ToString('o')
+        status               = 'running'
+        pid                  = $Pid
+        last_updated         = $start.ToString('o')
+    }
+
+    $dir = Get-SessionDir -ConfigSessionsDir $ConfigSessionsDir
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    }
+
+    Save-SessionInfo -Session $session -ConfigSessionsDir $ConfigSessionsDir | Out-Null
+    return $session
+}
+
+function Save-SessionInfo {
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Session,
+        [string]$ConfigSessionsDir = ''
+    )
+
+    $dir = Get-SessionDir -ConfigSessionsDir $ConfigSessionsDir
+    $path = Join-Path $dir ("{0}.json" -f $Session.sessionId)
+    $tmpPath = "$path.tmp"
+
+    # atomic rename: .tmp に書いてから Move-Item で上書き（部分書込み事故を防ぐ）
+    $Session.last_updated = (Get-Date).ToString('o')
+    $json = $Session | ConvertTo-Json -Depth 5
+    Set-Content -Path $tmpPath -Value $json -Encoding UTF8
+    Move-Item -Path $tmpPath -Destination $path -Force
+    return $path
+}
+
+function Get-SessionInfo {
+    param(
+        [Parameter(Mandatory)][string]$SessionId,
+        [string]$ConfigSessionsDir = ''
+    )
+
+    $dir = Get-SessionDir -ConfigSessionsDir $ConfigSessionsDir
+    $path = Join-Path $dir "$SessionId.json"
+    if (-not (Test-Path $path)) {
+        return $null
+    }
+    return (Get-Content $path -Raw -Encoding UTF8 | ConvertFrom-Json)
+}
+
+function Set-SessionStatus {
+    param(
+        [Parameter(Mandatory)][string]$SessionId,
+        [Parameter(Mandatory)]
+        [ValidateSet('running', 'completed', 'cancelled', 'exited', 'failed')]
+        [string]$Status,
+        [string]$ConfigSessionsDir = ''
+    )
+
+    $session = Get-SessionInfo -SessionId $SessionId -ConfigSessionsDir $ConfigSessionsDir
+    if ($null -eq $session) { return $null }
+    $session.status = $Status
+    return (Save-SessionInfo -Session $session -ConfigSessionsDir $ConfigSessionsDir)
+}
+
+function Update-SessionDuration {
+    param(
+        [Parameter(Mandatory)][string]$SessionId,
+        [Parameter(Mandatory)][int]$DurationMinutes,
+        [string]$ConfigSessionsDir = ''
+    )
+
+    $session = Get-SessionInfo -SessionId $SessionId -ConfigSessionsDir $ConfigSessionsDir
+    if ($null -eq $session) { return $null }
+
+    # 開始時刻起点で end_time_planned を再計算
+    $start = [datetime]::Parse($session.start_time)
+    $session.max_duration_minutes = $DurationMinutes
+    $session.end_time_planned = $start.AddMinutes($DurationMinutes).ToString('o')
+    return (Save-SessionInfo -Session $session -ConfigSessionsDir $ConfigSessionsDir)
+}
+
+function Get-ActiveSession {
+    param([string]$ConfigSessionsDir = '')
+
+    $dir = Get-SessionDir -ConfigSessionsDir $ConfigSessionsDir
+    if (-not (Test-Path $dir)) { return $null }
+
+    $latest = Get-ChildItem -Path $dir -Filter '*.json' -ErrorAction SilentlyContinue |
+        Where-Object {
+            try {
+                $s = Get-Content $_.FullName -Raw -Encoding UTF8 | ConvertFrom-Json
+                $s.status -eq 'running'
+            }
+            catch { $false }
+        } |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1
+
+    if ($null -eq $latest) { return $null }
+    return (Get-Content $latest.FullName -Raw -Encoding UTF8 | ConvertFrom-Json)
+}
+
+Export-ModuleMember -Function New-SessionInfo, Save-SessionInfo, Get-SessionInfo, `
+    Set-SessionStatus, Update-SessionDuration, Get-ActiveSession, `
+    Get-SessionDir, New-SessionId

--- a/scripts/lib/StatuslineManager.psm1
+++ b/scripts/lib/StatuslineManager.psm1
@@ -1,0 +1,102 @@
+# ============================================================
+# StatuslineManager.psm1 - Statusline グローバル設定の Linux 同期
+# ClaudeOS v3.1.0 / メニュー 13 の中核
+# ============================================================
+
+Set-StrictMode -Version Latest
+
+function Get-GlobalStatusLineConfig {
+    <#
+    .SYNOPSIS Windows 側 ~/.claude/settings.json から statusLine セクションを抽出
+    #>
+    param([string]$SettingsPath = '')
+
+    if ([string]::IsNullOrWhiteSpace($SettingsPath)) {
+        $SettingsPath = Join-Path $env:USERPROFILE '.claude\settings.json'
+    }
+
+    if (-not (Test-Path $SettingsPath)) {
+        return [pscustomobject]@{
+            found = $false
+            path = $SettingsPath
+            statusLine = $null
+            raw = $null
+        }
+    }
+
+    try {
+        $content = Get-Content $SettingsPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $statusLine = if ($content.PSObject.Properties.Name -contains 'statusLine') { $content.statusLine } else { $null }
+        return [pscustomobject]@{
+            found = $true
+            path = $SettingsPath
+            statusLine = $statusLine
+            raw = $content
+        }
+    }
+    catch {
+        throw "設定ファイルの解析に失敗しました: $SettingsPath ($($_.Exception.Message))"
+    }
+}
+
+function Invoke-RemoteSettingsSync {
+    <#
+    .SYNOPSIS Linux 側 ~/.claude/settings.json に statusLine を merge
+    .DESCRIPTION
+      既存ファイルがあればバックアップを取り、Python (Linux 標準) で JSON merge
+    #>
+    param(
+        [Parameter(Mandatory)][string]$LinuxHost,
+        [Parameter(Mandatory)][object]$StatusLine,
+        [switch]$Backup
+    )
+
+    $jsonPayload = $StatusLine | ConvertTo-Json -Depth 10 -Compress
+    $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($jsonPayload))
+    $backupLine = if ($Backup) {
+        'if [ -f "$TARGET" ]; then cp "$TARGET" "$TARGET.bak-$(date +%Y%m%d-%H%M%S)"; fi'
+    } else { '' }
+
+    $script = @"
+set -e
+TARGET="`$HOME/.claude/settings.json"
+mkdir -p "`$(dirname "`$TARGET")"
+$backupLine
+if [ ! -f "`$TARGET" ]; then
+  echo "{}" > "`$TARGET"
+fi
+python3 - "`$TARGET" "$b64" <<'PYEOF'
+import json, sys, base64
+path = sys.argv[1]
+status_line = json.loads(base64.b64decode(sys.argv[2]).decode('utf-8'))
+try:
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+except Exception:
+    data = {}
+data['statusLine'] = status_line
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(data, f, ensure_ascii=False, indent=2)
+print('[OK] statusLine を適用しました:', path)
+PYEOF
+"@
+
+    $sshExe = if ($env:AI_STARTUP_SSH_EXE) { $env:AI_STARTUP_SSH_EXE } else { 'ssh' }
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $sshExe
+    $psi.Arguments = "-T -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o ControlMaster=no $LinuxHost `"bash -s`""
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardInput = $true
+
+    $proc = [System.Diagnostics.Process]::new()
+    $proc.StartInfo = $psi
+    [void]$proc.Start()
+    $proc.StandardInput.NewLine = "`n"
+    $proc.StandardInput.Write(($script -replace "`r`n", "`n"))
+    $proc.StandardInput.WriteLine()
+    $proc.StandardInput.Close()
+    $proc.WaitForExit()
+    return $proc.ExitCode
+}
+
+Export-ModuleMember -Function Get-GlobalStatusLineConfig, Invoke-RemoteSettingsSync

--- a/scripts/main/New-CronSchedule.ps1
+++ b/scripts/main/New-CronSchedule.ps1
@@ -1,0 +1,221 @@
+<#
+.SYNOPSIS
+    メニュー 12 本体。Linux crontab の CLAUDEOS エントリを対話的に登録・編集・削除する。
+.DESCRIPTION
+    ClaudeOS v3.1.0
+#>
+
+param(
+    [switch]$NonInteractive
+)
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\LauncherCommon.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\Config.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\CronManager.psm1') -Force -DisableNameChecking
+
+$ConfigPath = Get-StartupConfigPath -StartupRoot $ScriptRoot
+$Config = Import-LauncherConfig -ConfigPath $ConfigPath
+$LinuxHost = $Config.linuxHost
+
+if ([string]::IsNullOrWhiteSpace($LinuxHost) -or $LinuxHost -eq '<your-linux-host>') {
+    Write-Host "[ERROR] config.json の linuxHost が未設定です。" -ForegroundColor Red
+    exit 1
+}
+
+# CronManager 設定を config から反映
+if ($Config.PSObject.Properties.Name -contains 'cron') {
+    $cronConfig = $Config.cron
+    $prefix = if ($cronConfig.PSObject.Properties.Name -contains 'entryPrefix') { $cronConfig.entryPrefix } else { 'CLAUDEOS' }
+    $launcher = if ($cronConfig.PSObject.Properties.Name -contains 'launcherPath') { $cronConfig.launcherPath } else { '/home/kensan/.claudeos/cron-launcher.sh' }
+    $logs = if ($cronConfig.PSObject.Properties.Name -contains 'logsDir') { $cronConfig.logsDir } else { '/home/kensan/.claudeos/logs' }
+    Set-CronManagerConfig -EntryPrefix $prefix -LauncherPath $launcher -LogsDir $logs
+}
+
+$defaultDuration = if ($Config.PSObject.Properties.Name -contains 'cron' -and $Config.cron.PSObject.Properties.Name -contains 'defaultDurationMinutes') {
+    [int]$Config.cron.defaultDurationMinutes
+} else { 300 }
+
+function Show-CronMenu {
+    Clear-Host
+    Write-Host ""
+    Write-Host "  =========================================" -ForegroundColor Cyan
+    Write-Host "   Cron 登録・編集・削除 (Linux: $LinuxHost)" -ForegroundColor Cyan
+    Write-Host "  =========================================" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "    [1] 新規登録" -ForegroundColor Yellow
+    Write-Host "    [2] 一覧" -ForegroundColor Yellow
+    Write-Host "    [3] 編集" -ForegroundColor Yellow
+    Write-Host "    [4] 削除 (ID 指定)" -ForegroundColor Yellow
+    Write-Host "    [5] 全解除" -ForegroundColor Yellow
+    Write-Host "    [0] 戻る" -ForegroundColor Gray
+    Write-Host ""
+}
+
+function Get-ProjectList {
+    # Linux 側の /home/kensan/Projects を ssh ls で取得
+    $sshExe = if ($env:AI_STARTUP_SSH_EXE) { $env:AI_STARTUP_SSH_EXE } else { 'ssh' }
+    $base = $Config.linuxBase
+    $output = & $sshExe -T -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o ControlMaster=no `
+        $LinuxHost "ls -1 '$base' 2>/dev/null | grep -v '^\.'"
+    if ($null -eq $output) { return @() }
+    return @($output | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Select-Project {
+    $projects = Get-ProjectList
+    if ($projects.Count -eq 0) {
+        Write-Host "  プロジェクト一覧が取得できません。手動入力してください。" -ForegroundColor Yellow
+        $name = Read-Host "  プロジェクト名"
+        return $name.Trim()
+    }
+    Write-Host ""
+    Write-Host "  -- プロジェクト一覧 --" -ForegroundColor Cyan
+    for ($i = 0; $i -lt $projects.Count; $i++) {
+        Write-Host ("    [{0}] {1}" -f ($i + 1), $projects[$i]) -ForegroundColor White
+    }
+    Write-Host ""
+    $idx = Read-Host "  番号を入力"
+    if ($idx -match '^\d+$') {
+        $n = [int]$idx - 1
+        if ($n -ge 0 -and $n -lt $projects.Count) { return $projects[$n] }
+    }
+    Write-Host "  無効な番号です" -ForegroundColor Red
+    return $null
+}
+
+function Select-DayOfWeek {
+    Write-Host ""
+    Write-Host "  -- 曜日選択 (複数可、カンマ区切り) --" -ForegroundColor Cyan
+    Write-Host "    0=日 1=月 2=火 3=水 4=木 5=金 6=土" -ForegroundColor DarkGray
+    $input = Read-Host "  曜日 (例: 0 または 1,3,5)"
+    $list = @()
+    foreach ($token in ($input -split ',')) {
+        $t = $token.Trim()
+        if ($t -match '^\d$') { $list += [int]$t }
+    }
+    if ($list.Count -eq 0) {
+        Write-Host "  曜日を 1 つ以上指定してください" -ForegroundColor Red
+        return $null
+    }
+    return $list
+}
+
+function Invoke-Register {
+    $project = Select-Project
+    if ([string]::IsNullOrWhiteSpace($project)) { return }
+
+    $dow = Select-DayOfWeek
+    if ($null -eq $dow) { return }
+
+    $time = Read-Host "  時刻 (HH:MM, 例: 21:00)"
+    $durationInput = Read-Host "  作業時間 (分、Enter で $defaultDuration)"
+    $duration = if ([string]::IsNullOrWhiteSpace($durationInput)) { $defaultDuration } else { [int]$durationInput }
+
+    Write-Host ""
+    Write-Host "  == 確認 ==" -ForegroundColor Yellow
+    Write-Host "    プロジェクト : $project"
+    Write-Host "    曜日         : $(($dow | ForEach-Object { Get-DayOfWeekLabel -Dow $_ }) -join '/')"
+    Write-Host "    時刻         : $time"
+    Write-Host "    作業時間     : $duration 分"
+    Write-Host ""
+    $confirm = Read-Host "  登録しますか? [y/N]"
+    if ($confirm -notmatch '^[yY]') {
+        Write-Host "  キャンセルしました" -ForegroundColor Yellow
+        return
+    }
+
+    try {
+        $entry = Add-ClaudeOSCronEntry -LinuxHost $LinuxHost -Project $project -DayOfWeek $dow -Time $time -DurationMinutes $duration
+        Write-Host ""
+        Write-Host "  [OK] Cron エントリを登録しました: ID=$($entry.Id)" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "  [ERROR] $($_.Exception.Message)" -ForegroundColor Red
+    }
+}
+
+function Invoke-List {
+    $entries = Get-ClaudeOSCronEntries -LinuxHost $LinuxHost
+    Write-Host ""
+    if ($entries.Count -eq 0) {
+        Write-Host "  登録済みの CLAUDEOS Cron エントリはありません。" -ForegroundColor Yellow
+        return
+    }
+    Write-Host "  -- 登録済み Cron エントリ ($($entries.Count) 件) --" -ForegroundColor Cyan
+    foreach ($e in $entries) {
+        Write-Host ("    " + (Format-CronEntryForDisplay -Entry $e)) -ForegroundColor White
+    }
+}
+
+function Invoke-Edit {
+    Invoke-List
+    $entries = Get-ClaudeOSCronEntries -LinuxHost $LinuxHost
+    if ($entries.Count -eq 0) { return }
+    $id = Read-Host "  編集対象の ID"
+    $target = $entries | Where-Object { $_.Id -eq $id }
+    if ($null -eq $target) {
+        Write-Host "  ID が見つかりません: $id" -ForegroundColor Red
+        return
+    }
+    Write-Host "  一度削除して新規登録します。項目を再入力してください。" -ForegroundColor Cyan
+    Remove-ClaudeOSCronEntry -LinuxHost $LinuxHost -Id $id | Out-Null
+    Invoke-Register
+}
+
+function Invoke-Remove {
+    Invoke-List
+    $entries = Get-ClaudeOSCronEntries -LinuxHost $LinuxHost
+    if ($entries.Count -eq 0) { return }
+    $id = Read-Host "  削除対象の ID"
+    try {
+        $removed = Remove-ClaudeOSCronEntry -LinuxHost $LinuxHost -Id $id
+        if ($removed -gt 0) {
+            Write-Host "  [OK] 削除しました: ID=$id" -ForegroundColor Green
+        }
+        else {
+            Write-Host "  [INFO] 該当する ID がありません" -ForegroundColor Yellow
+        }
+    }
+    catch {
+        Write-Host "  [ERROR] $($_.Exception.Message)" -ForegroundColor Red
+    }
+}
+
+function Invoke-RemoveAll {
+    $confirm = Read-Host "  全 CLAUDEOS エントリを削除します。本当によろしいですか? [y/N]"
+    if ($confirm -notmatch '^[yY]') {
+        Write-Host "  キャンセルしました" -ForegroundColor Yellow
+        return
+    }
+    try {
+        $removed = Remove-AllClaudeOSCronEntries -LinuxHost $LinuxHost
+        Write-Host "  [OK] $removed 件削除しました" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "  [ERROR] $($_.Exception.Message)" -ForegroundColor Red
+    }
+}
+
+if ($NonInteractive) { exit 0 }
+
+while ($true) {
+    Show-CronMenu
+    $choice = Read-Host "  番号を入力"
+    switch ($choice) {
+        '1' { Invoke-Register; Read-Host "  Enter で戻ります" | Out-Null }
+        '2' { Invoke-List; Read-Host "  Enter で戻ります" | Out-Null }
+        '3' { Invoke-Edit; Read-Host "  Enter で戻ります" | Out-Null }
+        '4' { Invoke-Remove; Read-Host "  Enter で戻ります" | Out-Null }
+        '5' { Invoke-RemoveAll; Read-Host "  Enter で戻ります" | Out-Null }
+        '0' { exit 0 }
+        default {
+            Write-Host "  無効な入力" -ForegroundColor Red
+            Start-Sleep -Seconds 1
+        }
+    }
+}

--- a/scripts/main/Set-Statusline.ps1
+++ b/scripts/main/Set-Statusline.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    メニュー 13 本体。Windows 側 ~/.claude/settings.json の statusLine を Linux 側へ同期する。
+.DESCRIPTION
+    ClaudeOS v3.1.0 / Statusline グローバル設定を全プロジェクトに一括適用
+#>
+
+param(
+    [switch]$NonInteractive
+)
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\LauncherCommon.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\Config.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\StatuslineManager.psm1') -Force -DisableNameChecking
+
+$ConfigPath = Get-StartupConfigPath -StartupRoot $ScriptRoot
+$Config = Import-LauncherConfig -ConfigPath $ConfigPath
+$LinuxHost = $Config.linuxHost
+
+Write-Host ""
+Write-Host "  =========================================" -ForegroundColor Cyan
+Write-Host "   Statusline グローバル設定 適用" -ForegroundColor Cyan
+Write-Host "  =========================================" -ForegroundColor Cyan
+Write-Host ""
+
+$sourcePath = if ($Config.PSObject.Properties.Name -contains 'statusline' -and `
+    $Config.statusline.PSObject.Properties.Name -contains 'sourceSettingsPath') {
+    [Environment]::ExpandEnvironmentVariables($Config.statusline.sourceSettingsPath)
+} else {
+    Join-Path $env:USERPROFILE '.claude\settings.json'
+}
+$backup = if ($Config.PSObject.Properties.Name -contains 'statusline' -and `
+    $Config.statusline.PSObject.Properties.Name -contains 'backupBeforeApply') {
+    [bool]$Config.statusline.backupBeforeApply
+} else { $true }
+
+Write-Host "  ソース     : $sourcePath" -ForegroundColor Gray
+Write-Host "  ターゲット : ${LinuxHost}:~/.claude/settings.json" -ForegroundColor Gray
+Write-Host "  バックアップ: $backup" -ForegroundColor Gray
+Write-Host ""
+
+try {
+    $global = Get-GlobalStatusLineConfig -SettingsPath $sourcePath
+}
+catch {
+    Write-Host "  [ERROR] $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
+
+if (-not $global.found) {
+    Write-Host "  [WARN] ソースの settings.json が存在しません: $sourcePath" -ForegroundColor Yellow
+    Write-Host "  先に Windows 側で ClaudeCode の statusLine を設定してください。" -ForegroundColor Yellow
+    exit 0
+}
+
+if ($null -eq $global.statusLine) {
+    Write-Host "  [INFO] ソース settings.json に statusLine セクションがありません。" -ForegroundColor Yellow
+    Write-Host "  ~/.claude/settings.json の statusLine を先に設定してください。" -ForegroundColor Yellow
+    exit 0
+}
+
+Write-Host "  -- 適用内容のプレビュー --" -ForegroundColor Cyan
+Write-Host ($global.statusLine | ConvertTo-Json -Depth 10) -ForegroundColor White
+Write-Host ""
+
+if (-not $NonInteractive) {
+    $confirm = Read-Host "  Linux 側へ適用します。よろしいですか? [y/N]"
+    if ($confirm -notmatch '^[yY]') {
+        Write-Host "  キャンセルしました" -ForegroundColor Yellow
+        exit 0
+    }
+}
+
+try {
+    $rc = Invoke-RemoteSettingsSync -LinuxHost $LinuxHost -StatusLine $global.statusLine -Backup:$backup
+    if ($rc -eq 0) {
+        Write-Host "  [OK] Statusline 設定を同期しました。" -ForegroundColor Green
+        Write-Host "  次回 ClaudeCode 起動時から全プロジェクトで有効になります。" -ForegroundColor DarkGray
+    }
+    else {
+        Write-Host "  [ERROR] 同期に失敗 (exit=$rc)" -ForegroundColor Red
+        exit $rc
+    }
+}
+catch {
+    Write-Host "  [ERROR] $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}

--- a/scripts/main/Show-SessionInfoTab.ps1
+++ b/scripts/main/Show-SessionInfoTab.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+    Windows Terminal に情報タブ（Claude Session Info）を 1 枚開く。
+.DESCRIPTION
+    wt.exe -w 0 new-tab で新規タブを生成し、Watch-SessionInfo.ps1 を開始する。
+    wt.exe が無い環境では Start-Process フォールバックを使う。
+    ClaudeOS v3.1.0
+#>
+
+param(
+    [Parameter(Mandatory)][string]$SessionId,
+    [string]$SessionsDir = '',
+    [string]$Title = 'Claude Session Info',
+    [int]$PollIntervalSeconds = 1
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$WatchScript = Join-Path $ScriptRoot 'scripts\tools\Watch-SessionInfo.ps1'
+
+if (-not (Test-Path $WatchScript)) {
+    Write-Host "[ERROR] Watch-SessionInfo.ps1 が見つかりません: $WatchScript" -ForegroundColor Red
+    exit 1
+}
+
+$wtExe = Get-Command wt.exe -ErrorAction SilentlyContinue
+$psExe = (Get-Process -Id $PID).Path
+
+# Watch-SessionInfo.ps1 への引数
+$psArgs = @(
+    '-NoExit',
+    '-NoProfile',
+    '-ExecutionPolicy', 'Bypass',
+    '-File', $WatchScript,
+    '-SessionId', $SessionId,
+    '-PollIntervalSeconds', $PollIntervalSeconds
+)
+if (-not [string]::IsNullOrWhiteSpace($SessionsDir)) {
+    $psArgs += @('-SessionsDir', $SessionsDir)
+}
+
+try {
+    if ($wtExe) {
+        # wt.exe 経由で同一ウィンドウ (w 0) に新タブ
+        $wtArgs = @('-w', '0', 'new-tab', '--title', $Title, $psExe) + $psArgs
+        Start-Process -FilePath $wtExe.Source -ArgumentList $wtArgs -WindowStyle Hidden
+        Write-Host "[INFO] Claude Session Info タブを開きました (wt.exe)" -ForegroundColor Cyan
+    }
+    else {
+        # フォールバック: 独立した PowerShell ウィンドウを起動
+        Start-Process -FilePath $psExe -ArgumentList $psArgs -WindowStyle Normal
+        Write-Host "[INFO] Claude Session Info ウィンドウを開きました (wt.exe 非検出、フォールバック)" -ForegroundColor Yellow
+    }
+    exit 0
+}
+catch {
+    Write-Host "[WARN] Session Info タブの起動に失敗: $($_.Exception.Message)" -ForegroundColor Yellow
+    Write-Host "[WARN] セッション本体は継続します。" -ForegroundColor Yellow
+    exit 0
+}

--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -20,6 +20,7 @@ Import-Module (Join-Path $ScriptRoot 'scripts\lib\LauncherCommon.psm1') -Force -
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\Config.psm1') -Force -DisableNameChecking
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\McpHealthCheck.psm1') -Force -DisableNameChecking
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\AgentTeams.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\SessionTabManager.psm1') -Force -DisableNameChecking
 
 $ScriptRoot = Get-StartupRoot -PSScriptRootPath $PSScriptRoot
 $ConfigPath = Get-StartupConfigPath -StartupRoot $ScriptRoot
@@ -190,6 +191,38 @@ try {
         exit 0
     }
 
+    # --- Session Info Tab (v3.1.0) ---
+    # session.json を生成して、Windows Terminal に情報タブを 1 枚開く。
+    $sessionDurationMin = 300
+    if ($Config.PSObject.Properties.Name -contains 'sessionTabs' -and $Config.sessionTabs.enabled) {
+        try {
+            $sessionsDir = if ($Config.sessionTabs.PSObject.Properties.Name -contains 'localSessionsDir') {
+                [Environment]::ExpandEnvironmentVariables($Config.sessionTabs.localSessionsDir)
+            } else { '' }
+
+            $session = New-SessionInfo -Project $Project -DurationMinutes $sessionDurationMin `
+                -Trigger 'manual' -Pid $PID -ConfigSessionsDir $sessionsDir
+            $env:CLAUDE_SESSION_ID = $session.sessionId
+            $launchContext | Add-Member -NotePropertyName 'SessionId' -NotePropertyValue $session.sessionId -Force
+
+            $tabLauncher = Join-Path $ScriptRoot 'scripts\main\Show-SessionInfoTab.ps1'
+            if (Test-Path $tabLauncher) {
+                $tabArgs = @(
+                    '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $tabLauncher,
+                    '-SessionId', $session.sessionId
+                )
+                if (-not [string]::IsNullOrWhiteSpace($sessionsDir)) {
+                    $tabArgs += @('-SessionsDir', $sessionsDir)
+                }
+                Start-Process -FilePath (Get-Process -Id $PID).Path -ArgumentList $tabArgs -WindowStyle Hidden
+                Write-Info "Session Info タブを起動: $($session.sessionId)"
+            }
+        }
+        catch {
+            Write-Warn "Session Info タブの起動をスキップ: $($_.Exception.Message)"
+        }
+    }
+
     # --- Instance Lock: 同一プロジェクトの多重起動を防止 ---
     # PTY bridge が stdin (fd 0) を同時にrawモードで取り合うと片方が永久にフリーズするため、
     # Named Mutex で同一プロジェクトのインスタンスを1つに制限する。
@@ -354,6 +387,15 @@ try {
         (New-RemoteTemplateDeployScript -TemplatePath $templatePrompt -TargetPath "$linuxProject/.claude/START_PROMPT.md" -Label '.claude/START_PROMPT.md' -EnsureParentDirectory)
         (New-RemoteTemplateDeployScript -TemplatePath $bridgeSource -TargetPath $remoteBridgePath -Label '.claude/claude_pty_bridge.py' -EnsureParentDirectory)
         (New-RemoteTemplateDeployScript -TemplatePath (Join-Path $ScriptRoot 'scripts\templates\claude-statusline.py') -TargetPath "$linuxProject/.claude/statusline.py" -Label '.claude/statusline.py' -EnsureParentDirectory)
+        # v3.1.0: Slash commands (cron / work-time / session-info) を .claude/commands に配布
+        (New-RemoteTemplateDeployScript -TemplatePath (Join-Path $ScriptRoot 'Claude\templates\claudeos\commands\cron-register.md') -TargetPath "$linuxProject/.claude/commands/cron-register.md" -Label '.claude/commands/cron-register.md' -EnsureParentDirectory)
+        (New-RemoteTemplateDeployScript -TemplatePath (Join-Path $ScriptRoot 'Claude\templates\claudeos\commands\cron-cancel.md') -TargetPath "$linuxProject/.claude/commands/cron-cancel.md" -Label '.claude/commands/cron-cancel.md' -EnsureParentDirectory)
+        (New-RemoteTemplateDeployScript -TemplatePath (Join-Path $ScriptRoot 'Claude\templates\claudeos\commands\cron-list.md') -TargetPath "$linuxProject/.claude/commands/cron-list.md" -Label '.claude/commands/cron-list.md' -EnsureParentDirectory)
+        (New-RemoteTemplateDeployScript -TemplatePath (Join-Path $ScriptRoot 'Claude\templates\claudeos\commands\work-time-set.md') -TargetPath "$linuxProject/.claude/commands/work-time-set.md" -Label '.claude/commands/work-time-set.md' -EnsureParentDirectory)
+        (New-RemoteTemplateDeployScript -TemplatePath (Join-Path $ScriptRoot 'Claude\templates\claudeos\commands\work-time-reset.md') -TargetPath "$linuxProject/.claude/commands/work-time-reset.md" -Label '.claude/commands/work-time-reset.md' -EnsureParentDirectory)
+        (New-RemoteTemplateDeployScript -TemplatePath (Join-Path $ScriptRoot 'Claude\templates\claudeos\commands\session-info.md') -TargetPath "$linuxProject/.claude/commands/session-info.md" -Label '.claude/commands/session-info.md' -EnsureParentDirectory)
+        # v3.1.0: cron-launcher.sh を ~/.claudeos/ に配布
+        (New-RemoteTemplateDeployScript -TemplatePath (Join-Path $ScriptRoot 'Claude\templates\linux\cron-launcher.sh') -TargetPath "~/.claudeos/cron-launcher.sh" -Label '~/.claudeos/cron-launcher.sh' -EnsureParentDirectory)
 @"
 cat > $(ConvertTo-BashSingleQuoted -Value $remoteBootstrap) <<'EOF'
 #!/usr/bin/env bash
@@ -417,6 +459,28 @@ finally {
     if ($Config) {
         Complete-LauncherExecutionContext -Context $launchContext -Config $Config
     }
+
+    # --- Session Info Tab: status を最終状態へ更新 (v3.1.0) ---
+    if ($launchContext -and ($launchContext.PSObject.Properties.Name -contains 'SessionId') -and $launchContext.SessionId) {
+        try {
+            $sessionsDir = if ($Config -and $Config.PSObject.Properties.Name -contains 'sessionTabs' -and `
+                $Config.sessionTabs.PSObject.Properties.Name -contains 'localSessionsDir') {
+                [Environment]::ExpandEnvironmentVariables($Config.sessionTabs.localSessionsDir)
+            } else { '' }
+
+            $finalStatus = switch ($launchContext.Result) {
+                'success' { 'completed' }
+                'cancelled' { 'cancelled' }
+                'failure' { 'failed' }
+                default { 'exited' }
+            }
+            Set-SessionStatus -SessionId $launchContext.SessionId -Status $finalStatus -ConfigSessionsDir $sessionsDir | Out-Null
+        }
+        catch {
+            Write-Debug "Session status update failed: $_"
+        }
+    }
+
     # 終了通知音（同期再生：セッション終了を確実に通知）
     Invoke-LauncherNotificationSound -Tool 'claude' -Config $Config -Wait $true
     # インスタンスロック解放

--- a/scripts/main/Start-Menu.ps1
+++ b/scripts/main/Start-Menu.ps1
@@ -191,21 +191,17 @@ function Show-Menu {
 
     Write-Host ""
     Write-Host $sep -ForegroundColor Cyan
-    Write-Host "   AI CLI ユニバーサルスタートアップツール v3.0" -ForegroundColor Cyan
-    Write-Host "   Claude Code / Codex CLI / GitHub Copilot CLI" -ForegroundColor DarkCyan
+    Write-Host "   Claude Code ユニバーサルスタートアップツール v3.1" -ForegroundColor Cyan
+    Write-Host "   ClaudeOS v8.1 統合 / Cron / Session Info Tab" -ForegroundColor DarkCyan
     Write-Host $sep -ForegroundColor Cyan
     Write-Host ""
 
     Write-Host "  -- SSH 接続 ($LinuxHost -> $LinuxBase) --" -ForegroundColor Yellow
     Write-Host "    S1. Claude Code を起動" -ForegroundColor Yellow
-    Write-Host "    S2. Codex CLI を起動" -ForegroundColor Yellow
-    Write-Host "    S3. GitHub Copilot CLI を起動" -ForegroundColor Yellow
     Write-Host ""
 
     Write-Host "  -- ローカル ($LocalDir) --" -ForegroundColor Green
     Write-Host "    L1. Claude Code を起動" -ForegroundColor Green
-    Write-Host "    L2. Codex CLI を起動" -ForegroundColor Green
-    Write-Host "    L3. GitHub Copilot CLI を起動" -ForegroundColor Green
     Write-Host ""
 
     Write-Host "  -- 診断・セットアップ --" -ForegroundColor Magenta
@@ -216,6 +212,8 @@ function Show-Menu {
     Write-Host "    9.  Agent Teams ランタイム" -ForegroundColor Magenta
     Write-Host "    10. Worktree Manager" -ForegroundColor Magenta
     Write-Host "    11. Architecture Check" -ForegroundColor Magenta
+    Write-Host "    12. Cron 登録・編集・削除" -ForegroundColor Magenta
+    Write-Host "    13. Statusline 設定" -ForegroundColor Magenta
     Write-Host ""
 
     Write-Host "    0.  終了" -ForegroundColor Gray
@@ -289,11 +287,7 @@ while ($true) {
 
     switch ($choice.ToUpper()) {
         "S1" { Invoke-ToolFromMenu -Tool "claude" }
-        "S2" { Invoke-ToolFromMenu -Tool "codex" }
-        "S3" { Invoke-ToolFromMenu -Tool "copilot" }
         "L1" { Invoke-ToolFromMenu -Tool "claude" -Local }
-        "L2" { Invoke-ToolFromMenu -Tool "codex" -Local }
-        "L3" { Invoke-ToolFromMenu -Tool "copilot" -Local }
         "5"  { Invoke-MenuScript -File "scripts\test\Test-AllTools.ps1" }
         "6"  { Invoke-MenuScript -File "scripts\test\test-drive-mapping.ps1" }
         "7"  { Invoke-MenuScript -File "scripts\setup\setup-windows-terminal.ps1" }
@@ -301,6 +295,8 @@ while ($true) {
         "9"  { Invoke-MenuScript -File "scripts\test\Test-AgentTeams.ps1" }
         "10" { Invoke-MenuScript -File "scripts\test\Test-WorktreeManager.ps1" }
         "11" { Invoke-MenuScript -File "scripts\test\Test-ArchitectureCheck.ps1" }
+        "12" { Invoke-MenuScript -File "scripts\main\New-CronSchedule.ps1" }
+        "13" { Invoke-MenuScript -File "scripts\main\Set-Statusline.ps1" }
         "0"  { exit 0 }
         default {
             Write-Host ""

--- a/scripts/test/Test-CronAndSession.ps1
+++ b/scripts/test/Test-CronAndSession.ps1
@@ -1,0 +1,131 @@
+<#
+.SYNOPSIS
+    CronManager / SessionTabManager のスモークテスト (v3.1.0)
+.DESCRIPTION
+    SSH を伴わない純粋関数 (Format-CronExpression, New-CronEntryId) と、
+    SessionTabManager のローカルファイル CRUD を検証する。
+    Pester 非依存で実行可能。
+#>
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\CronManager.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\SessionTabManager.psm1') -Force -DisableNameChecking
+
+$script:Total = 0
+$script:Passed = 0
+$script:Failed = @()
+
+function Assert-Eq {
+    param($Expected, $Actual, [string]$Label)
+    $script:Total++
+    if ($Expected -eq $Actual) {
+        $script:Passed++
+        Write-Host "  [OK]   $Label" -ForegroundColor Green
+    }
+    else {
+        $script:Failed += $Label
+        Write-Host "  [FAIL] $Label" -ForegroundColor Red
+        Write-Host "         期待値: $Expected" -ForegroundColor DarkGray
+        Write-Host "         実際値: $Actual" -ForegroundColor DarkGray
+    }
+}
+
+function Assert-Match {
+    param([string]$Pattern, [string]$Actual, [string]$Label)
+    $script:Total++
+    if ($Actual -match $Pattern) {
+        $script:Passed++
+        Write-Host "  [OK]   $Label" -ForegroundColor Green
+    }
+    else {
+        $script:Failed += $Label
+        Write-Host "  [FAIL] $Label (pattern=$Pattern, actual=$Actual)" -ForegroundColor Red
+    }
+}
+
+function Assert-Throws {
+    param([scriptblock]$Block, [string]$Label)
+    $script:Total++
+    try {
+        & $Block
+        $script:Failed += $Label
+        Write-Host "  [FAIL] $Label (例外が発生しなかった)" -ForegroundColor Red
+    }
+    catch {
+        $script:Passed++
+        Write-Host "  [OK]   $Label" -ForegroundColor Green
+    }
+}
+
+Write-Host ""
+Write-Host "=== CronManager テスト ===" -ForegroundColor Cyan
+
+Assert-Eq '0 21 * * 0' (Format-CronExpression -DayOfWeek @(0) -Time '21:00') 'Format-CronExpression: 日曜 21:00'
+Assert-Eq '30 9 * * 1,3,5' (Format-CronExpression -DayOfWeek @(1, 3, 5) -Time '09:30') 'Format-CronExpression: 月水金 9:30'
+Assert-Eq '0 0 * * 0,1,2,3,4,5,6' (Format-CronExpression -DayOfWeek @(0, 1, 2, 3, 4, 5, 6) -Time '00:00') 'Format-CronExpression: 毎日 0:00'
+Assert-Throws { Format-CronExpression -DayOfWeek @(0) -Time '25:00' } 'Format-CronExpression: 不正時刻で例外'
+Assert-Throws { Format-CronExpression -DayOfWeek @(7) -Time '10:00' } 'Format-CronExpression: 不正曜日で例外'
+Assert-Throws { Format-CronExpression -DayOfWeek @(0) -Time 'abc' } 'Format-CronExpression: 文字列時刻で例外'
+
+$id1 = New-CronEntryId
+$id2 = New-CronEntryId
+Assert-Match '^[0-9a-f]{8}$' $id1 'New-CronEntryId: 8桁16進'
+Assert-Eq $true ($id1 -ne $id2) 'New-CronEntryId: ユニーク'
+
+Assert-Eq '日' (Get-DayOfWeekLabel -Dow 0) 'Get-DayOfWeekLabel: 0=日'
+Assert-Eq '土' (Get-DayOfWeekLabel -Dow 6) 'Get-DayOfWeekLabel: 6=土'
+
+Write-Host ""
+Write-Host "=== SessionTabManager テスト ===" -ForegroundColor Cyan
+
+# 一時ディレクトリで CRUD 検証
+$tmpDir = Join-Path $env:TEMP ("claudeos-test-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+try {
+    $sess = New-SessionInfo -Project 'test-proj' -DurationMinutes 60 -Trigger 'manual' -Pid 12345 -ConfigSessionsDir $tmpDir
+    Assert-Match 'test-proj' $sess.sessionId 'New-SessionInfo: sessionId にプロジェクト名'
+    Assert-Eq 60 $sess.max_duration_minutes 'New-SessionInfo: duration 保存'
+    Assert-Eq 'running' $sess.status 'New-SessionInfo: 初期 status=running'
+    Assert-Eq 'manual' $sess.trigger 'New-SessionInfo: trigger=manual'
+
+    $loaded = Get-SessionInfo -SessionId $sess.sessionId -ConfigSessionsDir $tmpDir
+    Assert-Eq $sess.sessionId $loaded.sessionId 'Get-SessionInfo: ラウンドトリップ'
+
+    Update-SessionDuration -SessionId $sess.sessionId -DurationMinutes 120 -ConfigSessionsDir $tmpDir | Out-Null
+    $updated = Get-SessionInfo -SessionId $sess.sessionId -ConfigSessionsDir $tmpDir
+    Assert-Eq 120 $updated.max_duration_minutes 'Update-SessionDuration: 120 分に変更'
+
+    # end_time_planned が start_time + 120 分になっていることを確認
+    $start = [datetime]::Parse($updated.start_time)
+    $end = [datetime]::Parse($updated.end_time_planned)
+    $diffMin = [int]($end - $start).TotalMinutes
+    Assert-Eq 120 $diffMin 'Update-SessionDuration: end_time_planned 再計算'
+
+    Set-SessionStatus -SessionId $sess.sessionId -Status 'completed' -ConfigSessionsDir $tmpDir | Out-Null
+    $completed = Get-SessionInfo -SessionId $sess.sessionId -ConfigSessionsDir $tmpDir
+    Assert-Eq 'completed' $completed.status 'Set-SessionStatus: completed'
+
+    # Get-ActiveSession は running 限定なので completed 後は null
+    $active = Get-ActiveSession -ConfigSessionsDir $tmpDir
+    Assert-Eq $true ($null -eq $active) 'Get-ActiveSession: completed 後は null'
+}
+finally {
+    Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "==========================================" -ForegroundColor Cyan
+Write-Host " 結果: $script:Passed / $script:Total 件成功" -ForegroundColor $(if ($script:Failed.Count -eq 0) { 'Green' } else { 'Red' })
+Write-Host "==========================================" -ForegroundColor Cyan
+
+if ($script:Failed.Count -gt 0) {
+    Write-Host ""
+    Write-Host "失敗:" -ForegroundColor Red
+    foreach ($f in $script:Failed) { Write-Host "  - $f" -ForegroundColor Red }
+    exit 1
+}
+exit 0

--- a/scripts/tools/Watch-SessionInfo.ps1
+++ b/scripts/tools/Watch-SessionInfo.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+    情報タブ内で実行されるセッション表示ループ。
+.DESCRIPTION
+    session.json を 1 秒間隔で読み直し、開始時刻 / 終了予定 / 残り時間 / status
+    を整形表示する。Ctrl+C で閉じてもセッション本体には影響しない。
+    ClaudeOS v3.1.0
+#>
+
+param(
+    [Parameter(Mandatory)][string]$SessionId,
+    [string]$SessionsDir = '',
+    [int]$PollIntervalSeconds = 1,
+    [int]$AutoCloseAfterExitSeconds = 10
+)
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\SessionTabManager.psm1') -Force -DisableNameChecking
+
+function Format-Duration {
+    param([TimeSpan]$Span)
+    if ($Span.TotalSeconds -lt 0) { return '00:00:00' }
+    return "{0:00}:{1:00}:{2:00}" -f [int]$Span.TotalHours, $Span.Minutes, $Span.Seconds
+}
+
+function Get-StatusColor {
+    param([string]$Status)
+    switch ($Status) {
+        'running'   { return 'Green' }
+        'completed' { return 'Green' }
+        'exited'    { return 'Cyan' }
+        'cancelled' { return 'Yellow' }
+        'failed'    { return 'Red' }
+        default     { return 'Gray' }
+    }
+}
+
+function Show-SessionFrame {
+    param([pscustomobject]$Session)
+
+    Clear-Host
+    $start = [datetime]::Parse($Session.start_time)
+    $end = [datetime]::Parse($Session.end_time_planned)
+    $now = Get-Date
+
+    $elapsed = $now - $start
+    $remaining = $end - $now
+    $duration = [TimeSpan]::FromMinutes($Session.max_duration_minutes)
+
+    $statusColor = Get-StatusColor -Status $Session.status
+    $title = "Claude Session Info — $($Session.project)"
+
+    Write-Host ""
+    Write-Host ("  " + "=" * 52) -ForegroundColor Cyan
+    Write-Host ("   $title") -ForegroundColor Cyan
+    Write-Host ("  " + "=" * 52) -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host ("   Session ID : " + $Session.sessionId) -ForegroundColor DarkGray
+    Write-Host ("   Trigger    : " + $Session.trigger) -ForegroundColor Gray
+    Write-Host ""
+    Write-Host ("   開始時刻   : " + $start.ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor White
+    Write-Host ("   終了予定   : " + $end.ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor White
+    Write-Host ("   作業時間   : " + ("{0}h {1:00}m ({2} 分)" -f [int]$duration.TotalHours, $duration.Minutes, $Session.max_duration_minutes)) -ForegroundColor White
+    Write-Host ""
+    Write-Host ("   経過       : " + (Format-Duration -Span $elapsed)) -ForegroundColor Yellow
+    Write-Host ("   残り       : " + (Format-Duration -Span $remaining)) -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host ("   Status     : " + $Session.status) -ForegroundColor $statusColor
+    Write-Host ""
+    Write-Host ("  " + "-" * 52) -ForegroundColor DarkGray
+    Write-Host ("   Last update: " + $now.ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor DarkGray
+    Write-Host ("   Ctrl+C でこのタブを閉じる（セッション本体は継続）") -ForegroundColor DarkGray
+    Write-Host ""
+}
+
+try {
+    while ($true) {
+        $session = Get-SessionInfo -SessionId $SessionId -ConfigSessionsDir $SessionsDir
+        if ($null -eq $session) {
+            Clear-Host
+            Write-Host ""
+            Write-Host "  セッション情報が見つかりません: $SessionId" -ForegroundColor Red
+            Write-Host "  ディレクトリ: $(Get-SessionDir -ConfigSessionsDir $SessionsDir)" -ForegroundColor DarkGray
+            Start-Sleep -Seconds 3
+            continue
+        }
+
+        Show-SessionFrame -Session $session
+
+        if ($session.status -in @('completed', 'exited', 'cancelled', 'failed')) {
+            Write-Host ("   -> セッション終了 ({0})。{1} 秒後に閉じます..." -f $session.status, $AutoCloseAfterExitSeconds) -ForegroundColor Magenta
+            Start-Sleep -Seconds $AutoCloseAfterExitSeconds
+            exit 0
+        }
+
+        Start-Sleep -Seconds $PollIntervalSeconds
+    }
+}
+catch {
+    Write-Host ""
+    Write-Host "  Watch-SessionInfo でエラー: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
## Summary

- Codex CLI / GitHub Copilot CLI の起動メニューを削除し、**Claude Code 専用ランチャー** として整理 (v3.1.0)
- **メニュー 12 (Cron 登録・編集・削除)**: Linux crontab へ `# CLAUDEOS:<uuid>` アンカ付きで週次自動起動を登録、auto mode で `timeout 5h claude` が実行される
- **メニュー 13 (Statusline 設定)**: Windows 側 `~/.claude/settings.json` の `statusLine` を Linux 側へ一括適用 (Python merge + バックアップ)
- **Windows Terminal 2 タブ構成**: S1/L1 起動時にメインタブに加えて「Claude Session Info」タブが自動生成され、開始時刻/終了予定/残時間を 1 秒間隔でカウントダウン表示
- **Slash commands 6 本**: `/cron-register` `/cron-cancel` `/cron-list` `/work-time-set` `/work-time-reset` `/session-info`

## 変更ファイル (19 = 4 modified + 15 new)

### 新規
- \`scripts/lib/CronManager.psm1\` - crontab round-trip 編集
- \`scripts/lib/SessionTabManager.psm1\` - session.json atomic CRUD
- \`scripts/lib/StatuslineManager.psm1\` - 設定同期
- \`scripts/main/New-CronSchedule.ps1\` - メニュー 12 対話 UI
- \`scripts/main/Set-Statusline.ps1\` - メニュー 13 UI
- \`scripts/main/Show-SessionInfoTab.ps1\` - \`wt.exe new-tab\` ランチャ
- \`scripts/tools/Watch-SessionInfo.ps1\` - 1 秒 poll 表示ループ
- \`scripts/test/Test-CronAndSession.ps1\` - スモークテスト
- \`Claude/templates/linux/cron-launcher.sh\` - Linux cron 実行ラッパ
- \`Claude/templates/claudeos/commands/*.md\` - Slash commands 6 本

### 修正
- \`scripts/main/Start-Menu.ps1\` - S2/S3/L2/L3 削除、12/13 追加
- \`scripts/main/Start-ClaudeCode.ps1\` - セッション情報タブ起動 + commands 配布
- \`config/config.json.template\` - cron/sessionTabs/statusline 追加、codex/copilot 無効化
- \`README.md\` - v3.1.0 新機能のドキュメント化、アーキテクチャ図更新

## Test plan

- [x] \`pwsh -File scripts/test/Test-CronAndSession.ps1\` → **19/19 PASS**
- [x] 9 本の PS ファイル構文チェック (Parser.ParseFile) 全緑
- [x] \`AI_STARTUP_MENU_TEST_EXPORT=1\` で Start-Menu.ps1 exit 0
- [ ] 実機: メニュー 12 → 新規登録 → \`ssh <host> crontab -l\` で \`# CLAUDEOS:\` 行確認
- [ ] 実機: メニュー 13 → 完了メッセージ → \`ssh <host> cat ~/.claude/settings.json\` で statusLine 反映確認
- [ ] 実機: S1 起動 → メインタブ + Session Info タブの 2 枚生成、残時間が 1 秒でカウントダウン
- [ ] 実機: ClaudeCode 内で \`/work-time-set 240\` → 情報タブの残時間即追従
- [ ] 実機: \`/exit\` → session.json status=exited、情報タブ自動 close

## 設計メモ

- Cron エントリは \`# CLAUDEOS:<uuid>\` コメントでマーキングし、他の crontab 行を破壊せず安全に Add/Remove できる伝統的なパターンを採用
- session.json は Windows 側と Linux 側で同じスキーマを共有し、どちらから起動しても情報タブが同じ表示を再生できる
- 情報タブを 3 枚 → 2 枚構成に統合することで \`wt new-tab\` 呼び出しを 1 回に減らし、タブ順序 race を回避
- Slash commands は \`.claude/commands/\` へ自動 deploy されるため、ユーザーが手動配置する必要なし

## 互換性

- Codex/Copilot 起動スクリプト (\`Start-CodexCLI.ps1\`, \`Start-CopilotCLI.ps1\`) は残置 (config.json の enabled=false で無効化)。将来復活・回帰テスト時の保険
- 既存の SSH PTY bridge / deploy 機構 / \`Resolve-LauncherProject\` はそのまま再利用

## 注意

本 PR merge 後、main 側 \`D:\\ClaudeCode-StartUpTools-New\\start.bat\` から v3.1.0 メニュー (12/13 追加) が利用可能になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * Linux上でClaudeCodeを定期実行するためのクロンスケジューリング機能
  * Windows Terminalでセッションをリアルタイム監視するSession Info Tab
  * ワークタイム管理コマンド（設定/リセット）
  * Windows-Linux間のステータスライン同期機能

* **ドキュメント**
  * 新しいスラッシュコマンド（クロン管理、セッション情報）のドキュメント追加
  * 設定ガイドの更新（v3.0.0 → v3.1.0）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->