### PR TITLE
feat(v3.2.16): 3タブ監視構成 + tmux UI — Watch-ClaudeLog + Watch-SessionInfoSSH + Claude-UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 # CHANGELOG
 
+## [v3.2.17] - 2026-04-17 — 3タブ監視構成 + tmux UI 統合
+
+### 🎯 概要
+
+cron 発火した ClaudeCode セッションを Windows Terminal から 3 タブでリアルタイム監視できる構成を実装：
+
+- **Tab①** ログ監視 (`Watch-ClaudeLog.ps1`): SSH `tail -f` で cron ログをリアルタイム表示
+- **Tab②** Claude UI (`tmux attach`): cron-launcher 側で tmux 内に Claude を TTY あり起動、`ssh -t tmux attach` で対話 UI を Windows から閲覧可能
+- **Tab③** Session Info (`Watch-SessionInfoSSH.ps1`): session.json を SSH ポーリングで残り時間・status をリアルタイム更新
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/tools/Watch-ClaudeLog.ps1` | 新規。cron ログ検出 + Tab②③ 自動展開 |
+| `scripts/tools/Watch-SessionInfoSSH.ps1` | 新規。session.json SSH ポーリング表示 |
+| `Claude/templates/linux/cron-launcher.sh` | tmux new-session で Claude を TTY あり実行、wrapper script で引数安全渡し、`tmux pipe-pane` でログも同時書き込み、`tmux wait-for` で同期 |
+| `scripts/main/Start-Menu.ps1` | 項目 14「Claude ログ監視タブを開く」追加 |
+| `config/config.json.template` | `linuxUser` フィールド追加（default: kensan） |
+
+### 🔐 CodeRabbit / Codex 指摘対応
+
+- SSH ユーザー名を `config.linuxUser` からパラメータ化（ハードコード解消）
+- DateTimeOffset でタイムゾーン情報を保持（Get-Date ローカルタイム問題解消）
+- wrapper script の `set -euo pipefail` を除去 — claude 非0終了でも `tmux wait-for -S` 到達保証
+
+### ✅ 検証結果
+
+- CI: test-and-validate / PSScriptAnalyzer / gitleaks / CodeRabbit 全 SUCCESS
+- Linux デプロイ: `/home/kensan/.claudeos/cron-launcher.sh` v3.2.16 確認
+- tmux 3.4 インストール確認済み
+
+---
+
 ## [v3.2.14] - 2026-04-17 — PSProvideCommentHelp 警告 85 件解消
 
 ### 🎯 概要

--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # ============================================================
 # cron-launcher.sh - Linux 側で ClaudeCode を cron から起動するラッパ
-# ClaudeOS v3.2.0
+# ClaudeOS v3.2.16
 #
 # Usage: cron-launcher.sh <project> <duration-minutes>
 #
@@ -65,14 +65,9 @@ cat > "$SESSION_FILE.tmp" <<EOF
 EOF
 mv "$SESSION_FILE.tmp" "$SESSION_FILE"
 
-# --- tmux log-tail セッション起動（CLAUDEOS_TMUX=0 で無効化） ---
-# tmux attach -t "claudeos-SAFEPROJECT" でリアルタイムログを閲覧できる
 TMUX_SESSION="claudeos-${SAFE_PROJECT}"
-if command -v tmux >/dev/null 2>&1 && [[ "${CLAUDEOS_TMUX:-1}" == "1" ]]; then
-  tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
-  tmux new-session -d -s "$TMUX_SESSION" bash -c "tail -f '$LOG_FILE'"
-  echo "[cron-launcher] tmux log-tail: tmux attach -t $TMUX_SESSION" >> "$LOG_FILE"
-fi
+CLAUDE_EXIT_FILE="$SESSIONS_DIR/${SESSION_ID}.exit"
+CLAUDE_WRAPPER="$SESSIONS_DIR/${SESSION_ID}.wrapper.sh"
 
 # 終了時に status を更新するトラップ
 finalize() {
@@ -103,10 +98,11 @@ finalize() {
 
   echo "[cron-launcher] session finished status=$final_status exit=$exit_code at $now" >> "$LOG_FILE"
 
-  # tmux log-tail セッションを終了
+  # tmux セッションを終了・一時ファイルを削除
   if command -v tmux >/dev/null 2>&1; then
     tmux kill-session -t "claudeos-${SAFE_PROJECT}" 2>/dev/null || true
   fi
+  rm -f "$CLAUDE_WRAPPER" "$CLAUDE_EXIT_FILE"
 
   # --- v3.2.0: HTML レポートメール送信 ---
   # 明示的トグル CLAUDEOS_EMAIL_ENABLED=1 が必要。誤送信防止のため既定 off。
@@ -145,8 +141,44 @@ if [[ -f "$PROJECT_DIR/.claude/START_PROMPT.md" ]]; then
   PROMPT_ARG="$(cat "$PROJECT_DIR/.claude/START_PROMPT.md")"
 fi
 
-if [[ -n "$PROMPT_ARG" ]]; then
-  timeout "${DURATION_SEC}s" claude --dangerously-skip-permissions "$PROMPT_ARG" >> "$LOG_FILE" 2>&1
+# wrapper script: env var 経由で引数を安全に渡す（tmux new-session での引用符崩れ対策）
+cat > "$CLAUDE_WRAPPER" <<'WRAPPER_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -n "${_CLAUDEOS_PROMPT_ARG:-}" ]]; then
+  timeout "${_CLAUDEOS_DURATION_SEC}s" claude --dangerously-skip-permissions "${_CLAUDEOS_PROMPT_ARG}"
 else
-  timeout "${DURATION_SEC}s" claude --dangerously-skip-permissions >> "$LOG_FILE" 2>&1
+  timeout "${_CLAUDEOS_DURATION_SEC}s" claude --dangerously-skip-permissions
+fi
+echo $? > "${_CLAUDEOS_EXIT_FILE}"
+# tmux wait-for でメイン shell へ終了を通知
+tmux wait-for -S "${_CLAUDEOS_TMUX_DONE}"
+WRAPPER_EOF
+chmod +x "$CLAUDE_WRAPPER"
+
+export _CLAUDEOS_PROMPT_ARG="$PROMPT_ARG"
+export _CLAUDEOS_DURATION_SEC="$DURATION_SEC"
+export _CLAUDEOS_EXIT_FILE="$CLAUDE_EXIT_FILE"
+export _CLAUDEOS_TMUX_DONE="done-${SAFE_PROJECT}"
+
+if command -v tmux >/dev/null 2>&1 && [[ "${CLAUDEOS_TMUX:-1}" == "1" ]]; then
+  # Claude を tmux セッション内で起動（TTY あり → attach で UI 閲覧可能）
+  tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$TMUX_SESSION" -x 220 -y 50 "$CLAUDE_WRAPPER"
+  # tmux pipe-pane でセッション出力をログファイルへも書き込む
+  tmux pipe-pane -t "$TMUX_SESSION" -o "cat >> '$LOG_FILE'"
+  echo "[cron-launcher] tmux attach -t $TMUX_SESSION  (UI閲覧用)" >> "$LOG_FILE"
+  # tmux セッション終了まで待機
+  tmux wait-for "${_CLAUDEOS_TMUX_DONE}"
+else
+  # tmux 無効時は従来通り TTY なし実行
+  timeout "${DURATION_SEC}s" claude --dangerously-skip-permissions ${PROMPT_ARG:+"$PROMPT_ARG"} >> "$LOG_FILE" 2>&1
+fi
+
+# wrapper が書いた終了コードを読み取り、EXIT トラップへ伝播
+if [[ -f "$CLAUDE_EXIT_FILE" ]]; then
+  CLAUDE_EXIT=$(cat "$CLAUDE_EXIT_FILE")
+  if [[ "$CLAUDE_EXIT" != "0" ]]; then
+    exit "${CLAUDE_EXIT}"
+  fi
 fi

--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -65,6 +65,15 @@ cat > "$SESSION_FILE.tmp" <<EOF
 EOF
 mv "$SESSION_FILE.tmp" "$SESSION_FILE"
 
+# --- tmux log-tail セッション起動（CLAUDEOS_TMUX=0 で無効化） ---
+# tmux attach -t "claudeos-SAFEPROJECT" でリアルタイムログを閲覧できる
+TMUX_SESSION="claudeos-${SAFE_PROJECT}"
+if command -v tmux >/dev/null 2>&1 && [[ "${CLAUDEOS_TMUX:-1}" == "1" ]]; then
+  tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$TMUX_SESSION" bash -c "tail -f '$LOG_FILE'"
+  echo "[cron-launcher] tmux log-tail: tmux attach -t $TMUX_SESSION" >> "$LOG_FILE"
+fi
+
 # 終了時に status を更新するトラップ
 finalize() {
   local exit_code=$?
@@ -93,6 +102,11 @@ finalize() {
   fi
 
   echo "[cron-launcher] session finished status=$final_status exit=$exit_code at $now" >> "$LOG_FILE"
+
+  # tmux log-tail セッションを終了
+  if command -v tmux >/dev/null 2>&1; then
+    tmux kill-session -t "claudeos-${SAFE_PROJECT}" 2>/dev/null || true
+  fi
 
   # --- v3.2.0: HTML レポートメール送信 ---
   # 明示的トグル CLAUDEOS_EMAIL_ENABLED=1 が必要。誤送信防止のため既定 off。

--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -142,16 +142,17 @@ if [[ -f "$PROJECT_DIR/.claude/START_PROMPT.md" ]]; then
 fi
 
 # wrapper script: env var 経由で引数を安全に渡す（tmux new-session での引用符崩れ対策）
+# set -e を使わず claude_exit に明示的に格納する（非0終了でも wait-for -S を必ず実行するため）
 cat > "$CLAUDE_WRAPPER" <<'WRAPPER_EOF'
 #!/usr/bin/env bash
-set -euo pipefail
+claude_exit=0
 if [[ -n "${_CLAUDEOS_PROMPT_ARG:-}" ]]; then
-  timeout "${_CLAUDEOS_DURATION_SEC}s" claude --dangerously-skip-permissions "${_CLAUDEOS_PROMPT_ARG}"
+  timeout "${_CLAUDEOS_DURATION_SEC}s" claude --dangerously-skip-permissions "${_CLAUDEOS_PROMPT_ARG}" || claude_exit=$?
 else
-  timeout "${_CLAUDEOS_DURATION_SEC}s" claude --dangerously-skip-permissions
+  timeout "${_CLAUDEOS_DURATION_SEC}s" claude --dangerously-skip-permissions || claude_exit=$?
 fi
-echo $? > "${_CLAUDEOS_EXIT_FILE}"
-# tmux wait-for でメイン shell へ終了を通知
+echo "$claude_exit" > "${_CLAUDEOS_EXIT_FILE}"
+# 終了コード書き込み後に親 shell へ通知（失敗時もここまで必ず到達する）
 tmux wait-for -S "${_CLAUDEOS_TMUX_DONE}"
 WRAPPER_EOF
 chmod +x "$CLAUDE_WRAPPER"

--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 29. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.12 PSUseOutputTypeCorrectly 警告解消 — 7 ファイル 13 関数 [OutputType()] 追加 / STABLE N=2 達成 (PR #164)
 30. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.13 PSAvoidUsingPositionalParameters 残存 1 件解消 (Test-ArchitectureCheck.ps1) + CLAUDE.md v8.3 Auto mode / Response length calibration 追加 / STABLE N=2 達成 (PR #165)
 31. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.14 PSProvideCommentHelp 警告 85 件解消 — 9 ファイル全関数に .SYNOPSIS 追加 / STABLE N=2 達成 (PR #167)
+32. [Priority:P1][Owner:Developer][Source:Manual] v3.2.17 3タブ監視構成 + tmux UI 統合 — Watch-ClaudeLog.ps1 / Watch-SessionInfoSSH.ps1 新規 / cron-launcher.sh tmux TTY 実行化 / linuxUser config パラメータ化 / DateTimeOffset TZ 対応 (PR #168)
 
 ## Auto Extracted From Agent Teams Matrix
 

--- a/config/config.json.template
+++ b/config/config.json.template
@@ -5,6 +5,7 @@
   "sshProjectsDir": "auto",
   "projectsDirUnc": "\\\\<your-linux-host>\\Projects",
   "linuxHost": "<your-linux-host>",
+  "linuxUser": "kensan",
   "linuxBase": "/home/kensan/Projects",
   "localExcludes": [],
   "tools": {

--- a/scripts/main/Start-Menu.ps1
+++ b/scripts/main/Start-Menu.ps1
@@ -214,6 +214,7 @@ function Show-Menu {
     Write-Host "    11. Architecture Check" -ForegroundColor Magenta
     Write-Host "    12. Cron 登録・編集・削除" -ForegroundColor Magenta
     Write-Host "    13. Statusline 設定" -ForegroundColor Magenta
+    Write-Host "    14. Claude ログ監視タブを開く" -ForegroundColor Magenta
     Write-Host ""
 
     Write-Host "    0.  終了" -ForegroundColor Gray
@@ -297,6 +298,12 @@ while ($true) {
         "11" { Invoke-MenuScript -File "scripts\test\Test-ArchitectureCheck.ps1" }
         "12" { Invoke-MenuScript -File "scripts\main\New-CronSchedule.ps1" }
         "13" { Invoke-MenuScript -File "scripts\main\Set-Statusline.ps1" }
+        "14" {
+            $watchScript = Join-Path $ProjectRoot "scripts\tools\Watch-ClaudeLog.ps1"
+            & $ShellExe -NoProfile -ExecutionPolicy Bypass -File $watchScript -NewTab -WithSessionInfoTab
+            Write-Host ""
+            Read-Host "  Enterキーでメニューに戻ります"
+        }
         "0"  { exit 0 }
         default {
             Write-Host ""

--- a/scripts/tools/Watch-ClaudeLog.ps1
+++ b/scripts/tools/Watch-ClaudeLog.ps1
@@ -31,6 +31,8 @@ Import-Module (Join-Path $ScriptRoot 'scripts\lib\Config.psm1') -Force -DisableN
 $ConfigPath = Get-StartupConfigPath -StartupRoot $ScriptRoot
 $Config     = Import-LauncherConfig -ConfigPath $ConfigPath
 $LinuxHost  = $Config.linuxHost
+$LinuxUser  = if ($Config.PSObject.Properties.Name -contains 'linuxUser' -and -not [string]::IsNullOrWhiteSpace($Config.linuxUser)) { $Config.linuxUser } else { 'kensan' }
+$SshTarget  = "${LinuxUser}@${LinuxHost}"
 
 $LogsDir = '/home/kensan/.claudeos/logs'
 if ($Config.PSObject.Properties.Name -contains 'cron' -and
@@ -108,7 +110,7 @@ function Write-LiveHeader {
 }
 
 function Get-LatestLog {
-    $result = ssh "kensan@$LinuxHost" "ls -t $LogsDir/cron-*.log 2>/dev/null | head -1" 2>$null
+    $result = ssh $SshTarget "ls -t $LogsDir/cron-*.log 2>/dev/null | head -1" 2>$null
     if ($null -eq $result) { return '' }
     return $result.Trim()
 }
@@ -117,7 +119,7 @@ function Get-SessionIdForLog {
     param([string]$LogPath)
     $basename = ($LogPath -split '/')[-1]
     $stamp    = $basename -replace '^cron-', '' -replace '\.log$', ''
-    $result   = ssh "kensan@$LinuxHost" "ls '$SessionsDir/${stamp}-'*.json 2>/dev/null | head -1" 2>$null
+    $result   = ssh $SshTarget "ls '$SessionsDir/${stamp}-'*.json 2>/dev/null | head -1" 2>$null
     if ($null -eq $result -or [string]::IsNullOrWhiteSpace($result)) { return '' }
     return ($result.Trim() -split '/')[-1] -replace '\.json$', ''
 }
@@ -137,7 +139,7 @@ function Open-TmuxAttachTab {
     }
     $safeProject = $parts[2]
     $tmuxSession  = "claudeos-$safeProject"
-    $sshCmd       = "ssh -t kensan@$LinuxHost tmux attach -t $tmuxSession"
+    $sshCmd       = "ssh -t $SshTarget tmux attach -t $tmuxSession"
     $psExe        = (Get-Process -Id $PID).Path
     $psArgs = @(
         '-NoExit', '-NoProfile', '-ExecutionPolicy', 'Bypass',
@@ -166,6 +168,7 @@ function Open-SessionInfoTab {
         '-File', $siScript,
         '-SessionId', $SessionId,
         '-LinuxHost', $LinuxHost,
+        '-LinuxUser', $LinuxUser,
         '-SessionsDir', $SessionsDir
     )
     $wtArgs = @('-w', '0', 'new-tab', '--title', 'Session-Info', '--', $psExe) + $psArgs
@@ -202,7 +205,7 @@ while ($true) {
 
         Write-Host ''
         # tail -f でリアルタイム表示（SSH セッションが終わるまでブロック）
-        ssh "kensan@$LinuxHost" "tail -n 50 -f '$latest'"
+        ssh $SshTarget "tail -n 50 -f '$latest'"
         $sshExitCode = $LASTEXITCODE
         Write-Host ''
         if ($sshExitCode -ne 0) {

--- a/scripts/tools/Watch-ClaudeLog.ps1
+++ b/scripts/tools/Watch-ClaudeLog.ps1
@@ -1,0 +1,201 @@
+<#
+.SYNOPSIS
+    Claude Code ログをリアルタイム監視する（SSH + tail -f）。
+.DESCRIPTION
+    Linux 側の cron-launcher.sh が出力するログファイルを自動検出し
+    Windows Terminal の新規タブで tail -f を開始する。
+    cron 実行前に起動しておくと、発火を検知して自動でログ表示を開始する。
+    ClaudeOS v3.2.15
+.PARAMETER NewTab
+    Windows Terminal の新規タブで開く（既定: 現在のウィンドウで実行）。
+.PARAMETER PollIntervalSeconds
+    ログファイル検出のポーリング間隔（秒）。既定: 5。
+.PARAMETER WithSessionInfoTab
+    新しいセッション検出時に Session Info タブを自動で開く。
+#>
+
+param(
+    [switch]$NewTab,
+    [switch]$WithSessionInfoTab,
+    [int]$PollIntervalSeconds = 5
+)
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\LauncherCommon.psm1') -Force -DisableNameChecking
+Import-Module (Join-Path $ScriptRoot 'scripts\lib\Config.psm1') -Force -DisableNameChecking
+
+$ConfigPath = Get-StartupConfigPath -StartupRoot $ScriptRoot
+$Config     = Import-LauncherConfig -ConfigPath $ConfigPath
+$LinuxHost  = $Config.linuxHost
+
+$LogsDir = '/home/kensan/.claudeos/logs'
+if ($Config.PSObject.Properties.Name -contains 'cron' -and
+    $Config.cron.PSObject.Properties.Name -contains 'logsDir') {
+    $LogsDir = $Config.cron.logsDir
+}
+
+$SessionsDir = '/home/kensan/.claudeos/sessions'
+if ($Config.PSObject.Properties.Name -contains 'cron' -and
+    $Config.cron.PSObject.Properties.Name -contains 'sessionsDir') {
+    $SessionsDir = $Config.cron.sessionsDir
+}
+
+if ([string]::IsNullOrWhiteSpace($LinuxHost) -or $LinuxHost -eq '<your-linux-host>') {
+    Write-Host '[ERROR] config.json の linuxHost が未設定です。' -ForegroundColor Red
+    exit 1
+}
+
+# NewTab モード: 自身を新しい Windows Terminal タブで再起動
+if ($NewTab) {
+    $psExe  = (Get-Process -Id $PID).Path
+    $wtExe  = Get-Command wt.exe -ErrorAction SilentlyContinue
+    $myPath = $PSCommandPath
+
+    # $PSCommandPath が空の場合（dot-source 経由など）はガード
+    if ([string]::IsNullOrWhiteSpace($myPath)) {
+        Write-Host '[ERROR] -NewTab モードは PSCommandPath が空のため使用できません。直接ファイルパスを指定して実行してください。' -ForegroundColor Red
+        exit 1
+    }
+
+    $psArgs = @(
+        '-NoExit', '-NoProfile', '-ExecutionPolicy', 'Bypass',
+        '-File', $myPath,
+        '-PollIntervalSeconds', $PollIntervalSeconds
+    )
+    if ($WithSessionInfoTab) { $psArgs += '-WithSessionInfoTab' }
+
+    if ($wtExe) {
+        $wtArgs = @('-w', '0', 'new-tab', '--title', 'Claude-Live-Log', '--', $psExe) + $psArgs
+        Start-Process -FilePath $wtExe.Source -ArgumentList $wtArgs -WindowStyle Hidden
+        Write-Host '[INFO] Claude-Live-Log タブを開きました。' -ForegroundColor Cyan
+    } else {
+        Start-Process -FilePath $psExe -ArgumentList $psArgs -WindowStyle Normal
+        Write-Host '[INFO] Claude Live Log ウィンドウを開きました（wt.exe 非検出）。' -ForegroundColor Yellow
+    }
+    exit 0
+}
+
+# ─── 内部関数 ────────────────────────────────────────────────────────────
+
+function Write-WaitHeader {
+    Write-Host ''
+    Write-Host ('  ' + '=' * 54) -ForegroundColor Cyan
+    Write-Host '   Claude Code ライブログ監視' -ForegroundColor Cyan
+    Write-Host "   Host : $LinuxHost" -ForegroundColor DarkCyan
+    Write-Host "   Log  : (待機中)" -ForegroundColor DarkCyan
+    Write-Host ('  ' + '=' * 54) -ForegroundColor Cyan
+    Write-Host ''
+    Write-Host '  cron 発火待機中...' -ForegroundColor Yellow
+    Write-Host "  ログディレクトリ: $LogsDir" -ForegroundColor DarkGray
+    Write-Host ''
+}
+
+function Write-LiveHeader {
+    param([string]$LogFile)
+    Clear-Host
+    Write-Host ''
+    Write-Host ('  ' + '=' * 54) -ForegroundColor Cyan
+    Write-Host '   Claude Code ライブログ監視' -ForegroundColor Cyan
+    Write-Host "   Host : $LinuxHost" -ForegroundColor DarkCyan
+    Write-Host "   Log  : $LogFile" -ForegroundColor DarkCyan
+    Write-Host ('  ' + '=' * 54) -ForegroundColor Cyan
+    Write-Host '  Ctrl+C でこのタブを閉じる（セッション本体は継続）' -ForegroundColor DarkGray
+    Write-Host ''
+}
+
+function Get-LatestLog {
+    $result = ssh "kensan@$LinuxHost" "ls -t $LogsDir/cron-*.log 2>/dev/null | head -1" 2>$null
+    if ($null -eq $result) { return '' }
+    return $result.Trim()
+}
+
+function Get-SessionIdForLog {
+    param([string]$LogPath)
+    $basename = ($LogPath -split '/')[-1]
+    $stamp    = $basename -replace '^cron-', '' -replace '\.log$', ''
+    $result   = ssh "kensan@$LinuxHost" "ls '$SessionsDir/${stamp}-'*.json 2>/dev/null | head -1" 2>$null
+    if ($null -eq $result -or [string]::IsNullOrWhiteSpace($result)) { return '' }
+    return ($result.Trim() -split '/')[-1] -replace '\.json$', ''
+}
+
+function Open-SessionInfoTab {
+    param([string]$SessionId)
+    $wtExe = Get-Command wt.exe -ErrorAction SilentlyContinue
+    if (-not $wtExe) {
+        Write-Host '  [INFO] wt.exe が非検出のため Session Info タブを開けません。' -ForegroundColor Yellow
+        return
+    }
+    $psExe    = (Get-Process -Id $PID).Path
+    $siScript = Join-Path $PSScriptRoot 'Watch-SessionInfoSSH.ps1'
+    if (-not (Test-Path $siScript)) {
+        Write-Host "  [WARN] Watch-SessionInfoSSH.ps1 が見つかりません: $siScript" -ForegroundColor Yellow
+        return
+    }
+    $psArgs = @(
+        '-NoExit', '-NoProfile', '-ExecutionPolicy', 'Bypass',
+        '-File', $siScript,
+        '-SessionId', $SessionId,
+        '-LinuxHost', $LinuxHost,
+        '-SessionsDir', $SessionsDir
+    )
+    $wtArgs = @('-w', '0', 'new-tab', '--title', 'Session-Info', '--', $psExe) + $psArgs
+    Start-Process -FilePath $wtExe.Source -ArgumentList $wtArgs -WindowStyle Hidden
+    Write-Host "  Session Info タブを開きました: $SessionId" -ForegroundColor Cyan
+}
+
+# ─── 本体: ログ監視ループ ────────────────────────────────────────────────
+
+Write-WaitHeader
+
+$knownLog = Get-LatestLog
+$dotCount = 0
+
+while ($true) {
+    $latest = Get-LatestLog
+
+    # 新しいログが現れたら監視開始
+    if ($latest -and ($latest -ne $knownLog)) {
+        Write-LiveHeader -LogFile $latest
+        Write-Host "  新しいセッション検出: $latest" -ForegroundColor Green
+
+        if ($WithSessionInfoTab) {
+            Write-Host '  Session ID を取得中...' -ForegroundColor DarkGray
+            $sessionId = Get-SessionIdForLog -LogPath $latest
+            if ($sessionId) {
+                Open-SessionInfoTab -SessionId $sessionId
+            } else {
+                Write-Host '  [WARN] Session ID が見つかりませんでした。' -ForegroundColor Yellow
+            }
+        }
+
+        Write-Host ''
+        # tail -f でリアルタイム表示（SSH セッションが終わるまでブロック）
+        ssh "kensan@$LinuxHost" "tail -n 50 -f '$latest'"
+        $sshExitCode = $LASTEXITCODE
+        Write-Host ''
+        if ($sshExitCode -ne 0) {
+            Write-Host "  [WARN] SSH が終了コード $sshExitCode で切断されました。次のポーリングへ戻ります..." -ForegroundColor Yellow
+        } else {
+            Write-Host '  セッション終了を検知しました。次の cron 発火を待機します...' -ForegroundColor Yellow
+        }
+        Write-Host ''
+        $knownLog = $latest
+        $dotCount = 0
+        Write-WaitHeader
+        continue
+    }
+
+    # 待機中ドット表示
+    Write-Host '.' -NoNewline -ForegroundColor DarkGray
+    $dotCount++
+    if ($dotCount -ge 60) {
+        Write-Host ''
+        $dotCount = 0
+    }
+
+    Start-Sleep -Seconds $PollIntervalSeconds
+}

--- a/scripts/tools/Watch-ClaudeLog.ps1
+++ b/scripts/tools/Watch-ClaudeLog.ps1
@@ -5,7 +5,7 @@
     Linux 側の cron-launcher.sh が出力するログファイルを自動検出し
     Windows Terminal の新規タブで tail -f を開始する。
     cron 実行前に起動しておくと、発火を検知して自動でログ表示を開始する。
-    ClaudeOS v3.2.15
+    ClaudeOS v3.2.16
 .PARAMETER NewTab
     Windows Terminal の新規タブで開く（既定: 現在のウィンドウで実行）。
 .PARAMETER PollIntervalSeconds
@@ -122,6 +122,32 @@ function Get-SessionIdForLog {
     return ($result.Trim() -split '/')[-1] -replace '\.json$', ''
 }
 
+function Open-TmuxAttachTab {
+    param([string]$SessionId)
+    $wtExe = Get-Command wt.exe -ErrorAction SilentlyContinue
+    if (-not $wtExe) {
+        Write-Host '  [INFO] wt.exe が非検出のため Tmux Attach タブを開けません。' -ForegroundColor Yellow
+        return
+    }
+    # SessionId = "YYYYMMDD-HHMMSS-SAFEPROJECT" → 3番目セグメントが SAFE_PROJECT
+    $parts = $SessionId -split '-', 3
+    if ($parts.Count -lt 3) {
+        Write-Host "  [WARN] SessionId のパースに失敗しました: $SessionId" -ForegroundColor Yellow
+        return
+    }
+    $safeProject = $parts[2]
+    $tmuxSession  = "claudeos-$safeProject"
+    $sshCmd       = "ssh -t kensan@$LinuxHost tmux attach -t $tmuxSession"
+    $psExe        = (Get-Process -Id $PID).Path
+    $psArgs = @(
+        '-NoExit', '-NoProfile', '-ExecutionPolicy', 'Bypass',
+        '-Command', $sshCmd
+    )
+    $wtArgs = @('-w', '0', 'new-tab', '--title', 'Claude-UI', '--', $psExe) + $psArgs
+    Start-Process -FilePath $wtExe.Source -ArgumentList $wtArgs -WindowStyle Hidden
+    Write-Host "  Claude UI タブを開きました: tmux attach -t $tmuxSession" -ForegroundColor Magenta
+}
+
 function Open-SessionInfoTab {
     param([string]$SessionId)
     $wtExe = Get-Command wt.exe -ErrorAction SilentlyContinue
@@ -166,7 +192,9 @@ while ($true) {
             Write-Host '  Session ID を取得中...' -ForegroundColor DarkGray
             $sessionId = Get-SessionIdForLog -LogPath $latest
             if ($sessionId) {
-                Open-SessionInfoTab -SessionId $sessionId
+                Open-TmuxAttachTab -SessionId $sessionId   # Tab ②: Claude UI (tmux attach)
+                Start-Sleep -Seconds 1
+                Open-SessionInfoTab -SessionId $sessionId  # Tab ③: Session Info
             } else {
                 Write-Host '  [WARN] Session ID が見つかりませんでした。' -ForegroundColor Yellow
             }

--- a/scripts/tools/Watch-SessionInfoSSH.ps1
+++ b/scripts/tools/Watch-SessionInfoSSH.ps1
@@ -1,0 +1,133 @@
+<#
+.SYNOPSIS
+    Linux側の session.json を SSH 経由でリアルタイム監視して表示する。
+.DESCRIPTION
+    cron-launcher.sh が生成する session.json を SSH 経由で 1 秒ごとに読み取り、
+    開始時刻・終了予定・残り時間・status を整形表示する。
+    セッション終了を検知すると自動的に閉じる。
+    ClaudeOS v3.2.15
+.PARAMETER SessionId
+    監視するセッション ID (例: 20260417-120000-myproject)。
+.PARAMETER LinuxHost
+    SSH接続先ホスト名。
+.PARAMETER SessionsDir
+    Linux 側の sessions ディレクトリパス。既定: /home/kensan/.claudeos/sessions
+.PARAMETER PollIntervalSeconds
+    ポーリング間隔（秒）。既定: 1。
+.PARAMETER AutoCloseAfterExitSeconds
+    セッション終了後に自動クローズするまでの秒数。既定: 10。
+#>
+
+param(
+    [Parameter(Mandatory)][string]$SessionId,
+    [Parameter(Mandatory)][string]$LinuxHost,
+    [string]$SessionsDir = '/home/kensan/.claudeos/sessions',
+    [int]$PollIntervalSeconds = 1,
+    [int]$AutoCloseAfterExitSeconds = 10
+)
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Format-Duration {
+    param([TimeSpan]$Span)
+    if ($Span.TotalSeconds -lt 0) { return '00:00:00' }
+    return "{0:00}:{1:00}:{2:00}" -f [int]$Span.TotalHours, $Span.Minutes, $Span.Seconds
+}
+
+function Get-StatusColor {
+    param([string]$Status)
+    switch ($Status) {
+        'running'   { return 'Green' }
+        'completed' { return 'Green' }
+        'timeout'   { return 'Cyan' }
+        'exited'    { return 'Cyan' }
+        'cancelled' { return 'Yellow' }
+        'failed'    { return 'Red' }
+        default     { return 'Gray' }
+    }
+}
+
+function Get-RemoteSession {
+    $sessionFile = "$SessionsDir/${SessionId}.json"
+    $json = ssh "kensan@$LinuxHost" "cat '$sessionFile' 2>/dev/null" 2>$null
+    if ($null -eq $json -or [string]::IsNullOrWhiteSpace($json)) { return $null }
+    try { return ($json | ConvertFrom-Json) }
+    catch { return $null }
+}
+
+function Show-SessionFrame {
+    param([pscustomobject]$Session)
+    Clear-Host
+    $start     = [datetime]::Parse($Session.start_time)
+    $end       = [datetime]::Parse($Session.end_time_planned)
+    $now       = Get-Date
+    $elapsed   = $now - $start
+    $remaining = $end - $now
+    $duration  = [TimeSpan]::FromMinutes($Session.max_duration_minutes)
+    $statusColor = Get-StatusColor -Status $Session.status
+
+    Write-Host ''
+    Write-Host ('  ' + '=' * 52) -ForegroundColor Cyan
+    Write-Host ("   Claude Session Info — $($Session.project)") -ForegroundColor Cyan
+    Write-Host ('  ' + '=' * 52) -ForegroundColor Cyan
+    Write-Host ''
+    Write-Host ("   Session ID : " + $Session.sessionId) -ForegroundColor DarkGray
+    Write-Host ("   Host       : " + $LinuxHost) -ForegroundColor DarkGray
+    Write-Host ("   Trigger    : " + $Session.trigger) -ForegroundColor Gray
+    Write-Host ''
+    Write-Host ("   開始時刻   : " + $start.ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor White
+    Write-Host ("   終了予定   : " + $end.ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor White
+    Write-Host ("   作業時間   : " + ("{0}h {1:00}m" -f [int]$duration.TotalHours, $duration.Minutes)) -ForegroundColor White
+    Write-Host ''
+    Write-Host ("   経過       : " + (Format-Duration -Span $elapsed)) -ForegroundColor Yellow
+    Write-Host ("   残り       : " + (Format-Duration -Span $remaining)) -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host ("   Status     : " + $Session.status) -ForegroundColor $statusColor
+    Write-Host ''
+    Write-Host ('  ' + '-' * 52) -ForegroundColor DarkGray
+    Write-Host ("   Last update: " + $now.ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor DarkGray
+    Write-Host '   Ctrl+C でこのタブを閉じる（セッション本体は継続）' -ForegroundColor DarkGray
+    Write-Host ''
+}
+
+# 初期ヘッダー
+Clear-Host
+Write-Host ''
+Write-Host ('  ' + '=' * 52) -ForegroundColor Cyan
+Write-Host '   Claude Session Info (SSH)' -ForegroundColor Cyan
+Write-Host "   Host : $LinuxHost" -ForegroundColor DarkCyan
+Write-Host "   ID   : $SessionId" -ForegroundColor DarkCyan
+Write-Host ('  ' + '=' * 52) -ForegroundColor Cyan
+Write-Host ''
+Write-Host '  セッション情報を取得中...' -ForegroundColor Yellow
+
+try {
+    while ($true) {
+        $session = Get-RemoteSession
+        if ($null -eq $session) {
+            Clear-Host
+            Write-Host ''
+            Write-Host "  セッション情報が見つかりません: $SessionId" -ForegroundColor Red
+            Write-Host "  Host: $LinuxHost  Dir: $SessionsDir" -ForegroundColor DarkGray
+            Start-Sleep -Seconds 3
+            continue
+        }
+
+        Show-SessionFrame -Session $session
+
+        if ($session.status -in @('completed', 'timeout', 'exited', 'cancelled', 'failed')) {
+            Write-Host ("   -> セッション終了 ({0})。{1} 秒後に閉じます..." -f $session.status, $AutoCloseAfterExitSeconds) -ForegroundColor Magenta
+            Start-Sleep -Seconds $AutoCloseAfterExitSeconds
+            exit 0
+        }
+
+        Start-Sleep -Seconds $PollIntervalSeconds
+    }
+}
+catch {
+    Write-Host ''
+    Write-Host "  Watch-SessionInfoSSH でエラー: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}

--- a/scripts/tools/Watch-SessionInfoSSH.ps1
+++ b/scripts/tools/Watch-SessionInfoSSH.ps1
@@ -21,6 +21,7 @@
 param(
     [Parameter(Mandatory)][string]$SessionId,
     [Parameter(Mandatory)][string]$LinuxHost,
+    [string]$LinuxUser = 'kensan',
     [string]$SessionsDir = '/home/kensan/.claudeos/sessions',
     [int]$PollIntervalSeconds = 1,
     [int]$AutoCloseAfterExitSeconds = 10
@@ -51,7 +52,7 @@ function Get-StatusColor {
 
 function Get-RemoteSession {
     $sessionFile = "$SessionsDir/${SessionId}.json"
-    $json = ssh "kensan@$LinuxHost" "cat '$sessionFile' 2>/dev/null" 2>$null
+    $json = ssh "${LinuxUser}@$LinuxHost" "cat '$sessionFile' 2>/dev/null" 2>$null
     if ($null -eq $json -or [string]::IsNullOrWhiteSpace($json)) { return $null }
     try { return ($json | ConvertFrom-Json) }
     catch { return $null }

--- a/scripts/tools/Watch-SessionInfoSSH.ps1
+++ b/scripts/tools/Watch-SessionInfoSSH.ps1
@@ -60,9 +60,10 @@ function Get-RemoteSession {
 function Show-SessionFrame {
     param([pscustomobject]$Session)
     Clear-Host
-    $start     = [datetime]::Parse($Session.start_time)
-    $end       = [datetime]::Parse($Session.end_time_planned)
-    $now       = Get-Date
+    # DateTimeOffset でタイムゾーン情報を保持（Linux `date -Iseconds` はタイムゾーン付きを返す）
+    $start     = [datetimeoffset]::Parse($Session.start_time)
+    $end       = [datetimeoffset]::Parse($Session.end_time_planned)
+    $now       = [datetimeoffset]::Now
     $elapsed   = $now - $start
     $remaining = $end - $now
     $duration  = [TimeSpan]::FromMinutes($Session.max_duration_minutes)


### PR DESCRIPTION
## 変更内容

### 新規スクリプト
- **`scripts/tools/Watch-ClaudeLog.ps1`**: cron ログを SSH `tail -f` でリアルタイム監視
  - `-NewTab`: Windows Terminal の新規タブで起動
  - `-WithSessionInfoTab`: セッション検出時に自動で③タブを展開
  - `Get-SessionIdForLog`: cron-STAMP.log → STAMP-PROJECT.json の自動マッチング
- **`scripts/tools/Watch-SessionInfoSSH.ps1`**: Linux 側 session.json を SSH ポーリングで表示
  - 開始時刻・終了予定・経過・残り・status をリアルタイム更新
  - セッション終了を検知すると 10 秒後に自動クローズ

### 修正スクリプト
- **`scripts/main/Start-Menu.ps1`**: 項目 14「Claude ログ監視タブを開く」を追加（`-WithSessionInfoTab` 付き）
- **`Claude/templates/linux/cron-launcher.sh`**: tmux log-tail セッション起動を追加
  - `tmux attach -t claudeos-PROJECT` でも同一ログを閲覧可
  - `CLAUDEOS_TMUX=0` で無効化可

## 利用フロー（①+③ 2タブ構成）

1. メニュー 14 を選択
2. 「Claude-Live-Log」タブ①が開き cron 発火待機
3. cron 発火 → ログ検出 → 「Session-Info」タブ③が自動展開
4. タブ①: ログ全文、タブ③: 残り時間・status をリアルタイム表示

## テスト結果
- タブ①単体: ドット表示で待機動作確認済み（前回セッション）
- `-WithSessionInfoTab` ロジック: コードレビュー済み

## 影響範囲
- `Start-Menu.ps1` 項目 14 のみ動作変更（`-WithSessionInfoTab` 追加）
- 既存スクリプトへの破壊的変更なし

## 残課題
- タブ③の実動作確認（次回 cron 発火時）
- tmux 対応の実動作確認（Linux で `CLAUDEOS_TMUX=1` デフォルト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * リモートホストのClaude実行ログをSSH経由でリアルタイム監視可能に（Watch-ClaudeLog.ps1）
  * スタートメニューに「Claude ログ監視タブを開く」を追加
  * 検出したセッションに対して専用のセッション情報ビューを別タブで表示（Watch-SessionInfoSSH.ps1 と連携）
  * 新しいログ出力を自動検出して追跡開始
  * tmuxを使ったセッション実行管理オプションを追加（デフォルト有効）。実行終了検知・クリーンアップ・終了コード伝搬に対応
  * 設定テンプレートに linuxUser フィールドを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->