### PR TITLE
docs(v3.2.14): PSProvideCommentHelp 警告 85 件解消 — 9 ファイル全関数に .SYNOPSIS 追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 # CHANGELOG
 
+## [v3.2.14] - 2026-04-17 — PSProvideCommentHelp 警告 85 件解消
+
+### 🎯 概要
+
+- 9 ファイル 85 関数に `.SYNOPSIS` コメントブロックを追加
+- PSScriptAnalyzer `PSProvideCommentHelp` 警告を 0 件へ解消
+
+### 🔧 変更対象
+
+| ファイル | 追加件数 |
+|---|---|
+| `scripts/lib/LauncherCommon.psm1` | 41 |
+| `scripts/lib/CronManager.psm1` | 9 |
+| `scripts/lib/AgentTeams.psm1` | 8 |
+| `scripts/lib/SessionTabManager.psm1` | 8 |
+| `scripts/lib/LogManager.psm1` | 5 |
+| `scripts/lib/McpHealthCheck.psm1` | 5 |
+| `scripts/lib/Config.psm1` | 4 |
+| `scripts/lib/MenuCommon.psm1` | 3 |
+| `scripts/lib/StatuslineManager.psm1` | 2 |
+
+### ✅ 検証結果
+
+- `Invoke-ScriptAnalyzer -IncludeRule PSProvideCommentHelp` = **0 件**
+- `Invoke-Pester` Passed: **477** / Failed: **0**
+
+---
+
 ## [v3.2.13] - 2026-04-17 — PSAvoidUsingPositionalParameters 残存 1 件解消 + CLAUDE.md v8.3
 
 ### 🎯 概要

--- a/scripts/lib/AgentTeams.psm1
+++ b/scripts/lib/AgentTeams.psm1
@@ -34,6 +34,10 @@ $script:TaskTypePatterns = @(
     [pscustomobject]@{ type = 'kotlin';    pattern = 'Kotlin|Android';                                          agents = @('kotlin-reviewer', 'kotlin-build-resolver') }
 )
 
+<#
+.SYNOPSIS
+    Loads agent definitions from .md files in the specified agents directory.
+#>
 function Import-AgentDefinition {
     param(
         [Parameter(Mandatory)]
@@ -87,6 +91,10 @@ function Import-AgentDefinition {
     return $agents
 }
 
+<#
+.SYNOPSIS
+    Analyzes a task description and returns matched task types and specialist agent IDs.
+#>
 function Get-TaskTypeAnalysis {
     param(
         [Parameter(Mandatory)]
@@ -115,6 +123,10 @@ function Get-TaskTypeAnalysis {
     }
 }
 
+<#
+.SYNOPSIS
+    Matches a task description against backlog rules to determine priority and owner.
+#>
 function Get-BacklogRuleMatch {
     param(
         [Parameter(Mandatory)]
@@ -158,6 +170,10 @@ function Get-BacklogRuleMatch {
     return $result
 }
 
+<#
+.SYNOPSIS
+    Assembles an agent team based on task description and available agent definitions.
+#>
 function New-AgentTeam {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal autonomous CLI function; ShouldProcess disrupts unattended operation')]
     param(
@@ -228,6 +244,10 @@ function New-AgentTeam {
     return [pscustomobject]$team
 }
 
+<#
+.SYNOPSIS
+    Formats an agent team composition as a discussion-style text block.
+#>
 function Format-AgentTeamDiscussion {
     param(
         [Parameter(Mandatory)]
@@ -265,6 +285,10 @@ function Format-AgentTeamDiscussion {
     return ($lines -join "`n")
 }
 
+<#
+.SYNOPSIS
+    Displays the agent team composition in a formatted console output.
+#>
 function Show-AgentTeamComposition {
     param(
         [Parameter(Mandatory)]
@@ -297,6 +321,10 @@ function Show-AgentTeamComposition {
     Write-Host ''
 }
 
+<#
+.SYNOPSIS
+    Generates a report of available agents and optionally builds an agent team for a given task.
+#>
 function Get-AgentTeamReport {
     param(
         [Parameter(Mandatory)]
@@ -329,6 +357,10 @@ function Get-AgentTeamReport {
     return [pscustomobject]$report
 }
 
+<#
+.SYNOPSIS
+    Displays the agent team report to the console with formatted output.
+#>
 function Show-AgentTeamReport {
     param([pscustomobject]$Report)
 

--- a/scripts/lib/Config.psm1
+++ b/scripts/lib/Config.psm1
@@ -47,6 +47,10 @@ function Add-SchemaError {
     $Errors.Add($Message)
 }
 
+<#
+.SYNOPSIS
+    Validates a startup configuration object against the required schema and returns a list of errors.
+#>
 function Test-StartupConfigSchema {
     [CmdletBinding()]
     [OutputType([System.Object[]])]
@@ -181,6 +185,10 @@ function Test-StartupConfigSchema {
     return @($errors)
 }
 
+<#
+.SYNOPSIS
+    Loads and validates a config.json file, throwing on any schema errors.
+#>
 function Assert-StartupConfigSchema {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
@@ -279,6 +287,10 @@ function Import-StartupConfig {
 
 # 後方互換性のためのラッパー関数
 function Import-DevToolsConfig {
+    <#
+    .SYNOPSIS
+        Backward-compatible wrapper for Import-StartupConfig.
+    #>
     param([string]$ConfigPath)
     Import-StartupConfig -ConfigPath $ConfigPath
 }
@@ -546,6 +558,10 @@ function Update-RecentProject {
     }
 }
 
+<#
+.SYNOPSIS
+    Returns true if the recentProjects feature is enabled and configured in the given Config object.
+#>
 function Test-RecentProjectsEnabled {
     [CmdletBinding()]
     param(

--- a/scripts/lib/CronManager.psm1
+++ b/scripts/lib/CronManager.psm1
@@ -14,6 +14,10 @@ $script:EntryPrefix = 'CLAUDEOS'
 $script:LauncherPath = '/home/kensan/.claudeos/cron-launcher.sh'
 $script:LogsDir = '/home/kensan/.claudeos/logs'
 
+<#
+.SYNOPSIS
+    Overrides module-scope defaults for cron entry prefix, launcher path, and logs directory.
+#>
 function Set-CronManagerConfig {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal autonomous CLI function; ShouldProcess disrupts unattended operation')]
     param(
@@ -67,10 +71,11 @@ function Invoke-RemoteCrontab {
     return $proc.ExitCode
 }
 
+<#
+.SYNOPSIS
+    Extracts CLAUDEOS-managed cron entries and their expressions from the remote host's current crontab.
+#>
 function Get-ClaudeOSCronEntry {
-    <#
-    .SYNOPSIS 現在の crontab から CLAUDEOS: 行と対応する cron 式を抽出
-    #>
     param([Parameter(Mandatory)][string]$LinuxHost)
 
     $raw = Invoke-RemoteCrontab -LinuxHost $LinuxHost -Action 'read'
@@ -104,10 +109,11 @@ function Get-ClaudeOSCronEntry {
     return $entries
 }
 
+<#
+.SYNOPSIS
+    Generates a cron expression from day-of-week values (0=Sunday to 6=Saturday) and an HH:MM time string.
+#>
 function Format-CronExpression {
-    <#
-    .SYNOPSIS 曜日（0=日〜6=土、複数可）と HH:MM から cron 式を生成
-    #>
     param(
         [Parameter(Mandatory)][int[]]$DayOfWeek,
         [Parameter(Mandatory)][string]$Time
@@ -128,16 +134,21 @@ function Format-CronExpression {
     return "$minute $hour * * $dowStr"
 }
 
+<#
+.SYNOPSIS
+    Generates a short unique identifier for a new cron entry.
+#>
 function New-CronEntryId {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Factory function returns in-memory object; no persistent system state is modified')]
     param()
     return [Guid]::NewGuid().ToString('N').Substring(0, 8)
 }
 
+<#
+.SYNOPSIS
+    Appends a new CLAUDEOS-managed cron entry to the remote host's crontab.
+#>
 function Add-ClaudeOSCronEntry {
-    <#
-    .SYNOPSIS 新規 CLAUDEOS エントリを crontab 末尾に追加
-    #>
     param(
         [Parameter(Mandatory)][string]$LinuxHost,
         [Parameter(Mandatory)][string]$Project,
@@ -175,10 +186,11 @@ function Add-ClaudeOSCronEntry {
     }
 }
 
+<#
+.SYNOPSIS
+    Removes a CLAUDEOS-managed cron entry (comment line and cron line pair) identified by its ID from the remote crontab.
+#>
 function Remove-ClaudeOSCronEntry {
-    <#
-    .SYNOPSIS ID 指定で CLAUDEOS エントリを削除（コメント行 + 直後の cron 式の 2 行セット）
-    #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal autonomous CLI function; ShouldProcess disrupts unattended operation')]
     param(
         [Parameter(Mandatory)][string]$LinuxHost,
@@ -212,6 +224,10 @@ function Remove-ClaudeOSCronEntry {
     return $removed
 }
 
+<#
+.SYNOPSIS
+    Removes all CLAUDEOS-managed cron entries from the remote host's crontab.
+#>
 function Remove-AllClaudeOSCronEntry {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal autonomous CLI function; ShouldProcess disrupts unattended operation')]
     param([Parameter(Mandatory)][string]$LinuxHost)
@@ -224,6 +240,10 @@ function Remove-AllClaudeOSCronEntry {
     return $count
 }
 
+<#
+.SYNOPSIS
+    Returns the Japanese day-of-week label for an integer day value (0=Sunday, 6=Saturday).
+#>
 function Get-DayOfWeekLabel {
     param([int]$Dow)
     $labels = @('日', '月', '火', '水', '木', '金', '土')
@@ -231,6 +251,10 @@ function Get-DayOfWeekLabel {
     return "?"
 }
 
+<#
+.SYNOPSIS
+    Formats a cron entry object as a human-readable display string.
+#>
 function Format-CronEntryForDisplay {
     param([pscustomobject]$Entry)
 

--- a/scripts/lib/LauncherCommon.psm1
+++ b/scripts/lib/LauncherCommon.psm1
@@ -1,4 +1,8 @@
-﻿function Get-StartupRoot {
+﻿<#
+.SYNOPSIS
+    Returns the repository root directory by walking two levels up from the script root path.
+#>
+function Get-StartupRoot {
     param(
         [Parameter(Mandatory)]
         [string]$PSScriptRootPath
@@ -7,6 +11,10 @@
     return (Split-Path -Parent (Split-Path -Parent $PSScriptRootPath))
 }
 
+<#
+.SYNOPSIS
+    Returns the config.json path, honoring the AI_STARTUP_CONFIG_PATH environment variable override.
+#>
 function Get-StartupConfigPath {
     param(
         [Parameter(Mandatory)]
@@ -20,6 +28,10 @@ function Get-StartupConfigPath {
     return (Join-Path $StartupRoot "config\\config.json")
 }
 
+<#
+.SYNOPSIS
+    Reads and parses the launcher config.json file from the specified path.
+#>
 function Import-LauncherConfig {
     param(
         [Parameter(Mandatory)]
@@ -33,6 +45,10 @@ function Import-LauncherConfig {
     return (Get-Content $ConfigPath -Raw -Encoding UTF8 | ConvertFrom-Json)
 }
 
+<#
+.SYNOPSIS
+    Finds and returns the first available Windows drive letter not currently in use.
+#>
 function Find-AvailableDriveLetter {
     [CmdletBinding()]
     [OutputType([System.String])]
@@ -60,6 +76,10 @@ function Find-AvailableDriveLetter {
     return $null
 }
 
+<#
+.SYNOPSIS
+    Resolves the SSH projects directory path, auto-mapping a UNC drive when sshProjectsDir is 'auto'.
+#>
 function Resolve-SshProjectsDir {
     [CmdletBinding()]
     [OutputType([System.String])]
@@ -113,6 +133,10 @@ function Resolve-SshProjectsDir {
     return $sshDir
 }
 
+<#
+.SYNOPSIS
+    Returns true if the specified command is available in the current environment.
+#>
 function Test-LauncherCommand {
     param(
         [Parameter(Mandatory)]
@@ -122,6 +146,10 @@ function Test-LauncherCommand {
     return [bool](Get-Command $Command -ErrorAction SilentlyContinue)
 }
 
+<#
+.SYNOPSIS
+    Checks that a required CLI tool is installed and optionally prompts to install it if missing.
+#>
 function Assert-LauncherToolAvailable {
     param(
         [Parameter(Mandatory)]
@@ -153,6 +181,10 @@ function Assert-LauncherToolAvailable {
     return $false
 }
 
+<#
+.SYNOPSIS
+    Retrieves an API key value from environment variables or the EnvMap config object.
+#>
 function Get-LauncherApiKeyValue {
     param(
         [string]$ApiKeyName,
@@ -178,6 +210,10 @@ function Get-LauncherApiKeyValue {
     return $null
 }
 
+<#
+.SYNOPSIS
+    Displays a warning and setup hints when a required API key environment variable is not set.
+#>
 function Show-LauncherApiKeyWarning {
     param(
         [string]$ApiKeyName,
@@ -198,6 +234,10 @@ function Show-LauncherApiKeyWarning {
     }
 }
 
+<#
+.SYNOPSIS
+    Determines whether to run in local or SSH mode, prompting the user if linuxHost is unconfigured.
+#>
 function Resolve-LauncherMode {
     param(
         [Parameter(Mandatory)]
@@ -243,6 +283,10 @@ function Resolve-LauncherMode {
     }
 }
 
+<#
+.SYNOPSIS
+    Resolves the target project name, prompting the user with a directory listing when not specified.
+#>
 function Resolve-LauncherProject {
     param(
         [Parameter(Mandatory)]
@@ -324,6 +368,10 @@ SSH プロジェクトフォルダにアクセスできません。
     return $dirs[$numInt - 1].Name
 }
 
+<#
+.SYNOPSIS
+    Displays a numbered list of projects for the user to select from.
+#>
 function Show-LauncherProjectChoice {
     param(
         [Parameter(Mandatory)]
@@ -342,6 +390,10 @@ function Show-LauncherProjectChoice {
     }
 }
 
+<#
+.SYNOPSIS
+    Returns a human-readable label describing the current execution mode (local or SSH) and project path.
+#>
 function Get-LauncherModeLabel {
     param(
         [Parameter(Mandatory)]
@@ -359,6 +411,10 @@ function Get-LauncherModeLabel {
     return "SSH  $LinuxHost → $LinuxBase/$Project"
 }
 
+<#
+.SYNOPSIS
+    Returns 'local' or 'ssh' as the canonical mode name string.
+#>
 function Get-LauncherModeName {
     param([switch]$Local)
 
@@ -369,6 +425,10 @@ function Get-LauncherModeName {
     return 'ssh'
 }
 
+<#
+.SYNOPSIS
+    Returns a dry-run message string describing the command that would be executed.
+#>
 function New-LauncherDryRunMessage {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Factory function returns in-memory object; no persistent system state is modified')]
     param(
@@ -391,6 +451,10 @@ function New-LauncherDryRunMessage {
     return @("[DryRun] cd $WorkingDirectory && $Command$joinedArgs")
 }
 
+<#
+.SYNOPSIS
+    Prompts the user to confirm the launcher start unless NonInteractive mode is set.
+#>
 function Confirm-LauncherStart {
     param(
         [Parameter(Mandatory)]
@@ -418,6 +482,10 @@ function Confirm-LauncherStart {
     return ($confirm -notmatch '^(n|no)$')
 }
 
+<#
+.SYNOPSIS
+    Sets process-scoped environment variables from the provided EnvMap object.
+#>
 function Set-LauncherEnvironment {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal autonomous CLI function; ShouldProcess disrupts unattended operation')]
     param(
@@ -432,6 +500,10 @@ function Set-LauncherEnvironment {
     }
 }
 
+<#
+.SYNOPSIS
+    Converts an EnvMap object into a newline-separated string of Bash export statements.
+#>
 function ConvertTo-BashExport {
     param(
         [Parameter(Mandatory)]
@@ -449,6 +521,10 @@ function ConvertTo-BashExport {
     return ($lines -join "`n")
 }
 
+<#
+.SYNOPSIS
+    Copies a template file to the target path if it differs, creating parent directories as needed.
+#>
 function Sync-ProjectTemplate {
     param(
         [Parameter(Mandatory)]
@@ -488,6 +564,10 @@ function Sync-ProjectTemplate {
     }
 }
 
+<#
+.SYNOPSIS
+    Recursively copies all files from the source directory into the target directory.
+#>
 function Sync-ProjectDirectory {
     param(
         [Parameter(Mandatory)]
@@ -510,6 +590,10 @@ function Sync-ProjectDirectory {
     Write-Host "[OK] $Label を配置/更新しました: $TargetDirectory" -ForegroundColor Green
 }
 
+<#
+.SYNOPSIS
+    Recursively syncs each file in the template directory to the corresponding path in the target directory.
+#>
 function Sync-ProjectTemplateDirectory {
     param(
         [Parameter(Mandatory)]
@@ -544,6 +628,10 @@ function Sync-ProjectTemplateDirectory {
     }
 }
 
+<#
+.SYNOPSIS
+    Copies a template file to the target path only if the target does not already exist.
+#>
 function Initialize-ProjectTemplate {
     param(
         [Parameter(Mandatory)]
@@ -575,6 +663,10 @@ function Initialize-ProjectTemplate {
     Write-Host "[OK] $Label を初期配置しました: $TargetPath" -ForegroundColor Green
 }
 
+<#
+.SYNOPSIS
+    Syncs Claude global config templates (CLAUDE.md, .claude/claudeos, settings.json, .mcp.json) into the project directory.
+#>
 function Sync-LauncherClaudeGlobalConfig {
     param(
         [Parameter(Mandatory)]
@@ -617,6 +709,10 @@ function Sync-LauncherClaudeGlobalConfig {
         -EnsureParentDirectory
 }
 
+<#
+.SYNOPSIS
+    Syncs Codex global config templates (AGENTS.md, .codex/config.toml) into the project directory.
+#>
 function Sync-LauncherCodexGlobalConfig {
     param(
         [Parameter(Mandatory)]
@@ -642,6 +738,10 @@ function Sync-LauncherCodexGlobalConfig {
         -EnsureParentDirectory
 }
 
+<#
+.SYNOPSIS
+    Syncs Copilot global config templates (copilot-instructions.md, .github/mcp.json) into the project directory.
+#>
 function Sync-LauncherCopilotGlobalConfig {
     param(
         [Parameter(Mandatory)]
@@ -668,6 +768,10 @@ function Sync-LauncherCopilotGlobalConfig {
         -EnsureParentDirectory
 }
 
+<#
+.SYNOPSIS
+    Executes a shell script on a remote Linux host via SSH and returns the exit code.
+#>
 function Invoke-LauncherSshScript {
     param(
         [Parameter(Mandatory)]
@@ -734,6 +838,10 @@ function Invoke-LauncherSshScript {
     return $exitCode
 }
 
+<#
+.SYNOPSIS
+    Returns the PowerShell executable name, preferring pwsh over powershell.exe when available.
+#>
 function Get-LauncherShell {
     if (Get-Command pwsh -ErrorAction SilentlyContinue) {
         return "pwsh.exe"
@@ -742,6 +850,10 @@ function Get-LauncherShell {
     return "powershell.exe"
 }
 
+<#
+.SYNOPSIS
+    Records a launcher execution result to the recent projects history when the feature is enabled.
+#>
 function Write-LauncherExecutionResult {
     param(
         [Parameter(Mandatory)]
@@ -778,6 +890,10 @@ function Write-LauncherExecutionResult {
         -MaxHistory $Config.recentProjects.maxHistory
 }
 
+<#
+.SYNOPSIS
+    Returns the path to today's launch metadata JSONL log file derived from the Config logging or history settings.
+#>
 function Get-LauncherMetadataLogPath {
     param(
         [Parameter(Mandatory)]
@@ -798,6 +914,10 @@ function Get-LauncherMetadataLogPath {
     return $null
 }
 
+<#
+.SYNOPSIS
+    Reads and returns recent launcher metadata entries from the JSONL log files in the log directory.
+#>
 function Get-LauncherMetadataEntry {
     param(
         [Parameter(Mandatory)]
@@ -851,6 +971,10 @@ function Get-LauncherMetadataEntry {
     )
 }
 
+<#
+.SYNOPSIS
+    Reads TASKS.md and returns a summary of pending task count and priority distribution.
+#>
 function Get-LauncherBacklogSummary {
     param(
         [string]$TasksPath = (Join-Path (Get-Location) 'TASKS.md')
@@ -883,6 +1007,10 @@ function Get-LauncherBacklogSummary {
     }
 }
 
+<#
+.SYNOPSIS
+    Appends a launcher metadata entry as a JSON line to today's metadata log file with write-lock retry.
+#>
 function Write-LauncherMetadataLog {
     param(
         [Parameter(Mandatory)]
@@ -929,6 +1057,10 @@ function Write-LauncherMetadataLog {
     }
 }
 
+<#
+.SYNOPSIS
+    Creates a new execution context object used to track a launcher session's timing, tool, mode, and result.
+#>
 function New-LauncherExecutionContext {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Factory function returns in-memory object; no persistent system state is modified')]
     param()
@@ -941,6 +1073,10 @@ function New-LauncherExecutionContext {
     }
 }
 
+<#
+.SYNOPSIS
+    Finalizes an execution context by writing the result and elapsed time to the execution log.
+#>
 function Complete-LauncherExecutionContext {
     param(
         [Parameter(Mandatory)]
@@ -966,6 +1102,10 @@ function Complete-LauncherExecutionContext {
     })
 }
 
+<#
+.SYNOPSIS
+    Computes a summary (total runs, success rate, average elapsed time) from a collection of recent entries.
+#>
 function Get-LauncherRecentSummary {
     param(
         [Parameter(Mandatory)]
@@ -998,6 +1138,10 @@ function Get-LauncherRecentSummary {
     }
 }
 
+<#
+.SYNOPSIS
+    Returns per-tool statistics (runs, success rate, average elapsed time, latest result) from recent entries.
+#>
 function Get-LauncherToolStatistic {
     param(
         [AllowEmptyCollection()]
@@ -1035,6 +1179,10 @@ function Get-LauncherToolStatistic {
     return @($stats)
 }
 
+<#
+.SYNOPSIS
+    Builds Architect, QA, and Ops lane event summaries from recent metadata entries and the backlog summary.
+#>
 function Get-LauncherAgentLaneEvent {
     param(
         [Parameter(Mandatory)]
@@ -1143,6 +1291,10 @@ function Get-LauncherAgentLaneEvent {
     )
 }
 
+<#
+.SYNOPSIS
+    Returns the current token budget zone and status message based on the AI_STARTUP_TOKEN_USAGE_PCT environment variable.
+#>
 function Get-LauncherTokenBudgetStatus {
     $pct = if ($env:AI_STARTUP_TOKEN_USAGE_PCT) { [int]$env:AI_STARTUP_TOKEN_USAGE_PCT } else { -1 }
     if ($pct -lt 0) {
@@ -1161,6 +1313,10 @@ function Get-LauncherTokenBudgetStatus {
     return [pscustomobject]@{ Percent = $pct; Zone = 'Red'; Status = 'Development stop threshold' }
 }
 
+<#
+.SYNOPSIS
+    Returns recent project entries from the history file when the recentProjects feature is enabled.
+#>
 function Get-LauncherRecentEntry {
     param(
         [Parameter(Mandatory)]
@@ -1189,6 +1345,10 @@ function Get-LauncherRecentEntry {
     )
 }
 
+<#
+.SYNOPSIS
+    Returns the most recent result, elapsed time, and timestamp for each tool from the provided entry list.
+#>
 function Get-LauncherRecentToolResult {
     param(
         [Parameter(Mandatory)]
@@ -1339,6 +1499,10 @@ public class LauncherWinMM {
 }
 Export-ModuleMember -Function Invoke-LauncherNotificationSound
 
+<#
+.SYNOPSIS
+    Generates a Bash script fragment that deploys a template file to a remote target path via base64 encoding.
+#>
 function New-RemoteTemplateDeployScript {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Factory function returns in-memory object; no persistent system state is modified')]
     param(

--- a/scripts/lib/LogManager.psm1
+++ b/scripts/lib/LogManager.psm1
@@ -7,6 +7,10 @@
 $script:CurrentLogPath = $null
 $script:LoggingActive = $false
 
+<#
+.SYNOPSIS
+    Starts a transcript log session and returns the log file path.
+#>
 function Start-SessionLog {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
@@ -66,6 +70,10 @@ function Start-SessionLog {
     return @{ LogPath = $logPath }
 }
 
+<#
+.SYNOPSIS
+    Stops the active transcript log and renames the file with a SUCCESS or FAILURE suffix.
+#>
 function Stop-SessionLog {
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal autonomous CLI function; ShouldProcess disrupts unattended operation')]
@@ -103,6 +111,10 @@ function Stop-SessionLog {
     $script:CurrentLogPath = $null
 }
 
+<#
+.SYNOPSIS
+    Deletes aged log files from the log directory based on configured retention days.
+#>
 function Invoke-LogRotation {
     [CmdletBinding()]
     param(
@@ -176,6 +188,10 @@ function Invoke-LogRotation {
     }
 }
 
+<#
+.SYNOPSIS
+    Archives aged log files into monthly zip archives under the log directory.
+#>
 function Invoke-LogArchive {
     [CmdletBinding()]
     param(
@@ -223,6 +239,10 @@ function Invoke-LogArchive {
     }
 }
 
+<#
+.SYNOPSIS
+    Returns a summary hashtable of log file counts, sizes, and date range for the configured log directory.
+#>
 function Get-LogSummary {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]

--- a/scripts/lib/McpHealthCheck.psm1
+++ b/scripts/lib/McpHealthCheck.psm1
@@ -20,6 +20,10 @@ function ConvertTo-McpProcessArgumentString {
     )
 }
 
+<#
+.SYNOPSIS
+    Runs a process with a timeout and returns its exit code, output, and timeout status.
+#>
 function Invoke-McpProcessWithTimeout {
     param(
         [string]$Command,
@@ -58,12 +62,20 @@ function Invoke-McpProcessWithTimeout {
     }
 }
 
+<#
+.SYNOPSIS
+    Tests whether the specified command is available in the current environment.
+#>
 function Test-McpCommandExists {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Exists is a verb suffix not a plural noun')]
     param([string]$Command)
     return [bool](Get-Command $Command -ErrorAction SilentlyContinue)
 }
 
+<#
+.SYNOPSIS
+    Returns a health status object for a single MCP server definition.
+#>
 function Get-McpServerHealth {
     param(
         [string]$Name,
@@ -213,6 +225,10 @@ function Get-McpServerHealth {
     }
 }
 
+<#
+.SYNOPSIS
+    Generates a full MCP health report for all servers defined in the project's .mcp.json.
+#>
 function Get-McpHealthReport {
     param([string]$ProjectRoot)
 
@@ -279,6 +295,10 @@ function Get-McpHealthReport {
     return [pscustomobject]$report
 }
 
+<#
+.SYNOPSIS
+    Displays the MCP health report to the console with color-coded status indicators.
+#>
 function Show-McpHealthReport {
     param([pscustomobject]$Report)
 

--- a/scripts/lib/MenuCommon.psm1
+++ b/scripts/lib/MenuCommon.psm1
@@ -1,3 +1,7 @@
+<#
+.SYNOPSIS
+    Normalizes the tool filter string to a validated value or empty string for use in recent-menu queries.
+#>
 function ConvertTo-MenuRecentToolFilter {
     param([string]$ToolFilter = '')
 
@@ -12,6 +16,10 @@ function ConvertTo-MenuRecentToolFilter {
     return ''
 }
 
+<#
+.SYNOPSIS
+    Normalizes the sort mode string to a validated value, defaulting to 'success'.
+#>
 function ConvertTo-MenuRecentSortMode {
     param([string]$SortMode = 'success')
 
@@ -22,6 +30,10 @@ function ConvertTo-MenuRecentSortMode {
     return 'success'
 }
 
+<#
+.SYNOPSIS
+    Returns a summary object of the active recent-menu filter, search, and sort settings.
+#>
 function Get-MenuRecentFilterSummary {
     param(
         [string]$ToolFilter = '',

--- a/scripts/lib/SessionTabManager.psm1
+++ b/scripts/lib/SessionTabManager.psm1
@@ -5,6 +5,10 @@
 
 Set-StrictMode -Version Latest
 
+<#
+.SYNOPSIS
+    Returns the resolved path to the sessions directory, falling back to the default user profile location.
+#>
 function Get-SessionDir {
     param([string]$ConfigSessionsDir = '')
 
@@ -14,6 +18,10 @@ function Get-SessionDir {
     return (Join-Path $env:USERPROFILE '.claudeos\sessions')
 }
 
+<#
+.SYNOPSIS
+    Generates a timestamped unique session identifier for the given project name.
+#>
 function New-SessionId {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Factory function returns in-memory object; no persistent system state is modified')]
     param(
@@ -24,6 +32,10 @@ function New-SessionId {
     return "$stamp-$safe"
 }
 
+<#
+.SYNOPSIS
+    Creates and persists a new session info object with running status and planned end time.
+#>
 function New-SessionInfo {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Factory function returns in-memory object; no persistent system state is modified')]
     param(
@@ -60,6 +72,10 @@ function New-SessionInfo {
     return $session
 }
 
+<#
+.SYNOPSIS
+    Atomically writes a session info object to its JSON file in the sessions directory.
+#>
 function Save-SessionInfo {
     param(
         [Parameter(Mandatory)][pscustomobject]$Session,
@@ -78,6 +94,10 @@ function Save-SessionInfo {
     return $path
 }
 
+<#
+.SYNOPSIS
+    Reads and returns the session info object for the given session ID from the sessions directory.
+#>
 function Get-SessionInfo {
     param(
         [Parameter(Mandatory)][string]$SessionId,
@@ -92,6 +112,10 @@ function Get-SessionInfo {
     return (Get-Content $path -Raw -Encoding UTF8 | ConvertFrom-Json)
 }
 
+<#
+.SYNOPSIS
+    Updates the status field of the specified session and saves the change to disk.
+#>
 function Set-SessionStatus {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal autonomous CLI function; ShouldProcess disrupts unattended operation')]
     param(
@@ -108,6 +132,10 @@ function Set-SessionStatus {
     return (Save-SessionInfo -Session $session -ConfigSessionsDir $ConfigSessionsDir)
 }
 
+<#
+.SYNOPSIS
+    Updates the planned duration and recalculates end_time_planned for the specified session.
+#>
 function Update-SessionDuration {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal autonomous CLI function; ShouldProcess disrupts unattended operation')]
     param(
@@ -126,6 +154,10 @@ function Update-SessionDuration {
     return (Save-SessionInfo -Session $session -ConfigSessionsDir $ConfigSessionsDir)
 }
 
+<#
+.SYNOPSIS
+    Returns the most recently updated session with status 'running', or null if none exists.
+#>
 function Get-ActiveSession {
     param([string]$ConfigSessionsDir = '')
 

--- a/scripts/lib/StatuslineManager.psm1
+++ b/scripts/lib/StatuslineManager.psm1
@@ -5,10 +5,11 @@
 
 Set-StrictMode -Version Latest
 
+<#
+.SYNOPSIS
+    Extracts the statusLine section from the Windows-side ~/.claude/settings.json file.
+#>
 function Get-GlobalStatusLineConfig {
-    <#
-    .SYNOPSIS Windows 側 ~/.claude/settings.json から statusLine セクションを抽出
-    #>
     param([string]$SettingsPath = '')
 
     if ([string]::IsNullOrWhiteSpace($SettingsPath)) {
@@ -39,12 +40,11 @@ function Get-GlobalStatusLineConfig {
     }
 }
 
+<#
+.SYNOPSIS
+    Merges the statusLine configuration into the remote Linux host's ~/.claude/settings.json via SSH.
+#>
 function Invoke-RemoteSettingsSync {
-    <#
-    .SYNOPSIS Linux 側 ~/.claude/settings.json に statusLine を merge
-    .DESCRIPTION
-      既存ファイルがあればバックアップを取り、Python (Linux 標準) で JSON merge
-    #>
     param(
         [Parameter(Mandatory)][string]$LinuxHost,
         [Parameter(Mandatory)][object]$StatusLine,


### PR DESCRIPTION
## Summary
- PSScriptAnalyzer `PSProvideCommentHelp` 警告 85 件を 9 ファイルで解消
- 全関数に `.SYNOPSIS` コメントブロックを追加（実装ロジック変更なし）
- Pester 477 Passed / 0 Failed 確認済み

## Changes
| ファイル | 追加件数 |
|---|---|
| `scripts/lib/LauncherCommon.psm1` | 41 |
| `scripts/lib/CronManager.psm1` | 9 |
| `scripts/lib/AgentTeams.psm1` | 8 |
| `scripts/lib/SessionTabManager.psm1` | 8 |
| `scripts/lib/LogManager.psm1` | 5 |
| `scripts/lib/McpHealthCheck.psm1` | 5 |
| `scripts/lib/Config.psm1` | 4 |
| `scripts/lib/MenuCommon.psm1` | 3 |
| `scripts/lib/StatuslineManager.psm1` | 2 |

## Test Results
- `Invoke-ScriptAnalyzer -IncludeRule PSProvideCommentHelp` = **0 件**
- `Invoke-Pester` Passed: **477** / Failed: **0**

## Closes
Closes #166