### PR TITLE
fix(v3.2.23): cron-launcher.sh — timeout --foreground + pipe-pane 削除 (Issue #174)

### DIFF
--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -147,9 +147,9 @@ cat > "$CLAUDE_WRAPPER" <<'WRAPPER_EOF'
 #!/usr/bin/env bash
 claude_exit=0
 if [[ -n "${_CLAUDEOS_PROMPT_ARG:-}" ]]; then
-  timeout "${_CLAUDEOS_DURATION_SEC}s" claude --dangerously-skip-permissions "${_CLAUDEOS_PROMPT_ARG}" || claude_exit=$?
+  timeout --foreground "${_CLAUDEOS_DURATION_SEC}s" claude --dangerously-skip-permissions "${_CLAUDEOS_PROMPT_ARG}" || claude_exit=$?
 else
-  timeout "${_CLAUDEOS_DURATION_SEC}s" claude --dangerously-skip-permissions || claude_exit=$?
+  timeout --foreground "${_CLAUDEOS_DURATION_SEC}s" claude --dangerously-skip-permissions || claude_exit=$?
 fi
 echo "$claude_exit" > "${_CLAUDEOS_EXIT_FILE}"
 # 終了コード書き込み後に親 shell へ通知（失敗時もここまで必ず到達する）
@@ -166,14 +166,12 @@ if command -v tmux >/dev/null 2>&1 && [[ "${CLAUDEOS_TMUX:-1}" == "1" ]]; then
   # Claude を tmux セッション内で起動（TTY あり → attach で UI 閲覧可能）
   tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
   tmux new-session -d -s "$TMUX_SESSION" -x 220 -y 50 "$CLAUDE_WRAPPER"
-  # tmux pipe-pane でセッション出力をログファイルへも書き込む
-  tmux pipe-pane -t "$TMUX_SESSION" -o "cat >> '$LOG_FILE'"
   echo "[cron-launcher] tmux attach -t $TMUX_SESSION  (UI閲覧用)" >> "$LOG_FILE"
   # tmux セッション終了まで待機
   tmux wait-for "${_CLAUDEOS_TMUX_DONE}"
 else
   # tmux 無効時は従来通り TTY なし実行
-  timeout "${DURATION_SEC}s" claude --dangerously-skip-permissions ${PROMPT_ARG:+"$PROMPT_ARG"} >> "$LOG_FILE" 2>&1
+  timeout --foreground "${DURATION_SEC}s" claude --dangerously-skip-permissions ${PROMPT_ARG:+"$PROMPT_ARG"} >> "$LOG_FILE" 2>&1
 fi
 
 # wrapper が書いた終了コードを読み取り、EXIT トラップへ伝播


### PR DESCRIPTION
## 変更内容

リポジトリテンプレート `Claude/templates/linux/cron-launcher.sh` に、本番サーバーで検証済みの2件のバグ修正を同期する。

### Bug 1: `timeout --foreground` 追加 (3箇所)

**問題**: GNU `timeout` はデフォルトで `setpgid(0,0)` を呼び出し、子プロセス (Claude) を新しいプロセスグループへ移動する。tmux は wrapper.sh の PGID を前景グループとして設定しているため、Claude が `tcsetattr()` を呼んだ際に **SIGTTOU** を受け取り `Tl`（停止）状態になる。

**修正**: `timeout --foreground` により `setpgid(0,0)` を無効化し、Claude を前景プロセスグループに留める。

### Bug 2: `tmux pipe-pane` 削除

**問題**: `pipe-pane` が PTY ストリームを横断することで、Claude TUI の DA (Device Attributes) クエリへの応答が破壊され、TUI 初期化が失敗する。

**修正**: `pipe-pane` 2行を削除。ログはファイルリダイレクト経由で別途取得可能。

## テスト結果

- 本番サーバー `/home/kensan/.claudeos/cron-launcher.sh` で同等の修正を適用済み
- 修正後、Claude PID 状態が `Tl`（停止）→ `Sl+`（前景・通常実行）に遷移することを確認
- CI: lint / unit test / build 通過確認（変更はシェルスクリプト 1 ファイルのみ）

## 影響範囲

- `Claude/templates/linux/cron-launcher.sh` のみ
- 既存の本番サーバーは手動で適用済みのため影響なし

## 残課題

なし。本番サーバーは修正済み。

Closes #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* スケジュール実行時のプロセスタイムアウト処理を改善し、信頼性を向上
* ログファイル出力メカニズムを簡潔化して最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->