### PR TITLE
fix(v3.2.34): .sh CRLF→LF + .gitattributes — bash\r shebang 破壊防止

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Default: auto CRLF for Windows text files
+* text=auto
+
+# Shell scripts must always use LF (Linux/macOS execution)
+*.sh text eol=lf
+*.bash text eol=lf
+
+# Other Unix-only files
+Makefile text eol=lf
+*.mk text eol=lf


### PR DESCRIPTION
## 変更内容

- `.gitattributes` 新規追加 — `*.sh text eol=lf` でシェルスクリプトを LF 強制
- `Claude/templates/linux/cron-launcher.sh` — CRLF → LF 変換 (BOM なし UTF-8)
- `.claude/claudeos/scripts/project-sync.sh` — CRLF → LF 変換 (BOM なし UTF-8)

## 問題の原因

2026-04-18 12:00 cron 実行時に以下エラーが発生:
```
/usr/bin/env: 'bash\r': No such file or directory
```
Windows checkout 時に `text=auto` が shebang 行を CRLF 変換。サーバー上の `.sh` ファイルに `\r` が混入していた。

## 即時サーバー修正（PR merge 待たずに実行）

```bash
sed -i 's/\r//' ~/.claudeos/scripts/cron-launcher.sh
```

## テスト結果

- git object store は元から LF 保存済み
- `.gitattributes` 追加後、Windows checkout でも LF を維持

## 影響範囲

- シェルスクリプト実行環境 (Linux サーバー) — 改善
- PowerShell スクリプト — 影響なし

## 残課題

なし