### PR TITLE
fix: PSAvoidUsingPositionalParameters 残存 1 件解消 — Test-ArchitectureCheck.ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 # CHANGELOG
 
+## [v3.2.13] - 2026-04-17 — PSAvoidUsingPositionalParameters 残存 1 件解消 + CLAUDE.md v8.3
+
+### 🎯 概要
+
+- `Test-ArchitectureCheck.ps1:16` の `Join-Path` 位置パラメーター警告残存 1 件を修正
+- CLAUDE.md v8.3: Auto mode 操作手順（Shift+Tab）と Response length calibration 指針を追加
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/test/Test-ArchitectureCheck.ps1` | `Join-Path` → `-AdditionalChildPath` 名前付き引数へ変換 |
+| `CLAUDE.md` | §3 Auto mode Shift+Tab 操作手順テーブル追加 / §24.1 Response length calibration 指針追加 |
+
+### ✅ 検証結果
+
+- `Invoke-ScriptAnalyzer -IncludeRule PSAvoidUsingPositionalParameters` = **0 件**
+- `Invoke-Pester` Passed: **477** / Failed: **0**
+
 ## [v3.2.12] - 2026-04-17 — PSUseOutputTypeCorrectly 警告 37 件解消
 
 ### 🎯 概要

--- a/scripts/test/Test-ArchitectureCheck.ps1
+++ b/scripts/test/Test-ArchitectureCheck.ps1
@@ -13,7 +13,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $ScriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
-$ModulePath = Join-Path $ScriptDir '..' 'lib' 'ArchitectureCheck.psm1'
+$ModulePath = Join-Path -Path $ScriptDir -ChildPath '..' -AdditionalChildPath 'lib', 'ArchitectureCheck.psm1'
 Import-Module $ModulePath -Force -DisableNameChecking
 
 if (-not $Path) {


### PR DESCRIPTION
## Summary
- `Test-ArchitectureCheck.ps1:16` の `Join-Path` 位置パラメーター警告 1 件を修正
- v3.2.11 で lib/ を修正済みだが test/ スクリプトが漏れていたため追加修正

## Changes
- `Join-Path $ScriptDir '..' 'lib' 'ArchitectureCheck.psm1'`
  → `Join-Path -Path $ScriptDir -ChildPath '..' -AdditionalChildPath 'lib', 'ArchitectureCheck.psm1'`

## Test plan
- [x] `Invoke-ScriptAnalyzer -Path scripts/ -Recurse | Where-Object RuleName -eq PSAvoidUsingPositionalParameters` → 0 件
- [x] Pester 477/0 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テスト基盤インフラのメンテナンス改善を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->