### PR TITLE
feat(v3.2.26): tests/ サブディレクトリ分類 — unit / integration / smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 # CHANGELOG
 
+## [v3.2.26] - 2026-04-18 — tests/ サブディレクトリ分類 — unit / integration / smoke
+
+### 🎯 概要
+
+17 テストファイルを `tests/unit/`・`tests/integration/`・`tests/smoke/` へ分類（外部レビュー #11 対応）。
+`$PSScriptRoot` 基準のパス参照をディレクトリ深度増加に合わせて修正。
+`tests/README.md` で分類基準を文書化。Pester 5.x の再帰検索により CI 設定変更不要。
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `tests/unit/` | Config / ErrorHandler / LauncherCommon / MessageBus / TokenBudget — 5 ファイル移動 |
+| `tests/integration/` | AgentTeams / ArchitectureCheck / ClaudeOSPlugin / Diagnostics / IssueSyncManager / McpHealthCheck / SelfEvolution / SSHHelper / StartScripts / Sync-Issues / WorktreeManager — 11 ファイル移動 |
+| `tests/smoke/` | E2E — 1 ファイル移動 |
+| `tests/README.md` | 分類基準・ファイル一覧・実行方法を文書化（新規作成） |
+| 各テストファイル | `$PSScriptRoot` → `Split-Path -Parent (Split-Path -Parent $PSScriptRoot)` に修正 |
+
+### ✅ Verify
+
+- CI: 477/477 PASS
+- STABLE N=2 達成
+
+---
+
 ## [v3.2.25] - 2026-04-18 — Loop レポート reports/ 統合 — build / improve 出力先統一
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 > **📌 v3.1.0 で Claude Code 専用ツールに整理**
 > v3.1.0 より、Codex CLI / GitHub Copilot CLI の起動メニュー (S2/S3/L2/L3) は削除されました。本ツールは **Claude Code 専用の自律開発ランチャー** として位置づけを明確化し、Linux crontab 連携・セッション情報タブ・Statusline グローバル適用などの新機能に投資が集中しています。
 
-> **🔧 v3.2.25 — Loop レポート reports/ 統合 — build / improve 出力先統一**
-> 全 4 ループ（monitor / build / verify / improve）の Output 節が `reports/.loop-*.md` に統一。外部コードレビュー #17 独立 Issue 候補を完全解消。詳細は [`CHANGELOG.md`](./CHANGELOG.md) v3.2.25 節を参照。
+> **🔧 v3.2.26 — tests/ サブディレクトリ分類 — unit / integration / smoke**
+> 17 テストファイルを `tests/unit/`・`tests/integration/`・`tests/smoke/` へ分類。`tests/README.md` で分類基準を文書化。477/477 PASS 維持。詳細は [`CHANGELOG.md`](./CHANGELOG.md) v3.2.26 節を参照。
 
 > **📨 v3.2.0 — Cron HTML メールレポート (Visual Recap Mail)**
 > Cron で起動された ClaudeCode セッションの完了時に、**HTML 形式のレポートメール** を Gmail SMTP 経由で送信。アイコン+色付き表組み+実行サマリ(Monitor/Development/Verify/Improvement の出現回数/エラー検出/STABLE 達成)+次フェーズ提案を含む。送信先は `CLAUDEOS_DEFAULT_TO`(未設定時 `CLAUDEOS_SMTP_USER`)で指定し、SMTP 認証情報は `~/.env-claudeos` の Linux 環境変数で管理(config.json には書かない設計)。詳細は [`docs/common/16_HTMLメールレポート設定.md`](./docs/common/16_HTMLメールレポート設定.md) を参照。
@@ -27,7 +27,7 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.2.25** (Loop レポート reports/ 統合) — 旧: v3.2.24 (Memory MCP 退避機能) / v3.2.23 (cron-launcher.sh SIGTTOU 停止バグ修正) |
+| バージョン | **v3.2.26** (tests/ サブディレクトリ分類) — 旧: v3.2.25 (Loop レポート reports/ 統合) / v3.2.24 (Memory MCP 退避機能) |
 | テスト | **477件** — (Pester, CI) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | v8 (Opus 4.7 最適化 / Token 1.35x 補正 / Agent Teams 並列 spawn / `/compact` 事前発動 / `task_budget` / 1H cache / `/ultrareview` / PreCompact hook / `/recap` fallback / Push Notification / Effort 動的切替) |

--- a/TASKS.md
+++ b/TASKS.md
@@ -47,6 +47,7 @@
 38. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#174] v3.2.23 cron-launcher.sh SIGTTOU 停止バグ修正 — timeout --foreground (3箇所) + tmux pipe-pane 削除 / 本番サーバー検証済み (Issue #174) (PR #175)
 39. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#176] v3.2.24 Memory MCP 退避機能 — memory-mcp-evacuation.md + pre-compact.js evacuation JSON + hooks.json PreCompact + 08_AgentTeams対応表クリーンアップ (Issue #176)
 40. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#178] v3.2.25 Loop レポート reports/ 統合 — build-loop / improve-loop Output 節を reports/.loop-*.md に統一 / テンプレ同期 / reports/README.md ✅ 更新 (Issue #178)
+41. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#180] v3.2.26 tests/ サブディレクトリ分類 — unit / integration / smoke 17 ファイル分類 / $PSScriptRoot パス修正 / tests/README.md 追加 / 477 PASS (Issue #180)
 
 ## Auto Extracted From Agent Teams Matrix
 
@@ -54,6 +55,9 @@
 ## GitHub Issues Sync
 
 (No open issues)
+
+
+
 
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,70 @@
+# tests/ — テスト分類ガイド
+
+## ディレクトリ構成
+
+```
+tests/
+├── unit/          # 単体テスト（外部依存なし）
+├── integration/   # 統合テスト（モジュール連携・git 操作含む）
+└── smoke/         # E2E スモークテスト（リポジトリ全体の構造確認）
+```
+
+## 分類基準
+
+| ディレクトリ | 対象 | 外部依存 | 実行速度 |
+|---|---|---|---|
+| `unit/` | 単一モジュールの関数ロジック | なし | 高速 |
+| `integration/` | 複数モジュール連携・git 操作・ファイルシステム | あり | 中速 |
+| `smoke/` | リポジトリ構造・必須ファイル存在確認 | git repo 全体 | 低速 |
+
+### unit/
+
+外部ファイル・git・ネットワークに依存しない純粋なロジックテスト。
+
+| ファイル | テスト対象 |
+|---|---|
+| `Config.Tests.ps1` | `Config.psm1` — 設定読み込み・検証 |
+| `ErrorHandler.Tests.ps1` | `ErrorHandler.psm1` — エラー処理ユーティリティ |
+| `LauncherCommon.Tests.ps1` | `LauncherCommon.psm1` — ランチャー共通関数 |
+| `MessageBus.Tests.ps1` | `MessageBus.psm1` — メッセージバス |
+| `TokenBudget.Tests.ps1` | `TokenBudget.psm1` — トークン予算管理 |
+
+### integration/
+
+モジュール間連携や git worktree 操作など、実際のファイルシステムを使うテスト。
+
+| ファイル | テスト対象 |
+|---|---|
+| `AgentTeams.Tests.ps1` | `AgentTeams.psm1` — エージェントチーム管理 |
+| `ArchitectureCheck.Tests.ps1` | `ArchitectureCheck.psm1` — アーキテクチャ違反検出 |
+| `ClaudeOSPlugin.Tests.ps1` | `ClaudeOSPlugin.psm1` — Claude OS プラグイン |
+| `Diagnostics.Tests.ps1` | `Diagnostics.psm1` — 診断ツール |
+| `IssueSyncManager.Tests.ps1` | `IssueSyncManager.psm1` — Issue 同期管理 |
+| `McpHealthCheck.Tests.ps1` | `McpHealthCheck.psm1` — MCP ヘルスチェック |
+| `SelfEvolution.Tests.ps1` | `SelfEvolution.psm1` — 自己進化エンジン |
+| `SSHHelper.Tests.ps1` | `SSHHelper.psm1` — SSH ヘルパー |
+| `StartScripts.Tests.ps1` | 各種起動スクリプト |
+| `Sync-Issues.Tests.ps1` | `Sync-Issues.ps1` — Issue 同期スクリプト |
+| `WorktreeManager.Tests.ps1` | `WorktreeManager.psm1` — Worktree 管理 |
+
+### smoke/
+
+リポジトリ全体が想定どおりの構造を持つことを確認する E2E テスト。
+
+| ファイル | テスト対象 |
+|---|---|
+| `E2E.Tests.ps1` | 必須ファイル・ディレクトリ構造・hooks.json・state.json.example スキーマ |
+
+## 実行方法
+
+```powershell
+# 全テスト実行
+Invoke-Pester .\tests -Output Detailed
+
+# カテゴリ別実行
+Invoke-Pester .\tests\unit        -Output Detailed
+Invoke-Pester .\tests\integration -Output Detailed
+Invoke-Pester .\tests\smoke       -Output Detailed
+```
+
+CI では `.\tests` をルートとして再帰検索するため、サブディレクトリ追加時も CI 設定変更は不要です。

--- a/tests/integration/AgentTeams.Tests.ps1
+++ b/tests/integration/AgentTeams.Tests.ps1
@@ -4,7 +4,7 @@
 # ============================================================
 
 BeforeAll {
-    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     Import-Module (Join-Path $script:RepoRoot 'scripts\lib\AgentTeams.psm1') -Force
 }
 

--- a/tests/integration/ArchitectureCheck.Tests.ps1
+++ b/tests/integration/ArchitectureCheck.Tests.ps1
@@ -3,7 +3,7 @@
 # ============================================================
 
 BeforeAll {
-    $ModulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\scripts\lib\ArchitectureCheck.psm1'
+    $ModulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\scripts\lib\ArchitectureCheck.psm1'
     Import-Module $ModulePath -Force -DisableNameChecking
 }
 
@@ -126,13 +126,13 @@ Describe 'ArchitectureCheck Module' {
 
     Describe 'Test-ModuleDependency' {
         It 'プロジェクトルートでモジュール依存関係をチェックする' {
-            $projectRoot = Split-Path $PSScriptRoot -Parent
+            $projectRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
             $results = Test-ModuleDependency -Path $projectRoot
             $results | Should -Not -BeNullOrEmpty
         }
 
         It '結果にScript, Module, Status プロパティが含まれる' {
-            $projectRoot = Split-Path $PSScriptRoot -Parent
+            $projectRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
             $results = Test-ModuleDependency -Path $projectRoot
             if ($results.Count -gt 0) {
                 $results[0].PSObject.Properties.Name | Should -Contain 'Script'

--- a/tests/integration/ClaudeOSPlugin.Tests.ps1
+++ b/tests/integration/ClaudeOSPlugin.Tests.ps1
@@ -1,5 +1,5 @@
 ﻿BeforeAll {
-    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     $script:PluginRoot = Join-Path $script:RepoRoot '.claude\claudeos'
 }
 

--- a/tests/integration/Diagnostics.Tests.ps1
+++ b/tests/integration/Diagnostics.Tests.ps1
@@ -1,5 +1,5 @@
 ﻿BeforeAll {
-    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     . (Join-Path $script:RepoRoot 'scripts\test\test-drive-mapping.ps1')
     . (Join-Path $script:RepoRoot 'scripts\test\Test-AllTools.ps1')
 Import-Module (Join-Path $script:RepoRoot 'scripts\lib\MenuCommon.psm1') -Force -DisableNameChecking

--- a/tests/integration/IssueSyncManager.Tests.ps1
+++ b/tests/integration/IssueSyncManager.Tests.ps1
@@ -5,7 +5,7 @@
 # ============================================================
 
 BeforeAll {
-    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     Import-Module (Join-Path $script:RepoRoot 'scripts\lib\IssueSyncManager.psm1') -Force
 }
 

--- a/tests/integration/McpHealthCheck.Tests.ps1
+++ b/tests/integration/McpHealthCheck.Tests.ps1
@@ -4,7 +4,7 @@
 # ============================================================
 
 BeforeAll {
-    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     Import-Module (Join-Path $script:RepoRoot 'scripts\lib\McpHealthCheck.psm1') -Force
 
     $script:OriginalMcpConfigPath = $env:AI_STARTUP_MCP_CONFIG_PATH

--- a/tests/integration/SSHHelper.Tests.ps1
+++ b/tests/integration/SSHHelper.Tests.ps1
@@ -4,7 +4,7 @@
 # ============================================================
 
 BeforeAll {
-    Import-Module "$PSScriptRoot\..\scripts\lib\SSHHelper.psm1" -Force -DisableNameChecking
+    Import-Module "$PSScriptRoot\..\..\scripts\lib\SSHHelper.psm1" -Force -DisableNameChecking
 }
 
 Describe 'ConvertTo-EscapedSSHArgument' {

--- a/tests/integration/SelfEvolution.Tests.ps1
+++ b/tests/integration/SelfEvolution.Tests.ps1
@@ -3,7 +3,7 @@
 # ============================================================
 
 BeforeAll {
-    $ModulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\scripts\lib\SelfEvolution.psm1'
+    $ModulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\scripts\lib\SelfEvolution.psm1'
     Import-Module $ModulePath -Force -DisableNameChecking
 
     $TempEvolutionDir = Join-Path $env:TEMP "evolution-test-$(Get-Random)"

--- a/tests/integration/StartScripts.Tests.ps1
+++ b/tests/integration/StartScripts.Tests.ps1
@@ -1,5 +1,5 @@
 ﻿BeforeAll {
-    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     $script:PowerShellExe = (Get-Process -Id $PID).Path
     $script:OriginalPath = $env:PATH
     $script:OriginalConfigOverride = $env:AI_STARTUP_CONFIG_PATH

--- a/tests/integration/Sync-Issues.Tests.ps1
+++ b/tests/integration/Sync-Issues.Tests.ps1
@@ -5,7 +5,7 @@
 # ============================================================
 
 BeforeAll {
-    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     Import-Module (Join-Path $script:RepoRoot 'scripts\lib\IssueSyncManager.psm1') -Force
     $script:SyncScript = Join-Path $script:RepoRoot 'scripts\tools\Sync-Issues.ps1'
 }

--- a/tests/integration/WorktreeManager.Tests.ps1
+++ b/tests/integration/WorktreeManager.Tests.ps1
@@ -5,7 +5,7 @@
 # ============================================================
 
 BeforeAll {
-    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     Import-Module (Join-Path $script:RepoRoot 'scripts\lib\WorktreeManager.psm1') -Force
 }
 

--- a/tests/smoke/E2E.Tests.ps1
+++ b/tests/smoke/E2E.Tests.ps1
@@ -12,7 +12,7 @@
 # ============================================================
 
 BeforeDiscovery {
-    $script:RepoRoot    = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot    = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     $script:ClaudeOsDir = Join-Path $script:RepoRoot '.claude\claudeos'
     $script:AgentsDir   = Join-Path $script:ClaudeOsDir 'agents'
     $script:SkillsDir   = Join-Path $script:ClaudeOsDir 'skills'
@@ -44,7 +44,7 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:RepoRoot     = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot     = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     $script:ClaudeOsDir  = Join-Path $script:RepoRoot '.claude\claudeos'
     $script:AgentsDir    = Join-Path $script:ClaudeOsDir 'agents'
     $script:SkillsDir    = Join-Path $script:ClaudeOsDir 'skills'

--- a/tests/unit/Config.Tests.ps1
+++ b/tests/unit/Config.Tests.ps1
@@ -4,7 +4,7 @@
 # ============================================================
 
 BeforeAll {
-    Import-Module "$PSScriptRoot\..\scripts\lib\Config.psm1" -Force
+    Import-Module "$PSScriptRoot\..\..\scripts\lib\Config.psm1" -Force
 }
 
 Describe 'Import-StartupConfig' {

--- a/tests/unit/ErrorHandler.Tests.ps1
+++ b/tests/unit/ErrorHandler.Tests.ps1
@@ -4,7 +4,7 @@
 # ============================================================
 
 BeforeAll {
-    Import-Module "$PSScriptRoot\..\scripts\lib\ErrorHandler.psm1" -Force
+    Import-Module "$PSScriptRoot\..\..\scripts\lib\ErrorHandler.psm1" -Force
 }
 
 Describe 'ErrorHandler モジュール読み込み' {

--- a/tests/unit/LauncherCommon.Tests.ps1
+++ b/tests/unit/LauncherCommon.Tests.ps1
@@ -4,7 +4,7 @@
 # ============================================================
 
 BeforeAll {
-    Import-Module "$PSScriptRoot\..\scripts\lib\LauncherCommon.psm1" -Force -DisableNameChecking
+    Import-Module "$PSScriptRoot\..\..\scripts\lib\LauncherCommon.psm1" -Force -DisableNameChecking
 }
 
 Describe 'Find-AvailableDriveLetter' {

--- a/tests/unit/MessageBus.Tests.ps1
+++ b/tests/unit/MessageBus.Tests.ps1
@@ -5,7 +5,7 @@
 # ============================================================
 
 BeforeAll {
-    $script:RepoRoot  = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot  = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     $script:ModulePath = Join-Path $script:RepoRoot 'scripts\lib\MessageBus.psm1'
     Import-Module $script:ModulePath -Force
 

--- a/tests/unit/TokenBudget.Tests.ps1
+++ b/tests/unit/TokenBudget.Tests.ps1
@@ -5,7 +5,7 @@
 # ============================================================
 
 BeforeAll {
-    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     Import-Module (Join-Path $script:RepoRoot 'scripts\lib\TokenBudget.psm1') -Force
 }
 


### PR DESCRIPTION
## 概要

外部コードレビュー指摘 #11「テストファイルの分類」対応。
17 テストファイルを `tests/unit/` / `tests/integration/` / `tests/smoke/` へ分類。

## 変更内容

- **tests/unit/** (5 ファイル): Config / ErrorHandler / LauncherCommon / MessageBus / TokenBudget
- **tests/integration/** (11 ファイル): AgentTeams / ArchitectureCheck / ClaudeOSPlugin / Diagnostics / IssueSyncManager / McpHealthCheck / SelfEvolution / SSHHelper / StartScripts / Sync-Issues / WorktreeManager
- **tests/smoke/** (1 ファイル): E2E
- **tests/README.md** 新規作成 — 分類基準・ファイル一覧・実行方法を文書化
- `$PSScriptRoot` ベースのパス参照をディレクトリ深度増加に合わせて修正

## テスト結果

- Pester 5.x: **477/477 PASS**
- CI 設定変更なし（`$cfg.Run.Path = '.\tests'` が再帰検索するため）

## 影響範囲

テストファイルの移動のみ。プロダクションコード変更なし。

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * テスト分類ガイドを含む新しいドキュメント (`tests/README.md`) を追加しました。ユニットテスト、統合テスト、スモークテストの実行方法とクライテリアが記載されています。

* **Tests**
  * テストスイートを `unit/`、`integration/`、`smoke/` のサブディレクトリに再編成しました（17ファイル）。すべてのテスト（477件）が成功しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->