### PR TITLE
feat(v3.2.11): PSAvoidUsingPositionalParameters 警告解消 — 6 ファイル名前付き引数変換

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 # CHANGELOG
 
+## [v3.2.11] - 2026-04-17 — PSAvoidUsingPositionalParameters 警告解消
+
+### 🎯 概要
+
+PSScriptAnalyzer `PSAvoidUsingPositionalParameters` ルール警告を解消。
+`Join-Path`・`Assert-Eq`・`Assert-Match`・`Write-BootStep` の位置引数呼び出しを
+名前付き引数 (`-Path -ChildPath`、`-Expected -Actual -Label` 等) へ変換。
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/lib/SelfEvolution.psm1` | `Join-Path` → `-Path -ChildPath` |
+| `tests/ArchitectureCheck.Tests.ps1` | `Join-Path` → `-Path -ChildPath` |
+| `tests/SelfEvolution.Tests.ps1` | `Join-Path` → `-Path -ChildPath` |
+| `tests/E2E.Tests.ps1` | 3/4引数 `Join-Path` → `-Path -ChildPath` (2件) |
+| `scripts/test/Test-CronAndSession.ps1` | `Join-Path` 2件 + `Assert-Eq` 12件 + `Assert-Match` 2件 → 名前付き引数 |
+| `scripts/main/Start-ClaudeOS.ps1` | `Write-BootStep` → `-Number -Name -Status` |
+
+### ✅ 検証結果
+
+- `Invoke-ScriptAnalyzer -IncludeRule PSAvoidUsingPositionalParameters` = **0 件** (対象ファイル)
+- `Invoke-Pester` Passed: **477** / Failed: **0**
+
 ## [v3.2.10] - 2026-04-17 — PSReviewUnusedParameter 警告 7 件解消
 
 ### 🎯 概要

--- a/TASKS.md
+++ b/TASKS.md
@@ -34,6 +34,7 @@
 25. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#157] v3.2.8 PSUseSingularNouns 警告 36 件解消 — 32 関数リネーム / 誤検知 4 件 SuppressMessageAttribute / STABLE N=2 達成 (PR #158)
 26. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#160] v3.2.9 PSUseShouldProcessForStateChangingFunctions 警告 26 件解消 — 12 ファイル SuppressMessageAttribute / STABLE N=2 達成 (PR #161)
 27. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.10 PSReviewUnusedParameter 警告 7 件解消 — 6 ファイル修正 (SuppressMessage 4件 / 実使用 1件 / Add-Member修正 1件) / STABLE N=2 達成
+28. [Priority:P2][Owner:Developer][Source:Manual] v3.2.11 PSAvoidUsingPositionalParameters 警告解消 — 6 ファイル (Join-Path 6件 / Assert-Eq 12件 / Assert-Match 2件 / Write-BootStep 1件) 名前付き引数変換
 
 ## Auto Extracted From Agent Teams Matrix
 
@@ -42,6 +43,9 @@
 ## GitHub Issues Sync
 
 (No open issues)
+
+
+
 
 
 

--- a/scripts/lib/SelfEvolution.psm1
+++ b/scripts/lib/SelfEvolution.psm1
@@ -20,7 +20,7 @@ $script:EvolutionRecordSchema = @{
     next_actions  = @()
 }
 
-$script:DefaultEvolutionDir = Join-Path $env:USERPROFILE '.copilot' 'evolution'
+$script:DefaultEvolutionDir = Join-Path -Path $env:USERPROFILE -ChildPath '.copilot\evolution'
 
 function Get-EvolutionStorePath {
     [CmdletBinding()]

--- a/scripts/main/Start-ClaudeOS.ps1
+++ b/scripts/main/Start-ClaudeOS.ps1
@@ -191,7 +191,7 @@ function Invoke-StepMemoryRestore {
 
 function Invoke-StepPlaceholder {
     param([int]$Number, [string]$Name, [string]$Reason)
-    Write-BootStep $Number $Name 'SKIP'
+    Write-BootStep -Number $Number -Name $Name -Status 'SKIP'
     Write-Host ('  [SKIP] {0}' -f $Reason) -ForegroundColor DarkGray
     Write-Host ''
     return @{ Step = $Number; Name = $Name; Status = 'SKIP'; Detail = $Reason }

--- a/scripts/test/Test-CronAndSession.ps1
+++ b/scripts/test/Test-CronAndSession.ps1
@@ -12,8 +12,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-Import-Module (Join-Path $ScriptRoot 'scripts\lib\CronManager.psm1') -Force -DisableNameChecking
-Import-Module (Join-Path $ScriptRoot 'scripts\lib\SessionTabManager.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path -Path $ScriptRoot -ChildPath 'scripts\lib\CronManager.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path -Path $ScriptRoot -ChildPath 'scripts\lib\SessionTabManager.psm1') -Force -DisableNameChecking
 
 $script:Total = 0
 $script:Passed = 0
@@ -65,20 +65,20 @@ function Assert-Throws {
 Write-Host ""
 Write-Host "=== CronManager テスト ===" -ForegroundColor Cyan
 
-Assert-Eq '0 21 * * 0' (Format-CronExpression -DayOfWeek @(0) -Time '21:00') 'Format-CronExpression: 日曜 21:00'
-Assert-Eq '30 9 * * 1,3,5' (Format-CronExpression -DayOfWeek @(1, 3, 5) -Time '09:30') 'Format-CronExpression: 月水金 9:30'
-Assert-Eq '0 0 * * 0,1,2,3,4,5,6' (Format-CronExpression -DayOfWeek @(0, 1, 2, 3, 4, 5, 6) -Time '00:00') 'Format-CronExpression: 毎日 0:00'
+Assert-Eq -Expected '0 21 * * 0' -Actual (Format-CronExpression -DayOfWeek @(0) -Time '21:00') -Label 'Format-CronExpression: 日曜 21:00'
+Assert-Eq -Expected '30 9 * * 1,3,5' -Actual (Format-CronExpression -DayOfWeek @(1, 3, 5) -Time '09:30') -Label 'Format-CronExpression: 月水金 9:30'
+Assert-Eq -Expected '0 0 * * 0,1,2,3,4,5,6' -Actual (Format-CronExpression -DayOfWeek @(0, 1, 2, 3, 4, 5, 6) -Time '00:00') -Label 'Format-CronExpression: 毎日 0:00'
 Assert-Throws { Format-CronExpression -DayOfWeek @(0) -Time '25:00' } 'Format-CronExpression: 不正時刻で例外'
 Assert-Throws { Format-CronExpression -DayOfWeek @(7) -Time '10:00' } 'Format-CronExpression: 不正曜日で例外'
 Assert-Throws { Format-CronExpression -DayOfWeek @(0) -Time 'abc' } 'Format-CronExpression: 文字列時刻で例外'
 
 $id1 = New-CronEntryId
 $id2 = New-CronEntryId
-Assert-Match '^[0-9a-f]{8}$' $id1 'New-CronEntryId: 8桁16進'
-Assert-Eq $true ($id1 -ne $id2) 'New-CronEntryId: ユニーク'
+Assert-Match -Pattern '^[0-9a-f]{8}$' -Actual $id1 -Label 'New-CronEntryId: 8桁16進'
+Assert-Eq -Expected $true -Actual ($id1 -ne $id2) -Label 'New-CronEntryId: ユニーク'
 
-Assert-Eq '日' (Get-DayOfWeekLabel -Dow 0) 'Get-DayOfWeekLabel: 0=日'
-Assert-Eq '土' (Get-DayOfWeekLabel -Dow 6) 'Get-DayOfWeekLabel: 6=土'
+Assert-Eq -Expected '日' -Actual (Get-DayOfWeekLabel -Dow 0) -Label 'Get-DayOfWeekLabel: 0=日'
+Assert-Eq -Expected '土' -Actual (Get-DayOfWeekLabel -Dow 6) -Label 'Get-DayOfWeekLabel: 6=土'
 
 Write-Host ""
 Write-Host "=== SessionTabManager テスト ===" -ForegroundColor Cyan
@@ -88,31 +88,31 @@ $tmpDir = Join-Path $env:TEMP ("claudeos-test-" + [Guid]::NewGuid().ToString('N'
 New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
 try {
     $sess = New-SessionInfo -Project 'test-proj' -DurationMinutes 60 -Trigger 'manual' -Pid 12345 -ConfigSessionsDir $tmpDir
-    Assert-Match 'test-proj' $sess.sessionId 'New-SessionInfo: sessionId にプロジェクト名'
-    Assert-Eq 60 $sess.max_duration_minutes 'New-SessionInfo: duration 保存'
-    Assert-Eq 'running' $sess.status 'New-SessionInfo: 初期 status=running'
-    Assert-Eq 'manual' $sess.trigger 'New-SessionInfo: trigger=manual'
+    Assert-Match -Pattern 'test-proj' -Actual $sess.sessionId -Label 'New-SessionInfo: sessionId にプロジェクト名'
+    Assert-Eq -Expected 60 -Actual $sess.max_duration_minutes -Label 'New-SessionInfo: duration 保存'
+    Assert-Eq -Expected 'running' -Actual $sess.status -Label 'New-SessionInfo: 初期 status=running'
+    Assert-Eq -Expected 'manual' -Actual $sess.trigger -Label 'New-SessionInfo: trigger=manual'
 
     $loaded = Get-SessionInfo -SessionId $sess.sessionId -ConfigSessionsDir $tmpDir
-    Assert-Eq $sess.sessionId $loaded.sessionId 'Get-SessionInfo: ラウンドトリップ'
+    Assert-Eq -Expected $sess.sessionId -Actual $loaded.sessionId -Label 'Get-SessionInfo: ラウンドトリップ'
 
     Update-SessionDuration -SessionId $sess.sessionId -DurationMinutes 120 -ConfigSessionsDir $tmpDir | Out-Null
     $updated = Get-SessionInfo -SessionId $sess.sessionId -ConfigSessionsDir $tmpDir
-    Assert-Eq 120 $updated.max_duration_minutes 'Update-SessionDuration: 120 分に変更'
+    Assert-Eq -Expected 120 -Actual $updated.max_duration_minutes -Label 'Update-SessionDuration: 120 分に変更'
 
     # end_time_planned が start_time + 120 分になっていることを確認
     $start = [datetime]::Parse($updated.start_time)
     $end = [datetime]::Parse($updated.end_time_planned)
     $diffMin = [int]($end - $start).TotalMinutes
-    Assert-Eq 120 $diffMin 'Update-SessionDuration: end_time_planned 再計算'
+    Assert-Eq -Expected 120 -Actual $diffMin -Label 'Update-SessionDuration: end_time_planned 再計算'
 
     Set-SessionStatus -SessionId $sess.sessionId -Status 'completed' -ConfigSessionsDir $tmpDir | Out-Null
     $completed = Get-SessionInfo -SessionId $sess.sessionId -ConfigSessionsDir $tmpDir
-    Assert-Eq 'completed' $completed.status 'Set-SessionStatus: completed'
+    Assert-Eq -Expected 'completed' -Actual $completed.status -Label 'Set-SessionStatus: completed'
 
     # Get-ActiveSession は running 限定なので completed 後は null
     $active = Get-ActiveSession -ConfigSessionsDir $tmpDir
-    Assert-Eq $true ($null -eq $active) 'Get-ActiveSession: completed 後は null'
+    Assert-Eq -Expected $true -Actual ($null -eq $active) -Label 'Get-ActiveSession: completed 後は null'
 }
 finally {
     Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/tests/ArchitectureCheck.Tests.ps1
+++ b/tests/ArchitectureCheck.Tests.ps1
@@ -3,7 +3,7 @@
 # ============================================================
 
 BeforeAll {
-    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'lib' 'ArchitectureCheck.psm1'
+    $ModulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\scripts\lib\ArchitectureCheck.psm1'
     Import-Module $ModulePath -Force -DisableNameChecking
 }
 

--- a/tests/E2E.Tests.ps1
+++ b/tests/E2E.Tests.ps1
@@ -333,7 +333,7 @@ Describe 'ClaudeOS System Files Integrity' {
         }
 
         It 'benchmark-tasks.md が存在すること (Issue #109)' {
-            Join-Path $script:ClaudeOsDir 'frontier' 'benchmark-tasks.md' | Should -Exist
+            Join-Path -Path $script:ClaudeOsDir -ChildPath 'frontier\benchmark-tasks.md' | Should -Exist
         }
     }
 }
@@ -389,6 +389,6 @@ Describe 'v3.0.0 New Document Existence (Issue #103-#109)' {
     }
 
     It 'v3 リリースノート MD が存在すること' {
-        Join-Path $script:RepoRoot 'docs' 'common' '15_v3リリースノート.md' | Should -Exist
+        Join-Path -Path $script:RepoRoot -ChildPath 'docs\common\15_v3リリースノート.md' | Should -Exist
     }
 }

--- a/tests/SelfEvolution.Tests.ps1
+++ b/tests/SelfEvolution.Tests.ps1
@@ -3,7 +3,7 @@
 # ============================================================
 
 BeforeAll {
-    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'lib' 'SelfEvolution.psm1'
+    $ModulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\scripts\lib\SelfEvolution.psm1'
     Import-Module $ModulePath -Force -DisableNameChecking
 
     $TempEvolutionDir = Join-Path $env:TEMP "evolution-test-$(Get-Random)"


### PR DESCRIPTION
## Summary

- `PSAvoidUsingPositionalParameters` 警告を対象ファイルで **0 件** に解消
- `Join-Path` 6件・`Assert-Eq` 12件・`Assert-Match` 2件・`Write-BootStep` 1件を名前付き引数変換
- Pester Passed: **477** / Failed: **0**

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `scripts/lib/SelfEvolution.psm1` | `Join-Path` → `-Path -ChildPath` |
| `tests/ArchitectureCheck.Tests.ps1` | `Join-Path` → `-Path -ChildPath` |
| `tests/SelfEvolution.Tests.ps1` | `Join-Path` → `-Path -ChildPath` |
| `tests/E2E.Tests.ps1` | 3/4引数 `Join-Path` → `-Path -ChildPath` (2件) |
| `scripts/test/Test-CronAndSession.ps1` | `Join-Path` 2件 + `Assert-Eq` 12件 + `Assert-Match` 2件 → 名前付き引数 |
| `scripts/main/Start-ClaudeOS.ps1` | `Write-BootStep` → `-Number -Name -Status` |

## Test plan

- [x] `Invoke-ScriptAnalyzer -IncludeRule PSAvoidUsingPositionalParameters` = 0件 (対象ファイル)
- [x] `Invoke-Pester` Passed: 477 / Failed: 0
- [ ] CI STABLE N=2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v3.2.11

* **Style改善**
  * PowerShellスクリプト全体で関数呼び出しの一貫性を向上させました。複数のスクリプトおよびテストファイルにおいて、ポジショナルパラメータから明示的な名前付きパラメータへ統一することで、コードの可読性と保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->