### PR TITLE
feat(v3.2.12): PSUseOutputTypeCorrectly 警告 37 件解消 — 7 ファイル 13 関数 [OutputType()] 追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 # CHANGELOG
 
+## [v3.2.12] - 2026-04-17 — PSUseOutputTypeCorrectly 警告 37 件解消
+
+### 🎯 概要
+
+PSScriptAnalyzer `PSUseOutputTypeCorrectly` ルール警告を解消。
+7 ファイル 13 関数に `[OutputType()]` 属性を追加。
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/lib/ArchitectureCheck.psm1` | `Test-ModuleDependency` → `[OutputType([System.Object[]])]` |
+| `scripts/lib/Config.psm1` | `Test-StartupConfigSchema` / `Assert-StartupConfigSchema` / `Get-RecentProject` に `[OutputType()]` |
+| `scripts/lib/LauncherCommon.psm1` | `Find-AvailableDriveLetter` / `Resolve-SshProjectsDir` に `[OutputType([System.String])]` |
+| `scripts/lib/LogManager.psm1` | `Start-SessionLog` / `Get-LogSummary` に `[OutputType([System.Collections.Hashtable])]` |
+| `scripts/lib/MessageBus.psm1` | `Get-BusMessage` / `Confirm-BusMessage` / `Get-BusStatus` / `Initialize-MessageBus` に `[OutputType()]` |
+| `scripts/lib/SelfEvolution.psm1` | `Get-EvolutionStorePath` / `Get-EvolutionHistory` / `Get-FrequentLesson` に `[OutputType()]` |
+| `scripts/lib/SSHHelper.psm1` | `ConvertTo-EscapedSSHArgument` / `Test-SSHConnection` に `[OutputType()]` |
+
+### ✅ 検証結果
+
+- `Invoke-ScriptAnalyzer -IncludeRule PSUseOutputTypeCorrectly` = **0 件**
+- `Invoke-Pester` Passed: **477** / Failed: **0**
+
 ## [v3.2.11] - 2026-04-17 — PSAvoidUsingPositionalParameters 警告解消
 
 ### 🎯 概要

--- a/TASKS.md
+++ b/TASKS.md
@@ -35,6 +35,7 @@
 26. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#160] v3.2.9 PSUseShouldProcessForStateChangingFunctions 警告 26 件解消 — 12 ファイル SuppressMessageAttribute / STABLE N=2 達成 (PR #161)
 27. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.10 PSReviewUnusedParameter 警告 7 件解消 — 6 ファイル修正 (SuppressMessage 4件 / 実使用 1件 / Add-Member修正 1件) / STABLE N=2 達成
 28. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.11 PSAvoidUsingPositionalParameters 警告解消 — 6 ファイル (Join-Path 6件 / Assert-Eq 12件 / Assert-Match 2件 / Write-BootStep 1件) 名前付き引数変換 (PR #163)
+29. [Priority:P2][Owner:Developer][Source:Manual] v3.2.12 PSUseOutputTypeCorrectly 警告解消 — 7 ファイル 13 関数 [OutputType()] 追加
 
 ## Auto Extracted From Agent Teams Matrix
 
@@ -43,6 +44,9 @@
 ## GitHub Issues Sync
 
 (No open issues)
+
+
+
 
 
 

--- a/scripts/lib/ArchitectureCheck.psm1
+++ b/scripts/lib/ArchitectureCheck.psm1
@@ -196,6 +196,7 @@ function Show-ArchitectureCheckReport {
 
 function Test-ModuleDependency {
     [CmdletBinding()]
+    [OutputType([System.Object[]])]
     param(
         [string]$Path = ''
     )

--- a/scripts/lib/Config.psm1
+++ b/scripts/lib/Config.psm1
@@ -49,6 +49,7 @@ function Add-SchemaError {
 
 function Test-StartupConfigSchema {
     [CmdletBinding()]
+    [OutputType([System.Object[]])]
     param(
         [Parameter(Mandatory=$true)]
         [object]$Config
@@ -182,6 +183,7 @@ function Test-StartupConfigSchema {
 
 function Assert-StartupConfigSchema {
     [CmdletBinding()]
+    [OutputType([System.Boolean])]
     param(
         [Parameter(Mandatory=$true)]
         [string]$ConfigPath
@@ -400,6 +402,7 @@ function Backup-ConfigFile {
 #>
 function Get-RecentProject {
     [CmdletBinding()]
+    [OutputType([System.Object[]])]
     param(
         [Parameter(Mandatory=$true)]
         [string]$HistoryPath

--- a/scripts/lib/LauncherCommon.psm1
+++ b/scripts/lib/LauncherCommon.psm1
@@ -35,6 +35,7 @@ function Import-LauncherConfig {
 
 function Find-AvailableDriveLetter {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param(
         [string[]]$PreferredLetters = @('P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'Y'),
         [string[]]$ExcludeLetters = @()
@@ -61,6 +62,7 @@ function Find-AvailableDriveLetter {
 
 function Resolve-SshProjectsDir {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param(
         [Parameter(Mandatory)]
         [object]$Config

--- a/scripts/lib/LogManager.psm1
+++ b/scripts/lib/LogManager.psm1
@@ -9,6 +9,7 @@ $script:LoggingActive = $false
 
 function Start-SessionLog {
     [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal autonomous CLI function; ShouldProcess disrupts unattended operation')]
     param(
         [Parameter(Mandatory=$true)]
@@ -224,6 +225,7 @@ function Invoke-LogArchive {
 
 function Get-LogSummary {
     [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
     param(
         [Parameter(Mandatory=$true)]
         [psobject]$Config

--- a/scripts/lib/MessageBus.psm1
+++ b/scripts/lib/MessageBus.psm1
@@ -198,6 +198,7 @@ function Get-BusMessage {
         Get-BusMessage -Topic 'phase.transition' -Consumer 'Orchestrator'
     #>
     [CmdletBinding()]
+    [OutputType([System.Object[]])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Topic,
@@ -273,6 +274,7 @@ function Confirm-BusMessage {
             -Consumer 'Orchestrator'
     #>
     [CmdletBinding()]
+    [OutputType([System.Boolean])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Topic,
@@ -347,6 +349,7 @@ function Get-BusStatus {
         Get-BusStatus | Format-Table
     #>
     [CmdletBinding()]
+    [OutputType([System.Object[]])]
     param(
         [Parameter(Mandatory = $false)]
         [string]$StatePath
@@ -404,6 +407,7 @@ function Initialize-MessageBus {
         Initialize-MessageBus
     #>
     [CmdletBinding()]
+    [OutputType([System.Boolean])]
     param(
         [Parameter(Mandatory = $false)]
         [string]$StatePath

--- a/scripts/lib/SSHHelper.psm1
+++ b/scripts/lib/SSHHelper.psm1
@@ -20,6 +20,7 @@
 #>
 function ConvertTo-EscapedSSHArgument {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param(
         [Parameter(Mandatory=$true)]
         [string]$Value
@@ -50,6 +51,7 @@ function ConvertTo-EscapedSSHArgument {
 #>
 function Test-SSHConnection {
     [CmdletBinding()]
+    [OutputType([System.Boolean])]
     param(
         [Parameter(Mandatory=$true)]
         [string]$Host,

--- a/scripts/lib/SelfEvolution.psm1
+++ b/scripts/lib/SelfEvolution.psm1
@@ -24,6 +24,7 @@ $script:DefaultEvolutionDir = Join-Path -Path $env:USERPROFILE -ChildPath '.copi
 
 function Get-EvolutionStorePath {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param(
         [string]$BasePath = $script:DefaultEvolutionDir
     )
@@ -83,6 +84,7 @@ function Save-EvolutionRecord {
 
 function Get-EvolutionHistory {
     [CmdletBinding()]
+    [OutputType([System.Object[]])]
     param(
         [string]$StorePath = '',
         [int]$Last = 10,
@@ -112,6 +114,7 @@ function Get-EvolutionHistory {
 
 function Get-FrequentLesson {
     [CmdletBinding()]
+    [OutputType([System.Object[]])]
     param(
         [string]$StorePath = '',
         [int]$TopN = 5


### PR DESCRIPTION
## Summary
- PSScriptAnalyzer `PSUseOutputTypeCorrectly` 警告 37 件を解消
- 7 ファイル 13 関数に `[OutputType()]` 属性を追加（機能変更なし）
- `Invoke-Pester` 477/0 確認済み

## Test plan
- [ ] CI PSScriptAnalyzer pass (PSUseOutputTypeCorrectly = 0)
- [ ] CI test-and-validate pass (477/0)
- [ ] CodeRabbit pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)