### PR TITLE
feat(v3.2.0): Cron HTML メールレポート機能 (Visual Recap Mail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 # CHANGELOG
 
+## [v3.2.0] - 2026-04-17 — Cron HTML Mail Report
+
+### 🎯 コードネーム: Visual Recap Mail
+
+Cron で起動された ClaudeCode セッションの完了時に、**HTML 形式のレポートメール** を Gmail SMTP 経由で送信する機能を追加。アイコン + 色付き表組み + 実行サマリ + 次フェーズ提案まで含む。
+
+### 🚀 新機能
+
+- **`Claude/templates/linux/report-and-mail.py`** — Python 3 標準ライブラリのみの HTML メール送信スクリプト。
+  - ステータス判定: 🟢 completed / 🔴 failed / 🟡 timeout / 🔵 running
+  - 実行サマリ: Monitor / Development / Verify / Improvement の出現回数集計、エラー検出数、STABLE 達成判定
+  - 次フェーズ提案: ステータス + ログ集計から自動生成 (Repair / Release / Debug / Monitor 再開)
+  - インライン CSS で Gmail 表示崩れを回避
+  - SMTP 送信失敗時も `cron-launcher.sh` 全体を失敗にしない fail-soft 設計
+  - `--dry-run` で送信せず HTML プレビューを stdout 出力 (UTF-8 buffer 経由で Windows cp932 でも動作)
+- **`Claude/templates/linux/cron-launcher.sh` 改修** — `finalize` トラップ末尾で `report-and-mail.py` を best-effort 呼び出し。timeout 終了 (exit 124) を `timeout` ステータスとして区別。
+- **`config/config.json.template` 拡張** — `email` セクション追加。SMTP 認証情報は **環境変数経由** (`CLAUDEOS_SMTP_USER` / `CLAUDEOS_SMTP_PASS`)、config.json には絶対に書かない設計。
+- **`docs/common/16_HTMLメールレポート設定.md`** — Gmail アプリパスワード取得 → `~/.bashrc` または crontab 内 export での配置 → スクリプト配置 → `--dry-run` 検証 → 実機テスト送信までの完全手順ドキュメント。
+
+### 🛡️ セキュリティ設計
+
+- アプリパスワードは **config.json に書かない**(git commit リスク回避)
+- Linux 環境変数 `CLAUDEOS_SMTP_USER` / `CLAUDEOS_SMTP_PASS` で管理
+- `~/.env-claudeos` は `chmod 600` 必須
+- cron は `~/.bashrc` を読まないため、crontab 内 export または env ファイル source 方式を docs で明示
+
+### 📂 メール内容
+
+| セクション | 内容 |
+|---|---|
+| ヘッダ | プロジェクト名 + ステータスアイコン + 件名 |
+| メタ情報表 | ステータス / プロジェクト / セッション ID / ホスト / 開始 / 終了 / 総時間 / ログパス |
+| 実行サマリ表 | 4 フェーズの出現回数 + エラー数 + ログ行数 + STABLE 達成 |
+| ログ末尾 | 最後の 15 行 (ダーク背景・等幅) |
+| 次フェーズ提案 | ステータス連動の自動提案文 |
+
+### ✅ 検証
+
+- Python 3.14 syntax check pass
+- bash -n syntax check pass
+- JSON template valid
+- dry-run HTML 生成: 6505 bytes、9 項目内容検証 PASS (STABLE/時間/アイコン/フェーズ/プロジェクト名)
+
+---
+
 ## [v3.1.0] - 2026-04-16 — Cron / Session Info Tab / Statusline 全適用
 
 ### 🎯 コードネーム: Claude-Only Launcher

--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # ============================================================
 # cron-launcher.sh - Linux 側で ClaudeCode を cron から起動するラッパ
-# ClaudeOS v3.1.0
+# ClaudeOS v3.2.0
 #
 # Usage: cron-launcher.sh <project> <duration-minutes>
 #
@@ -10,6 +10,7 @@
 #   - timeout <Ns> 付きで claude を起動（auto mode）
 #   - session.json の生成・更新（start/end/status）
 #   - ログを /home/kensan/.claudeos/logs/ へ
+#   - 終了時に HTML レポートメールを送信 (v3.2.0 追加)
 # ============================================================
 
 set -euo pipefail
@@ -28,6 +29,7 @@ SESSIONS_DIR="$CLAUDEOS_HOME/sessions"
 LOGS_DIR="$CLAUDEOS_HOME/logs"
 PROJECTS_BASE="${PROJECTS_BASE:-$HOME/Projects}"
 PROJECT_DIR="$PROJECTS_BASE/$PROJECT"
+REPORT_SCRIPT="${CLAUDEOS_REPORT_SCRIPT:-$CLAUDEOS_HOME/report-and-mail.py}"
 
 mkdir -p "$SESSIONS_DIR" "$LOGS_DIR"
 chmod 700 "$CLAUDEOS_HOME" "$SESSIONS_DIR" "$LOGS_DIR" 2>/dev/null || true
@@ -69,7 +71,7 @@ finalize() {
   local final_status="completed"
   if [[ $exit_code -eq 124 ]]; then
     # timeout による終了
-    final_status="completed"
+    final_status="timeout"
   elif [[ $exit_code -ne 0 ]]; then
     final_status="failed"
   fi
@@ -91,6 +93,22 @@ finalize() {
   fi
 
   echo "[cron-launcher] session finished status=$final_status exit=$exit_code at $now" >> "$LOG_FILE"
+
+  # --- v3.2.0: HTML レポートメール送信 (best-effort、失敗しても全体は成功扱い) ---
+  if command -v python3 >/dev/null 2>&1 && [[ -f "$REPORT_SCRIPT" ]]; then
+    python3 "$REPORT_SCRIPT" \
+      --session "$SESSION_ID" \
+      --log "$LOG_FILE" \
+      --status "$final_status" \
+      --start "$START_TIME" \
+      --end "$now" \
+      --duration-min "$DURATION_MIN" \
+      --project "$PROJECT" \
+      --sessions-dir "$SESSIONS_DIR" \
+      >> "$LOG_FILE" 2>&1 || true
+  else
+    echo "[cron-launcher] report-and-mail.py をスキップ (script=$REPORT_SCRIPT, python3=$(command -v python3 || echo 'none'))" >> "$LOG_FILE"
+  fi
 }
 trap finalize EXIT
 

--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -94,8 +94,13 @@ finalize() {
 
   echo "[cron-launcher] session finished status=$final_status exit=$exit_code at $now" >> "$LOG_FILE"
 
-  # --- v3.2.0: HTML レポートメール送信 (best-effort、失敗しても全体は成功扱い) ---
-  if command -v python3 >/dev/null 2>&1 && [[ -f "$REPORT_SCRIPT" ]]; then
+  # --- v3.2.0: HTML レポートメール送信 ---
+  # 明示的トグル CLAUDEOS_EMAIL_ENABLED=1 が必要。誤送信防止のため既定 off。
+  # 加えて python3 とスクリプトの存在も確認 (best-effort、失敗しても全体は成功扱い)。
+  local email_enabled="${CLAUDEOS_EMAIL_ENABLED:-0}"
+  if [[ "$email_enabled" != "1" ]]; then
+    echo "[cron-launcher] HTML mail report skip (CLAUDEOS_EMAIL_ENABLED!=1)" >> "$LOG_FILE"
+  elif command -v python3 >/dev/null 2>&1 && [[ -f "$REPORT_SCRIPT" ]]; then
     python3 "$REPORT_SCRIPT" \
       --session "$SESSION_ID" \
       --log "$LOG_FILE" \

--- a/Claude/templates/linux/report-and-mail.py
+++ b/Claude/templates/linux/report-and-mail.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+report-and-mail.py — ClaudeOS v3.2.0
+====================================
+
+Cron で起動された ClaudeCode セッションの結果をログから解析し、
+HTML 形式のレポートメールを Gmail SMTP 経由で送信する。
+
+Usage:
+    python3 report-and-mail.py \
+        --session <session_id> \
+        --log <log_file_path> \
+        --status <completed|failed|timeout> \
+        --start <ISO8601> \
+        --end <ISO8601> \
+        --duration-min <minutes>
+
+設計原則:
+- Python 3 標準ライブラリのみ使用 (依存追加なし)
+- SMTP 認証情報は Linux 環境変数 CLAUDEOS_SMTP_USER / CLAUDEOS_SMTP_PASS から取得
+- 環境変数未設定時は警告を出して終了 (cron 全体は失敗させない)
+- HTML テンプレートはアイコン + 色付き + 表形式 (Gmail で確実に表示できるインライン CSS)
+- 全文字列は UTF-8、件名は MIME エンコード済
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import smtplib
+import socket
+import sys
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# 定数
+# ---------------------------------------------------------------------------
+
+DEFAULT_SMTP_HOST = "smtp.gmail.com"
+DEFAULT_SMTP_PORT = 587
+DEFAULT_TO = "kensan1969@gmail.com"
+DEFAULT_FROM = "kensan1969@gmail.com"
+DEFAULT_SUBJECT_PREFIX = "[ClaudeOS]"
+
+ICON = {
+    "completed": "🟢",
+    "failed": "🔴",
+    "timeout": "🟡",
+    "running": "🔵",
+    "session": "🤖",
+    "calendar": "📅",
+    "finish": "🏁",
+    "clock": "⏱",
+    "folder": "📂",
+    "summary": "📝",
+    "next": "➡️",
+    "host": "🖥",
+    "log": "📜",
+}
+
+COLOR = {
+    "completed": "#16a34a",  # green-600
+    "failed": "#dc2626",     # red-600
+    "timeout": "#ca8a04",    # yellow-600
+    "running": "#2563eb",    # blue-600
+    "header_bg": "#0f172a",  # slate-900
+    "header_fg": "#ffffff",
+    "row_bg": "#f8fafc",     # slate-50
+    "row_alt_bg": "#ffffff",
+    "border": "#cbd5e1",     # slate-300
+    "muted": "#64748b",      # slate-500
+}
+
+
+# ---------------------------------------------------------------------------
+# ログ解析
+# ---------------------------------------------------------------------------
+
+PHASE_PATTERNS = [
+    (re.compile(r"\bMonitor\b", re.IGNORECASE), "Monitor"),
+    (re.compile(r"\bDevelopment\b|\bBuild\b", re.IGNORECASE), "Development"),
+    (re.compile(r"\bVerify\b", re.IGNORECASE), "Verify"),
+    (re.compile(r"\bImprovement\b|\bImprove\b", re.IGNORECASE), "Improvement"),
+]
+
+ERROR_PATTERNS = [
+    re.compile(r"\b(error|ERROR|Error)\b"),
+    re.compile(r"\b(failed|FAILED|Failed)\b"),
+    re.compile(r"\b(traceback|Traceback)\b"),
+]
+
+STABLE_PATTERN = re.compile(r"STABLE\s*(達成|achieved)", re.IGNORECASE)
+
+
+def parse_log(log_path: Path) -> dict[str, Any]:
+    """ログファイルから集計情報を抽出する。ファイル無し/読み込み失敗時も dict を返す。"""
+    summary: dict[str, Any] = {
+        "lines_total": 0,
+        "phase_counts": {p[1]: 0 for p in PHASE_PATTERNS},
+        "error_count": 0,
+        "stable_achieved": False,
+        "tail": [],
+        "head": [],
+    }
+    if not log_path.exists():
+        summary["tail"] = ["(ログファイルが見つかりません)"]
+        return summary
+
+    try:
+        with log_path.open("r", encoding="utf-8", errors="replace") as fh:
+            lines = fh.readlines()
+    except OSError as exc:
+        summary["tail"] = [f"(ログ読み込み失敗: {exc})"]
+        return summary
+
+    summary["lines_total"] = len(lines)
+    for line in lines:
+        for pat, name in PHASE_PATTERNS:
+            if pat.search(line):
+                summary["phase_counts"][name] += 1
+                break
+        for ep in ERROR_PATTERNS:
+            if ep.search(line):
+                summary["error_count"] += 1
+                break
+        if STABLE_PATTERN.search(line):
+            summary["stable_achieved"] = True
+
+    summary["head"] = [ln.rstrip() for ln in lines[:10]]
+    summary["tail"] = [ln.rstrip() for ln in lines[-15:]]
+    return summary
+
+
+def load_session_json(session_dir: Path, session_id: str) -> dict[str, Any]:
+    """session.json があれば読み込んで dict を返す。無ければ空 dict。"""
+    candidate = session_dir / f"{session_id}.json"
+    if not candidate.exists():
+        return {}
+    try:
+        return json.loads(candidate.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def suggest_next_phase(parsed: dict[str, Any], status: str) -> str:
+    """次フェーズの提案文を生成する。ログ集計と status から判定。"""
+    if status == "failed":
+        return "🔧 Repair: 失敗原因の切り分け → 最小修正 → 再 Verify"
+    if status == "timeout":
+        return "⏸ 中断引継ぎ: state.json 確認 → 残課題整理 → 次セッションで /recap → 続行"
+    if parsed["stable_achieved"]:
+        return "🚀 Release: STABLE 達成済。次は Deploy Gate / マージ判断 → 本番反映"
+    if parsed["error_count"] > 0:
+        return "🐛 Debug: ログにエラー痕跡あり。Codex rescue で原因分析 → 最小修正"
+    if parsed["phase_counts"].get("Verify", 0) >= 1:
+        return "🔬 STABLE 判定の確定: 連続成功 N=3 を満たすか確認 → Improvement へ"
+    return "🔍 Monitor 再開: GitHub Projects / Issues / CI 状態確認 → 次タスク選定"
+
+
+# ---------------------------------------------------------------------------
+# 時刻計算
+# ---------------------------------------------------------------------------
+
+def parse_iso(value: str) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        # Python 3.11+ は fromisoformat が "+09:00" などを受け付ける
+        return dt.datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def format_duration(start: dt.datetime | None, end: dt.datetime | None) -> str:
+    if not start or not end:
+        return "(計測不能)"
+    delta = end - start
+    total_sec = int(delta.total_seconds())
+    if total_sec < 0:
+        return "(時刻順不整合)"
+    hours, rem = divmod(total_sec, 3600)
+    minutes, seconds = divmod(rem, 60)
+    return f"{hours} 時間 {minutes} 分 {seconds} 秒"
+
+
+def fmt_dt(value: dt.datetime | None) -> str:
+    if not value:
+        return "(不明)"
+    return value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+# ---------------------------------------------------------------------------
+# HTML レンダリング
+# ---------------------------------------------------------------------------
+
+def render_html(ctx: dict[str, Any]) -> str:
+    status = ctx["status"]
+    status_color = COLOR.get(status, COLOR["muted"])
+    status_icon = ICON.get(status, "⚪")
+
+    parsed = ctx["parsed"]
+    rows = [
+        ("ステータス", f"{status_icon} <strong style=\"color:{status_color}\">{status}</strong>"),
+        ("プロジェクト", f"{ICON['folder']} {html_escape(ctx['project'])}"),
+        ("セッション ID", f"{ICON['session']} <code>{html_escape(ctx['session_id'])}</code>"),
+        ("ホスト", f"{ICON['host']} {html_escape(ctx['hostname'])}"),
+        ("開始", f"{ICON['calendar']} {html_escape(ctx['start_str'])}"),
+        ("終了", f"{ICON['finish']} {html_escape(ctx['end_str'])}"),
+        ("総作業時間", f"{ICON['clock']} <strong>{html_escape(ctx['duration_str'])}</strong>"),
+        ("ログファイル", f"{ICON['log']} <code>{html_escape(ctx['log_path'])}</code>"),
+    ]
+
+    rows_html = "\n".join(
+        f'<tr style="background:{COLOR["row_bg"] if i % 2 == 0 else COLOR["row_alt_bg"]}">'
+        f'<th align="left" style="padding:8px 12px;border:1px solid {COLOR["border"]};width:32%">{label}</th>'
+        f'<td style="padding:8px 12px;border:1px solid {COLOR["border"]}">{value}</td>'
+        f"</tr>"
+        for i, (label, value) in enumerate(rows)
+    )
+
+    phase_rows = "\n".join(
+        f'<tr><td style="padding:6px 12px;border:1px solid {COLOR["border"]}">{phase}</td>'
+        f'<td align="right" style="padding:6px 12px;border:1px solid {COLOR["border"]}">{count}</td></tr>'
+        for phase, count in parsed["phase_counts"].items()
+    )
+
+    tail_html = "<br>".join(html_escape(ln) for ln in parsed["tail"]) or "(ログ末尾なし)"
+
+    return f"""<!DOCTYPE html>
+<html lang="ja"><head>
+<meta charset="UTF-8">
+<title>{html_escape(ctx['subject'])}</title>
+</head>
+<body style="font-family:'Segoe UI','Hiragino Kaku Gothic ProN','Yu Gothic UI',sans-serif;
+             color:#0f172a;background:#f1f5f9;margin:0;padding:20px">
+  <div style="max-width:760px;margin:0 auto;background:#ffffff;
+              border:1px solid {COLOR['border']};border-radius:8px;overflow:hidden">
+
+    <div style="background:{COLOR['header_bg']};color:{COLOR['header_fg']};
+                padding:18px 20px">
+      <div style="font-size:18px;font-weight:bold">
+        {ICON['session']} ClaudeOS Cron セッション完了報告
+      </div>
+      <div style="font-size:12px;color:#cbd5e1;margin-top:4px">
+        {html_escape(ctx['subject'])}
+      </div>
+    </div>
+
+    <div style="padding:20px">
+      <table cellpadding="0" cellspacing="0"
+             style="width:100%;border-collapse:collapse;font-size:14px">
+        {rows_html}
+      </table>
+
+      <h3 style="margin-top:24px;border-left:4px solid {status_color};padding-left:8px">
+        {ICON['summary']} 実行サマリー
+      </h3>
+      <table cellpadding="0" cellspacing="0"
+             style="border-collapse:collapse;font-size:13px;margin-top:8px">
+        <thead>
+          <tr style="background:{COLOR['row_bg']}">
+            <th align="left" style="padding:6px 12px;border:1px solid {COLOR['border']}">フェーズ</th>
+            <th align="right" style="padding:6px 12px;border:1px solid {COLOR['border']}">出現回数</th>
+          </tr>
+        </thead>
+        <tbody>
+          {phase_rows}
+          <tr style="background:#fef2f2">
+            <td style="padding:6px 12px;border:1px solid {COLOR['border']}">エラー検出</td>
+            <td align="right" style="padding:6px 12px;border:1px solid {COLOR['border']};
+                                     color:{'#dc2626' if parsed['error_count'] > 0 else '#16a34a'};
+                                     font-weight:bold">
+              {parsed['error_count']}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:6px 12px;border:1px solid {COLOR['border']}">ログ総行数</td>
+            <td align="right" style="padding:6px 12px;border:1px solid {COLOR['border']}">
+              {parsed['lines_total']:,}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:6px 12px;border:1px solid {COLOR['border']}">STABLE 達成</td>
+            <td align="right" style="padding:6px 12px;border:1px solid {COLOR['border']};
+                                     color:{'#16a34a' if parsed['stable_achieved'] else COLOR['muted']};
+                                     font-weight:bold">
+              {'はい' if parsed['stable_achieved'] else 'いいえ'}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3 style="margin-top:24px;border-left:4px solid {status_color};padding-left:8px">
+        {ICON['log']} ログ末尾(最後の 15 行)
+      </h3>
+      <pre style="background:#0f172a;color:#e2e8f0;padding:12px;border-radius:4px;
+                  font-size:12px;line-height:1.5;overflow-x:auto;
+                  white-space:pre-wrap;word-break:break-all">{tail_html}</pre>
+
+      <h3 style="margin-top:24px;border-left:4px solid {status_color};padding-left:8px">
+        {ICON['next']} 次の開発フェーズ提案
+      </h3>
+      <div style="padding:12px 16px;background:#f0f9ff;border:1px solid #bae6fd;
+                  border-radius:6px;font-size:14px">
+        {html_escape(ctx['next_phase'])}
+      </div>
+
+      <div style="margin-top:24px;padding-top:12px;border-top:1px solid {COLOR['border']};
+                  font-size:11px;color:{COLOR['muted']}">
+        Generated by ClaudeOS v3.2.0 report-and-mail.py · {html_escape(ctx['generated_at'])}
+      </div>
+    </div>
+  </div>
+</body></html>
+"""
+
+
+def render_text(ctx: dict[str, Any]) -> str:
+    """HTML を表示できないクライアント向けの plain text 版。"""
+    parsed = ctx["parsed"]
+    lines = [
+        f"[ClaudeOS Cron] {ctx['status']} — {ctx['project']}",
+        "",
+        f"Session  : {ctx['session_id']}",
+        f"Host     : {ctx['hostname']}",
+        f"Project  : {ctx['project']}",
+        f"Status   : {ctx['status']}",
+        f"Start    : {ctx['start_str']}",
+        f"End      : {ctx['end_str']}",
+        f"Duration : {ctx['duration_str']}",
+        f"Log      : {ctx['log_path']}",
+        "",
+        "--- Phase counts ---",
+    ]
+    for phase, count in parsed["phase_counts"].items():
+        lines.append(f"  {phase:<14} {count}")
+    lines.append(f"  Errors        {parsed['error_count']}")
+    lines.append(f"  Log lines     {parsed['lines_total']}")
+    lines.append(f"  STABLE        {'yes' if parsed['stable_achieved'] else 'no'}")
+    lines.append("")
+    lines.append("--- Log tail ---")
+    lines.extend(parsed["tail"])
+    lines.append("")
+    lines.append("--- Next phase ---")
+    lines.append(ctx["next_phase"])
+    return "\n".join(lines)
+
+
+def html_escape(value: Any) -> str:
+    text = "" if value is None else str(value)
+    return (
+        text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+            .replace("'", "&#39;")
+    )
+
+
+# ---------------------------------------------------------------------------
+# SMTP 送信
+# ---------------------------------------------------------------------------
+
+def send_mail(
+    *,
+    smtp_host: str,
+    smtp_port: int,
+    user: str,
+    password: str,
+    sender: str,
+    recipient: str,
+    subject: str,
+    text_body: str,
+    html_body: str,
+    timeout: int = 20,
+) -> None:
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = sender
+    msg["To"] = recipient
+    msg.set_content(text_body, charset="utf-8")
+    msg.add_alternative(html_body, subtype="html", charset="utf-8")
+
+    with smtplib.SMTP(smtp_host, smtp_port, timeout=timeout) as server:
+        server.ehlo()
+        server.starttls()
+        server.ehlo()
+        server.login(user, password)
+        server.send_message(msg)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="ClaudeOS cron session HTML report mailer"
+    )
+    parser.add_argument("--session", required=True, help="session id")
+    parser.add_argument("--log", required=True, help="log file path")
+    parser.add_argument("--status", required=True,
+                        choices=["completed", "failed", "timeout", "running"])
+    parser.add_argument("--start", default="", help="ISO8601 start time")
+    parser.add_argument("--end", default="", help="ISO8601 end time")
+    parser.add_argument("--duration-min", type=int, default=0,
+                        help="planned duration in minutes")
+    parser.add_argument("--project", default=os.environ.get("CLAUDE_PROJECT", ""),
+                        help="project name")
+    parser.add_argument("--sessions-dir",
+                        default=os.path.expanduser("~/.claudeos/sessions"))
+    parser.add_argument("--smtp-host", default=DEFAULT_SMTP_HOST)
+    parser.add_argument("--smtp-port", type=int, default=DEFAULT_SMTP_PORT)
+    parser.add_argument("--from-addr", default=DEFAULT_FROM)
+    parser.add_argument("--to-addr", default=DEFAULT_TO)
+    parser.add_argument("--subject-prefix", default=DEFAULT_SUBJECT_PREFIX)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="送信せず HTML を stdout に出力")
+    args = parser.parse_args()
+
+    user_env = os.environ.get("CLAUDEOS_SMTP_USER", "")
+    pass_env = os.environ.get("CLAUDEOS_SMTP_PASS", "")
+    if not args.dry_run and (not user_env or not pass_env):
+        sys.stderr.write(
+            "[report-and-mail] WARN: CLAUDEOS_SMTP_USER / CLAUDEOS_SMTP_PASS "
+            "が未設定のためメール送信をスキップ。\n"
+        )
+        return 0
+
+    log_path = Path(args.log)
+    parsed = parse_log(log_path)
+    sess_meta = load_session_json(Path(args.sessions_dir), args.session)
+
+    project = args.project or sess_meta.get("project") or "(unknown)"
+    start_dt = parse_iso(args.start) or parse_iso(sess_meta.get("start_time", ""))
+    end_dt = parse_iso(args.end) or dt.datetime.now().astimezone()
+    next_phase = suggest_next_phase(parsed, args.status)
+
+    ctx: dict[str, Any] = {
+        "session_id": args.session,
+        "project": project,
+        "status": args.status,
+        "hostname": socket.gethostname(),
+        "start_str": fmt_dt(start_dt),
+        "end_str": fmt_dt(end_dt),
+        "duration_str": format_duration(start_dt, end_dt),
+        "log_path": str(log_path),
+        "parsed": parsed,
+        "next_phase": next_phase,
+        "generated_at": dt.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S %z"),
+        "subject": (
+            f"{args.subject_prefix} {ICON.get(args.status, '⚪')} "
+            f"{args.status} — {project} ({args.session})"
+        ),
+    }
+
+    html_body = render_html(ctx)
+    text_body = render_text(ctx)
+
+    if args.dry_run:
+        # 絵文字を含む HTML を確実に UTF-8 で出力する。
+        # Windows の cp932 stdout でも UnicodeEncodeError を起こさないよう
+        # buffer に直接バイト列を書き込む (Linux でも同等に動作)。
+        sys.stdout.buffer.write(html_body.encode("utf-8"))
+        return 0
+
+    try:
+        send_mail(
+            smtp_host=args.smtp_host,
+            smtp_port=args.smtp_port,
+            user=user_env,
+            password=pass_env,
+            sender=args.from_addr,
+            recipient=args.to_addr,
+            subject=ctx["subject"],
+            text_body=text_body,
+            html_body=html_body,
+        )
+        sys.stderr.write(
+            f"[report-and-mail] sent → {args.to_addr} (session={args.session})\n"
+        )
+        return 0
+    except (smtplib.SMTPException, OSError) as exc:
+        # SMTP 送信失敗は cron 全体を失敗にしないため exit 0
+        sys.stderr.write(f"[report-and-mail] send failed: {exc}\n")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Claude/templates/linux/report-and-mail.py
+++ b/Claude/templates/linux/report-and-mail.py
@@ -44,8 +44,20 @@ from typing import Any
 
 DEFAULT_SMTP_HOST = "smtp.gmail.com"
 DEFAULT_SMTP_PORT = 587
-DEFAULT_TO = "kensan1969@gmail.com"
-DEFAULT_FROM = "kensan1969@gmail.com"
+# 配布テンプレートとして実在アドレスをハードコードしない。
+# 1) --to-addr / --from-addr で明示指定、または
+# 2) 環境変数 CLAUDEOS_DEFAULT_TO / CLAUDEOS_DEFAULT_FROM で上書き、
+# 3) 最後の fallback として CLAUDEOS_SMTP_USER (= 認証アカウント) を使う。
+DEFAULT_TO = (
+    os.environ.get("CLAUDEOS_DEFAULT_TO")
+    or os.environ.get("CLAUDEOS_SMTP_USER")
+    or ""
+)
+DEFAULT_FROM = (
+    os.environ.get("CLAUDEOS_DEFAULT_FROM")
+    or os.environ.get("CLAUDEOS_SMTP_USER")
+    or ""
+)
 DEFAULT_SUBJECT_PREFIX = "[ClaudeOS]"
 
 ICON = {
@@ -177,10 +189,24 @@ def parse_iso(value: str) -> dt.datetime | None:
         return None
 
 
+def _normalize_tz(value: dt.datetime | None) -> dt.datetime | None:
+    """tzinfo の有無を揃えて aware/naive 混在による TypeError を防ぐ。"""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        # naive はローカル TZ として解釈する
+        return value.astimezone()
+    return value
+
+
 def format_duration(start: dt.datetime | None, end: dt.datetime | None) -> str:
     if not start or not end:
         return "(計測不能)"
-    delta = end - start
+    s = _normalize_tz(start)
+    e = _normalize_tz(end)
+    if s is None or e is None:
+        return "(計測不能)"
+    delta = e - s
     total_sec = int(delta.total_seconds())
     if total_sec < 0:
         return "(時刻順不整合)"
@@ -213,6 +239,7 @@ def render_html(ctx: dict[str, Any]) -> str:
         ("開始", f"{ICON['calendar']} {html_escape(ctx['start_str'])}"),
         ("終了", f"{ICON['finish']} {html_escape(ctx['end_str'])}"),
         ("総作業時間", f"{ICON['clock']} <strong>{html_escape(ctx['duration_str'])}</strong>"),
+        ("予定時間", f"{ICON['clock']} {ctx['duration_min']} 分"),
         ("ログファイル", f"{ICON['log']} <code>{html_escape(ctx['log_path'])}</code>"),
     ]
 
@@ -433,6 +460,13 @@ def main() -> int:
         )
         return 0
 
+    if not args.dry_run and (not args.to_addr or not args.from_addr):
+        sys.stderr.write(
+            "[report-and-mail] WARN: --to-addr / --from-addr 未指定 "
+            "(CLAUDEOS_DEFAULT_TO / CLAUDEOS_DEFAULT_FROM / CLAUDEOS_SMTP_USER のいずれかで設定)。\n"
+        )
+        return 0
+
     log_path = Path(args.log)
     parsed = parse_log(log_path)
     sess_meta = load_session_json(Path(args.sessions_dir), args.session)
@@ -450,6 +484,7 @@ def main() -> int:
         "start_str": fmt_dt(start_dt),
         "end_str": fmt_dt(end_dt),
         "duration_str": format_duration(start_dt, end_dt),
+        "duration_min": args.duration_min,
         "log_path": str(log_path),
         "parsed": parsed,
         "next_phase": next_phase,

--- a/config/config.json.template
+++ b/config/config.json.template
@@ -116,6 +116,21 @@
     "logsDir": "/home/kensan/.claudeos/logs",
     "entryPrefix": "CLAUDEOS"
   },
+  "email": {
+    "_comment": "v3.2.0 新設。Cron セッション終了時に HTML レポートメールを送信。SMTP 認証情報は Linux 環境変数で管理 (CLAUDEOS_SMTP_USER / CLAUDEOS_SMTP_PASS) — config.json には書かない。詳細は docs/common/16_HTMLメールレポート設定.md を参照。",
+    "enabled": false,
+    "smtp": {
+      "host": "smtp.gmail.com",
+      "port": 587,
+      "useStartTls": true,
+      "userEnvVar": "CLAUDEOS_SMTP_USER",
+      "passEnvVar": "CLAUDEOS_SMTP_PASS"
+    },
+    "from": "kensan1969@gmail.com",
+    "to": "kensan1969@gmail.com",
+    "subjectPrefix": "[ClaudeOS]",
+    "scriptPath": "/home/kensan/.claudeos/report-and-mail.py"
+  },
   "sessionTabs": {
     "_comment": "v3.1.0 新設。Windows Terminal に情報タブを 1 枚追加し、開始/終了/残り時間をリアルタイム表示する。",
     "enabled": true,

--- a/config/config.json.template
+++ b/config/config.json.template
@@ -1,6 +1,6 @@
 {
-  "_comment": "Claude Code スタートアップツール設定テンプレート v3.1.0 - コピーしてconfig.jsonとして使用",
-  "version": "3.1.0",
+  "_comment": "Claude Code スタートアップツール設定テンプレート v3.2.0 - コピーしてconfig.jsonとして使用",
+  "version": "3.2.0",
   "projectsDir": "X:\\",
   "sshProjectsDir": "auto",
   "projectsDirUnc": "\\\\<your-linux-host>\\Projects",
@@ -117,7 +117,7 @@
     "entryPrefix": "CLAUDEOS"
   },
   "email": {
-    "_comment": "v3.2.0 新設。Cron セッション終了時に HTML レポートメールを送信。SMTP 認証情報は Linux 環境変数で管理 (CLAUDEOS_SMTP_USER / CLAUDEOS_SMTP_PASS) — config.json には書かない。詳細は docs/common/16_HTMLメールレポート設定.md を参照。",
+    "_comment": "v3.2.0 新設。Cron セッション終了時に HTML レポートメールを送信。SMTP 認証情報は Linux 環境変数で管理 (CLAUDEOS_SMTP_USER / CLAUDEOS_SMTP_PASS) — config.json には書かない。送信トリガーは Linux 側 CLAUDEOS_EMAIL_ENABLED=1 で明示的に有効化。詳細は docs/common/16_HTMLメールレポート設定.md を参照。",
     "enabled": false,
     "smtp": {
       "host": "smtp.gmail.com",
@@ -126,10 +126,11 @@
       "userEnvVar": "CLAUDEOS_SMTP_USER",
       "passEnvVar": "CLAUDEOS_SMTP_PASS"
     },
-    "from": "kensan1969@gmail.com",
-    "to": "kensan1969@gmail.com",
+    "from": "<your-email>",
+    "to": "<your-email>",
     "subjectPrefix": "[ClaudeOS]",
-    "scriptPath": "/home/kensan/.claudeos/report-and-mail.py"
+    "scriptPath": "/home/kensan/.claudeos/report-and-mail.py",
+    "enableEnvVar": "CLAUDEOS_EMAIL_ENABLED"
   },
   "sessionTabs": {
     "_comment": "v3.1.0 新設。Windows Terminal に情報タブを 1 枚追加し、開始/終了/残り時間をリアルタイム表示する。",

--- a/docs/common/16_HTMLメールレポート設定.md
+++ b/docs/common/16_HTMLメールレポート設定.md
@@ -46,6 +46,11 @@ SSH で Linux ホストに接続後、`~/.bashrc` の **末尾** に以下を追
 # ----- ClaudeOS v3.2.0 SMTP credentials -----
 export CLAUDEOS_SMTP_USER="kensan1969@gmail.com"
 export CLAUDEOS_SMTP_PASS="abcdefghijklmnop"   # 手順 1 で取得した 16 桁(スペース除去)
+# 送信先・送信元の既定 (省略時 CLAUDEOS_SMTP_USER と同じになる)
+export CLAUDEOS_DEFAULT_TO="kensan1969@gmail.com"
+export CLAUDEOS_DEFAULT_FROM="kensan1969@gmail.com"
+# ★ メール送信トグル (1 で有効、未設定または 0 で無効) — 誤送信防止のため明示的 opt-in
+export CLAUDEOS_EMAIL_ENABLED=1
 ```
 
 権限を絞ります(他ユーザーから読めないように):
@@ -63,16 +68,23 @@ crontab -e
 # 先頭に以下を追記
 # CLAUDEOS_SMTP_USER=kensan1969@gmail.com
 # CLAUDEOS_SMTP_PASS=abcdefghijklmnop
+# CLAUDEOS_EMAIL_ENABLED=1
+# CLAUDEOS_DEFAULT_TO=kensan1969@gmail.com
 
 # 方式 B: cron-launcher.sh の冒頭で source ~/.env-claudeos
 mkdir -p ~ && cat > ~/.env-claudeos <<'EOF'
 export CLAUDEOS_SMTP_USER="kensan1969@gmail.com"
 export CLAUDEOS_SMTP_PASS="abcdefghijklmnop"
+export CLAUDEOS_DEFAULT_TO="kensan1969@gmail.com"
+export CLAUDEOS_DEFAULT_FROM="kensan1969@gmail.com"
+export CLAUDEOS_EMAIL_ENABLED=1
 EOF
 chmod 600 ~/.env-claudeos
 # その後、cron-launcher.sh の冒頭に以下を追記:
 #   [[ -f ~/.env-claudeos ]] && source ~/.env-claudeos
 ```
+
+> ⚠️ **`CLAUDEOS_EMAIL_ENABLED=1` を設定しないとメール送信は実行されません**(誤送信防止のため既定 off)。dry-run と実機テスト送信は `--dry-run` および直接 `python3 report-and-mail.py` 実行で動作するため、cron 経由の送信を有効化する場合のみ必要です。
 
 > ⚠️ **重要**: cron は対話シェルではないため `~/.bashrc` を **読みません**。方式 A(crontab 内 export)または方式 B(env ファイル source)を必ず使用してください。
 

--- a/docs/common/16_HTMLメールレポート設定.md
+++ b/docs/common/16_HTMLメールレポート設定.md
@@ -1,0 +1,170 @@
+# 16. HTML メールレポート設定 (ClaudeOS v3.2.0)
+
+## Summary
+
+Cron で起動された ClaudeCode セッションが終了するたびに、実行サマリ・所要時間・次フェーズ提案を含む **HTML 形式のレポートメール** を Gmail SMTP 経由で `kensan1969@gmail.com` に送信する機能のセットアップ手順です。
+
+## Risks
+
+- Gmail アプリパスワードを `.bashrc` に書くため、**ユーザーアカウント以外がアクセスできる状態にしない**(`chmod 600 ~/.bashrc`)。
+- 公開リポジトリ・公開バックアップに `.bashrc` を含めない。`config.json` にはパスワードを書かない設計です。
+- アプリパスワードが漏洩した場合は Google アカウントの「アプリパスワード」画面で即時失効可能。
+
+## Findings
+
+### 機能概要
+
+`cron-launcher.sh` が `finalize` トラップ内で `report-and-mail.py` を呼び出し、以下を含む HTML メールを送信します。
+
+| 項目 | 内容 |
+|---|---|
+| ステータス | 🟢 completed / 🔴 failed / 🟡 timeout |
+| 開始 / 終了時刻 | ISO 8601 → `YYYY-MM-DD HH:MM:SS` 形式 |
+| 総作業時間 | `H 時間 M 分 S 秒` |
+| プロジェクト名 | cron 引数の project |
+| セッション ID | `YYYYMMDD-HHMMSS-<project>` |
+| ログ末尾 15 行 | プレーンテキスト(色付きコードブロック) |
+| 実行サマリー | Monitor / Development / Verify / Improvement の出現回数、エラー検出数、STABLE 達成有無 |
+| 次の開発フェーズ | ステータス + ログ集計から自動提案 |
+
+### セットアップ手順 (Linux 側)
+
+#### 手順 1 — Gmail アプリパスワードの取得(取得済みの場合はスキップ)
+
+1. https://myaccount.google.com/security にアクセス
+2. 「2 段階認証プロセス」を有効化(まだの場合)
+3. https://myaccount.google.com/apppasswords にアクセス
+4. アプリ名(任意): `ClaudeOS Cron Report` 等を入力 → 作成
+5. 表示される **16 桁のパスワード**(スペース付き表示)を控える
+   - 例: `abcd efgh ijkl mnop` → 実際は `abcdefghijklmnop`(スペースなしで使用)
+
+#### 手順 2 — Linux 環境変数の設定(アプリパスワードの配置)
+
+SSH で Linux ホストに接続後、`~/.bashrc` の **末尾** に以下を追記:
+
+```bash
+# ----- ClaudeOS v3.2.0 SMTP credentials -----
+export CLAUDEOS_SMTP_USER="kensan1969@gmail.com"
+export CLAUDEOS_SMTP_PASS="abcdefghijklmnop"   # 手順 1 で取得した 16 桁(スペース除去)
+```
+
+権限を絞ります(他ユーザーから読めないように):
+
+```bash
+chmod 600 ~/.bashrc
+```
+
+シェルを再起動するか、cron 用に system-wide 環境変数として設定する場合は:
+
+```bash
+# cron は ~/.bashrc を読まないため、以下のいずれかが必要
+# 方式 A: crontab 内で直接 export (推奨、cron-launcher.sh が継承)
+crontab -e
+# 先頭に以下を追記
+# CLAUDEOS_SMTP_USER=kensan1969@gmail.com
+# CLAUDEOS_SMTP_PASS=abcdefghijklmnop
+
+# 方式 B: cron-launcher.sh の冒頭で source ~/.env-claudeos
+mkdir -p ~ && cat > ~/.env-claudeos <<'EOF'
+export CLAUDEOS_SMTP_USER="kensan1969@gmail.com"
+export CLAUDEOS_SMTP_PASS="abcdefghijklmnop"
+EOF
+chmod 600 ~/.env-claudeos
+# その後、cron-launcher.sh の冒頭に以下を追記:
+#   [[ -f ~/.env-claudeos ]] && source ~/.env-claudeos
+```
+
+> ⚠️ **重要**: cron は対話シェルではないため `~/.bashrc` を **読みません**。方式 A(crontab 内 export)または方式 B(env ファイル source)を必ず使用してください。
+
+#### 手順 3 — report-and-mail.py の配置
+
+リポジトリの `Claude/templates/linux/report-and-mail.py` を Linux ホストにコピー:
+
+```bash
+# Windows 側から SCP で送る例
+scp Claude/templates/linux/report-and-mail.py kensan@<your-linux-host>:~/.claudeos/
+
+# Linux 側で実行権限を付ける
+ssh kensan@<your-linux-host> 'chmod +x ~/.claudeos/report-and-mail.py'
+```
+
+または、メニュー経由のデプロイスクリプト(将来的に追加予定)で一括配置可能です。
+
+#### 手順 4 — cron-launcher.sh の更新
+
+リポジトリの `Claude/templates/linux/cron-launcher.sh` を Linux ホストにコピー:
+
+```bash
+scp Claude/templates/linux/cron-launcher.sh kensan@<your-linux-host>:~/.claudeos/
+ssh kensan@<your-linux-host> 'chmod +x ~/.claudeos/cron-launcher.sh'
+```
+
+`finalize` トラップ内で `report-and-mail.py` が **best-effort** で呼ばれます。Python 3 が無い・スクリプトが無い場合はスキップ(cron 全体は成功扱い)。
+
+#### 手順 5 — config.json の有効化(任意)
+
+`config/config.json` の `email.enabled` を `true` に変更(現状は表示用、将来 Windows メニューで読み取る予定):
+
+```json
+"email": {
+  "enabled": true,
+  ...
+}
+```
+
+### 動作確認(dry-run)
+
+メール送信前に HTML プレビューを stdout に出力するモードがあります:
+
+```bash
+ssh kensan@<your-linux-host> '
+  python3 ~/.claudeos/report-and-mail.py \
+    --session test-001 \
+    --log ~/.claudeos/logs/cron-test.log \
+    --status completed \
+    --start "$(date -Iseconds)" \
+    --end "$(date -Iseconds)" \
+    --duration-min 300 \
+    --project test-project \
+    --dry-run
+' > preview.html
+
+# Windows 側で preview.html を開いて HTML 表示を確認
+```
+
+### 実機テスト送信
+
+```bash
+ssh kensan@<your-linux-host> '
+  source ~/.env-claudeos 2>/dev/null || true
+  python3 ~/.claudeos/report-and-mail.py \
+    --session smoke-test-$(date +%s) \
+    --log ~/.claudeos/logs/cron-test.log \
+    --status completed \
+    --start "$(date -Iseconds)" \
+    --end "$(date -Iseconds)" \
+    --duration-min 300 \
+    --project smoke-test
+'
+```
+
+数秒以内に `kensan1969@gmail.com` 宛に HTML メールが届けば成功。
+
+## Next Action
+
+- [ ] `~/.bashrc` または `~/.env-claudeos` に SMTP 認証情報を配置
+- [ ] `report-and-mail.py` を `~/.claudeos/` に配置(`chmod +x` 付き)
+- [ ] `cron-launcher.sh` を v3.2.0 版で上書き(`chmod +x` 付き)
+- [ ] `--dry-run` で HTML プレビュー確認
+- [ ] 実機テスト送信で受信確認
+- [ ] 次回 cron 自動起動で実運用検証(週末 21:00 等)
+
+## Troubleshooting
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| メールが届かない・ログに `WARN: CLAUDEOS_SMTP_USER ... 未設定` | cron 環境に環境変数が渡っていない | crontab 内で直接 `export` するか `source ~/.env-claudeos` を `cron-launcher.sh` 冒頭で実行 |
+| `(535, b'5.7.8 Username and Password not accepted')` | アプリパスワードが間違っている / 2 段階認証が無効 | 手順 1 から再取得。スペースを除去しているか確認 |
+| HTML が文字化けする | Gmail の表示問題は稀。SMTP は UTF-8 で送信済み | クライアント側のエンコーディング設定を確認 |
+| ログ末尾が空 | cron-launcher.sh 実行直後で書き込みが終わっていない | 通常は `finalize` 後に呼ばれるため発生しないが、ログ消失時はプレーンテキスト fallback が動作 |
+| `command not found: python3` | Python 3 が Linux ホストに未インストール | `sudo apt install python3` 等で導入。標準ライブラリのみ使用するため追加 pip 不要 |


### PR DESCRIPTION
## Summary

Cron で起動された ClaudeCode セッションの完了時に、**HTML 形式のレポートメール** を Gmail SMTP 経由で `kensan1969@gmail.com` に自動送信する機能を新設。アイコン+色付き表組み+実行サマリ+次フェーズ提案を 1 通にまとめます。

## Changes

| ファイル | 種別 | 内容 |
|---|---|---|
| `Claude/templates/linux/report-and-mail.py` | 新規 | Python 3 標準ライブラリのみで HTML メール生成・SMTP 送信 |
| `Claude/templates/linux/cron-launcher.sh` | 改修 | finalize で report-and-mail.py を best-effort 呼出し |
| `config/config.json.template` | 改修 | `email` セクション追加（認証情報は環境変数経由） |
| `docs/common/16_HTMLメールレポート設定.md` | 新規 | Gmail アプリパスワード取得 → 配置 → 検証の完全手順 |
| `CHANGELOG.md` | 改修 | v3.2.0 セクション追加 |

## メール内容

```
🤖 ClaudeOS Cron セッション完了報告
─────────────────────────────────
🟢 ステータス  : completed (STABLE 達成)
📂 プロジェクト : <project>
🤖 セッション   : 20260417-210000-test-project
🖥 ホスト      : linux-host
📅 開始        : 2026-04-17 21:00:00
🏁 終了        : 2026-04-18 02:00:00
⏱ 総作業時間  : 5 時間 0 分 0 秒
📜 ログ        : /home/kensan/.claudeos/logs/cron-...log
─────────────────────────────────
📝 実行サマリー
  Monitor      2 / Development 3 / Verify 2 / Improvement 1
  エラー検出   0  ログ総行数  10  STABLE 達成 はい
─────────────────────────────────
📜 ログ末尾(最後の 15 行) [ダーク背景]
─────────────────────────────────
➡️ 次の開発フェーズ提案
  🚀 Release: STABLE 達成済。次は Deploy Gate / マージ判断
```

## セキュリティ設計

- アプリパスワードは **config.json に書かない**(git commit リスク回避)
- Linux 環境変数 `CLAUDEOS_SMTP_USER` / `CLAUDEOS_SMTP_PASS` 経由
- `~/.env-claudeos` は `chmod 600` 必須
- cron は `~/.bashrc` を読まないため、crontab 内 export または env file source 方式を docs で明示
- SMTP 送信失敗時も `cron-launcher.sh` 全体は成功扱い (fail-soft)

## Test Plan

### 既実施
- [x] Python 3.14 syntax check: pass
- [x] `bash -n cron-launcher.sh`: pass
- [x] `python -m json.tool config/config.json.template`: pass
- [x] `--dry-run` HTML 生成: **6505 bytes、9 項目内容検証 PASS** (STABLE 達成 / 5 時間表記 / 🟢 アイコン / 4 フェーズ集計 / プロジェクト名 / 次フェーズ提案)

### Linux ホストでのユーザー手動検証(merge 後)
- [ ] `report-and-mail.py` を `~/.claudeos/` に配置 + `chmod +x`
- [ ] `cron-launcher.sh` を v3.2.0 版で上書き + `chmod +x`
- [ ] アプリパスワードを `~/.env-claudeos` に配置 (`chmod 600`)
- [ ] `--dry-run` で HTML プレビュー確認
- [ ] 実機テスト送信で `kensan1969@gmail.com` 受信確認
- [ ] 次回 cron 自動起動で実運用検証

## 設定手順(merge 後にユーザー実施)

詳細は `docs/common/16_HTMLメールレポート設定.md` を参照。要点:

```bash
# 1. アプリパスワードを Linux 環境変数で配置
cat > ~/.env-claudeos <<'EOF2'
export CLAUDEOS_SMTP_USER="kensan1969@gmail.com"
export CLAUDEOS_SMTP_PASS="<取得済みアプリパスワード 16 桁>"
EOF2
chmod 600 ~/.env-claudeos

# 2. cron-launcher.sh の冒頭に source 行を追加 (任意)
sed -i '/^set -euo pipefail/a [[ -f ~/.env-claudeos ]] && source ~/.env-claudeos' \
  ~/.claudeos/cron-launcher.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cronセッション完了時にHTML形式のメールレポートを自動送信
  * レポートはステータス（完了/失敗/タイムアウト/実行中）、開始・終了時刻、所要時間、ログ要約、フェーズ出現回数、次フェーズ提案を含む
  * --dry-runでHTMLプレビュー表示、送信は環境変数指定のSMTP資格情報を利用しGmail対応、送信失敗は全体のCronを止めないフェイルソフト動作

* **Configuration**
  * 設定テンプレートにメール関連ブロックを追加（有効化フラグやSMTP設定、送信先等）

* **Documentation**
  * Gmailアプリパスワード取得やCron環境変数配置手順を含む設定ガイドを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->