### PR TITLE
fix(v3.2.39): Session Info タブ 3 点修正 (残り時間 / 凍結耐性 / UI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 # CHANGELOG
 
+## [v3.2.39] - 2026-04-19 — Session Info タブ 3 点修正 (残り時間表示 / 凍結耐性 / UI 補足)
+
+### 🎯 概要
+
+cron 監視タブ群で表面化していた 3 種類の UX 問題を同時修正。
+
+1. **残り時間表示の +1h ズレ**（ロジックバグ）: `Format-Duration` の `[int]$Span.TotalHours` が .NET の銀行丸め（`MidpointRounding.ToEven`）により時間成分を繰り上げ、「経過 00:04:06 + 残り 05:55:53 = 6h」のように合計が `作業時間`（5h）と一致しない現象。`[int][Math]::Floor($Span.TotalHours)` で明示的切り捨てに変更。v3.2.38 の TZ 修正でも残存していた独立バグ。
+2. **クリック凍結**（UX 問題）: Windows conhost の QuickEdit モードがタブ内の範囲選択で stdout をブロックし、監視タブが固まったように見える現象。`kernel32!SetConsoleMode` を P/Invoke 経由で呼び `ENABLE_QUICK_EDIT_MODE (0x40)` をクリア、`ENABLE_EXTENDED_FLAGS (0x80)` を付与。Windows Terminal の独自選択機構は conhost フラグ非依存なのでコピペ操作は従来通り動作する。
+3. **復旧操作の可視化**（UI 補足）: `Ctrl+C でこのタブを閉じる` 行の下に `Enterキーで更新可能` と **動的生成した再起動コマンド** を常時表示。`$PSCommandPath` + 実行時パラメータから自動生成するため、別セッション / 別プロジェクトでも常に正しい再起動コマンドが出る。凍結時のフォールバック手段を画面内に常設することで「ドキュメントを探し回らない運用 UI」を実現。
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/tools/Watch-SessionInfoSSH.ps1` | `Format-Duration` / `作業時間` 行: `[int]` → `[int][Math]::Floor` / QuickEdit 無効化 P/Invoke / `Enterキーで更新可能` + 再起動コマンド表示 |
+| `scripts/tools/Watch-SessionInfo.ps1` | 同上（非 SSH 版） |
+| `scripts/tools/Watch-ClaudeLog.ps1` | QuickEdit 無効化 P/Invoke 追加 |
+| `README.md` | バージョン v3.2.37 → v3.2.39、主要箇所のテスト件数 650 → 680 件に更新 |
+| `CHANGELOG.md` | v3.2.39 エントリ追加 |
+| `TASKS.md` | エントリ 54 (v3.2.39) 追加 |
+
+### ✅ テスト結果
+
+- 680/680 PASS (Pester, 139s)
+- PSScriptAnalyzer 警告 0 件（空 catch は `$null = $_` で明示的無視を表現）
+
+### 📝 補足: v3.2.38 の CHANGELOG ギャップ
+
+本エントリ作成時、v3.2.38 の CHANGELOG エントリが欠落していることを検出（TASKS.md エントリ 53 は存在）。スコープ外のため本 commit では backfill せず、別途 docs(changelog): v3.2.38 backfill として対応候補とする。
+
+---
+
 ## [v3.2.37] - 2026-04-18 — scripts/lib 全ファイル UTF-8 BOM 追加 (PSScriptAnalyzer 警告ゼロ回復)
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 > **📌 v3.1.0 で Claude Code 専用ツールに整理**
 > v3.1.0 より、Codex CLI / GitHub Copilot CLI の起動メニュー (S2/S3/L2/L3) は削除されました。本ツールは **Claude Code 専用の自律開発ランチャー** として位置づけを明確化し、Linux crontab 連携・セッション情報タブ・Statusline グローバル適用などの新機能に投資が集中しています。
 
-> **🔧 v3.2.37 — scripts/lib 全ファイル UTF-8 BOM 追加 (PSScriptAnalyzer 警告 0 件回復)**
-> AgentTeams 分割 (v3.2.35) で生成した 3 ファイルを含む `scripts/lib/` 11 ファイルに BOM を追加し `PSUseBOMForUnicodeEncodedFile` 警告 11 件を解消。v3.2.36: Watch-SessionInfoSSH の残り時間 TZ ズレ修正。詳細は [`CHANGELOG.md`](./CHANGELOG.md) を参照。
+> **🔧 v3.2.39 — Session Info タブ 3 点修正 (残り時間表示 / 凍結耐性 / UI 補足)**
+> `[int]$Span.TotalHours` の .NET 銀行丸めで残り時間が +1h 繰り上がる表示バグを `[Math]::Floor` で修正。Windows conhost QuickEdit モードをタブ起動時に P/Invoke で無効化しクリック凍結を防止。画面下部に `Enterキーで更新可能` + 動的生成した再起動コマンドを常時表示。v3.2.38: SessionLogger / TemplateSyncManager ユニットテスト 30 件追加（Pester 680 件）。詳細は [`CHANGELOG.md`](./CHANGELOG.md) を参照。
 
 > **📨 v3.2.0 — Cron HTML メールレポート (Visual Recap Mail)**
 > Cron で起動された ClaudeCode セッションの完了時に、**HTML 形式のレポートメール** を Gmail SMTP 経由で送信。アイコン+色付き表組み+実行サマリ(Monitor/Development/Verify/Improvement の出現回数/エラー検出/STABLE 達成)+次フェーズ提案を含む。送信先は `CLAUDEOS_DEFAULT_TO`(未設定時 `CLAUDEOS_SMTP_USER`)で指定し、SMTP 認証情報は `~/.env-claudeos` の Linux 環境変数で管理(config.json には書かない設計)。詳細は [`docs/common/16_HTMLメールレポート設定.md`](./docs/common/16_HTMLメールレポート設定.md) を参照。
@@ -27,8 +27,8 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.2.37** (scripts/lib BOM 追加・警告ゼロ) — 旧: v3.2.36 (Watch-SessionInfoSSH TZ 修正) / v3.2.35 (AgentTeams 分割) |
-| テスト | **650件** — Pester (Unit 17 / Integration 11 / Smoke 1) |
+| バージョン | **v3.2.39** (Session Info タブ 3 点修正: 残り時間 / 凍結耐性 / UI 補足) — 旧: v3.2.38 (Pester 680 件) / v3.2.37 (scripts/lib BOM) |
+| テスト | **680件** — Pester (Unit 17 / Integration 11 / Smoke 1) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | v8 (Opus 4.7 最適化 / Token 1.35x 補正 / Agent Teams 並列 spawn / `/compact` 事前発動 / `task_budget` / 1H cache / `/ultrareview` / PreCompact hook / `/recap` fallback / Push Notification / Effort 動的切替) |
 | Agents | **25体** の特化サブエージェント (2026Q2 棚卸し後、追加復元済み) |
@@ -93,7 +93,7 @@
 | 動詞 | コマンド | 目的 |
 |---|---|---|
 | **lint** | `Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error` | PSScriptAnalyzer による静的解析（Error 粒度で CI ゲート、Warning は非ブロッキング） |
-| **test** | `Invoke-Pester .\tests -CI` | Pester 全テスト（現在 650 件 / Unit + E2E）。`-CI` で `testResults.xml` 生成 |
+| **test** | `Invoke-Pester .\tests -CI` | Pester 全テスト（現在 680 件 / Unit + Integration + Smoke）。`-CI` で `testResults.xml` 生成 |
 | **build** | `.\scripts\main\Start-ClaudeOS.ps1 -DryRun` | ブートシーケンス検証（Step 1 〜 9 を実行せず設定のみ確認） |
 | **security** | `.\scripts\test\Test-McpHealth.ps1` + `gitleaks detect --source .`（CI と同等目的） | MCP サーバーヘルス + secret 漏洩スキャン（CI では [`security-scan.yml`](./.github/workflows/security-scan.yml) が gitleaks 実行） |
 
@@ -230,7 +230,7 @@ flowchart TD
 | 🐍 PTY Bridge | 🔧 共通 | SSH経由の Claude Code 操作を堅牢にサポート |
 | ⚙️ 一元設定 | 🔧 共通 | `config/config.json` で対応ツールを一元管理 |
 | 🩺 診断ツール | 🔧 共通 | `Test-AllTools.ps1` で環境を一括チェック |
-| ⚡ CI/CD | 🔧 共通 | GitHub Actions による自動テスト (Pester 650件 — 17 test files) |
+| ⚡ CI/CD | 🔧 共通 | GitHub Actions による自動テスト (Pester 680件 — 29 test files) |
 | 🧠 ClaudeOS カーネル | ⭐ Claude 専用 | 25体のエージェント + 4フック + 34コマンド |
 | 🔌 MCP ヘルスチェック | ⭐ Claude 専用 | `McpHealthCheck.psm1` で4サーバーの起動・接続・状態診断 |
 | 🤖 Agent Teams ランタイム | ⭐ Claude 専用 | `AgentTeams.psm1` でタスク分析→Team自動構成→能力マトリクス→可視化 |
@@ -505,7 +505,7 @@ scripts/helpers/     PTY bridge 等のヘルパー
 scripts/templates/   各ツール向けテンプレート
 scripts/test/        診断スクリプト
 scripts/tools/       TASKS同期・バックログ管理
-tests/               Pester テスト (17 files / 650件)
+tests/               Pester テスト (29 files / 680件 — Unit 17 / Integration 11 / Smoke 1)
 Claude/              ClaudeOS 互換ポリシー群
 Codex/               Codex AGENTS.md
 .claude/claudeos/    ClaudeOS カーネル（198ファイル、配備先 — 編集元は Claude/templates/claudeos/）

--- a/TASKS.md
+++ b/TASKS.md
@@ -60,6 +60,7 @@
 51. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.36 Watch-SessionInfoSSH TZ オフセット不整合修正 — end_time_planned の TZ ズレで残り時間が 1 時間超過する問題を start_time + max_duration_minutes 計算に切替 / ToLocalTime() 表示統一 / ドリフト警告追加 / 650 PASS (commit d09fad7)
 52. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.37 scripts/lib 全ファイル UTF-8 BOM 追加 — AgentTeams 分割 3 ファイルを含む 11 ファイルに BOM 欠落 / PSScriptAnalyzer 警告 0 件回復 / 650 PASS / STABLE N=2 達成 (commit b5cc9c8)
 53. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.38 SessionLogger / TemplateSyncManager ユニットテスト追加 (SessionLogger 14件 / TemplateSyncManager 16件 / 計 30件 / 680 PASS) + Watch-SessionInfo.ps1 TZ フィックス (end_time_planned → start_time + max_duration_minutes 方式) / STABLE N=2 達成 (commit ebe2045)
+54. [DONE] [Priority:P1][Owner:Developer][Source:Manual] v3.2.39 Session Info タブ 3 点修正 — Format-Duration の [int]$Span.TotalHours 銀行丸めで残り時間が +1h ズレる表示バグを [int][Math]::Floor に変更 / Watch-SessionInfo.ps1 / Watch-SessionInfoSSH.ps1 / Watch-ClaudeLog.ps1 に QuickEdit 無効化 P/Invoke 追加（クリック凍結防止）/ Session Info タブに `Enterキーで更新可能` + 動的生成再起動コマンド常時表示 / README v3.2.37 → v3.2.39、テスト件数 650 → 680 に揃える / 680 PASS / PSScriptAnalyzer 0 件
 
 ## Auto Extracted From Agent Teams Matrix
 
@@ -67,6 +68,9 @@
 ## GitHub Issues Sync
 
 (No open issues)
+
+
+
 
 
 

--- a/scripts/tools/Watch-ClaudeLog.ps1
+++ b/scripts/tools/Watch-ClaudeLog.ps1
@@ -24,6 +24,35 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Disable conhost QuickEdit: accidental click-select otherwise blocks stdout
+# until Enter/Esc, freezing this monitoring tab. Windows Terminal selection is
+# independent of this flag so copy/paste still works in WT.
+if (-not ('ClaudeConsoleMode' -as [type])) {
+    try {
+        Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class ClaudeConsoleMode {
+    [DllImport("kernel32.dll", SetLastError=true)]
+    private static extern IntPtr GetStdHandle(int n);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    private static extern bool GetConsoleMode(IntPtr h, out uint m);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    private static extern bool SetConsoleMode(IntPtr h, uint m);
+    public static void DisableQuickEdit() {
+        IntPtr h = GetStdHandle(-10);
+        uint m;
+        if (!GetConsoleMode(h, out m)) { return; }
+        // ENABLE_EXTENDED_FLAGS(0x80) must be set for the change to stick.
+        m = (m | 0x80u) & ~0x40u;
+        SetConsoleMode(h, m);
+    }
+}
+'@ -ErrorAction SilentlyContinue
+    } catch { $null = $_ }
+}
+try { [ClaudeConsoleMode]::DisableQuickEdit() } catch { $null = $_ }
+
 $ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\LauncherCommon.psm1') -Force -DisableNameChecking
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\Config.psm1') -Force -DisableNameChecking

--- a/scripts/tools/Watch-SessionInfo.ps1
+++ b/scripts/tools/Watch-SessionInfo.ps1
@@ -18,13 +18,43 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Disable conhost QuickEdit: accidental click-select otherwise blocks stdout
+# until Enter/Esc, freezing this monitoring tab. Windows Terminal selection is
+# independent of this flag so copy/paste still works in WT.
+if (-not ('ClaudeConsoleMode' -as [type])) {
+    try {
+        Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class ClaudeConsoleMode {
+    [DllImport("kernel32.dll", SetLastError=true)]
+    private static extern IntPtr GetStdHandle(int n);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    private static extern bool GetConsoleMode(IntPtr h, out uint m);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    private static extern bool SetConsoleMode(IntPtr h, uint m);
+    public static void DisableQuickEdit() {
+        IntPtr h = GetStdHandle(-10);
+        uint m;
+        if (!GetConsoleMode(h, out m)) { return; }
+        // ENABLE_EXTENDED_FLAGS(0x80) must be set for the change to stick.
+        m = (m | 0x80u) & ~0x40u;
+        SetConsoleMode(h, m);
+    }
+}
+'@ -ErrorAction SilentlyContinue
+    } catch { $null = $_ }
+}
+try { [ClaudeConsoleMode]::DisableQuickEdit() } catch { $null = $_ }
+
 $ScriptRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 Import-Module (Join-Path $ScriptRoot 'scripts\lib\SessionTabManager.psm1') -Force -DisableNameChecking
 
 function Format-Duration {
     param([TimeSpan]$Span)
     if ($Span.TotalSeconds -lt 0) { return '00:00:00' }
-    return "{0:00}:{1:00}:{2:00}" -f [int]$Span.TotalHours, $Span.Minutes, $Span.Seconds
+    # [int] は銀行丸めで繰上げてしまうため Math.Floor で切り捨てる
+    return "{0:00}:{1:00}:{2:00}" -f [int][Math]::Floor($Span.TotalHours), $Span.Minutes, $Span.Seconds
 }
 
 function Get-StatusColor {
@@ -66,7 +96,7 @@ function Show-SessionFrame {
     Write-Host ""
     Write-Host ("   開始時刻   : " + $start.ToLocalTime().ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor White
     Write-Host ("   終了予定   : " + $endComputed.ToLocalTime().ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor White
-    Write-Host ("   作業時間   : " + ("{0}h {1:00}m ({2} 分)" -f [int]$duration.TotalHours, $duration.Minutes, $Session.max_duration_minutes)) -ForegroundColor White
+    Write-Host ("   作業時間   : " + ("{0}h {1:00}m ({2} 分)" -f [int][Math]::Floor($duration.TotalHours), $duration.Minutes, $Session.max_duration_minutes)) -ForegroundColor White
     Write-Host ""
     Write-Host ("   経過       : " + (Format-Duration -Span $elapsed)) -ForegroundColor Yellow
     Write-Host ("   残り       : " + (Format-Duration -Span $remaining)) -ForegroundColor Yellow
@@ -76,6 +106,11 @@ function Show-SessionFrame {
     Write-Host ("  " + "-" * 52) -ForegroundColor DarkGray
     Write-Host ("   Last update: " + $now.ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor DarkGray
     Write-Host ("   Ctrl+C でこのタブを閉じる（セッション本体は継続）") -ForegroundColor DarkGray
+    Write-Host ("   Enterキーで更新可能") -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host ("   再起動コマンド（コピペ可）:") -ForegroundColor DarkGray
+    $restartCmd = '& "{0}" -SessionId "{1}"' -f $PSCommandPath, $SessionId
+    Write-Host ("   " + $restartCmd) -ForegroundColor Gray
     Write-Host ""
 }
 

--- a/scripts/tools/Watch-SessionInfoSSH.ps1
+++ b/scripts/tools/Watch-SessionInfoSSH.ps1
@@ -31,10 +31,40 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Disable conhost QuickEdit: accidental click-select otherwise blocks stdout
+# until Enter/Esc, freezing this monitoring tab. Windows Terminal selection is
+# independent of this flag so copy/paste still works in WT.
+if (-not ('ClaudeConsoleMode' -as [type])) {
+    try {
+        Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class ClaudeConsoleMode {
+    [DllImport("kernel32.dll", SetLastError=true)]
+    private static extern IntPtr GetStdHandle(int n);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    private static extern bool GetConsoleMode(IntPtr h, out uint m);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    private static extern bool SetConsoleMode(IntPtr h, uint m);
+    public static void DisableQuickEdit() {
+        IntPtr h = GetStdHandle(-10);
+        uint m;
+        if (!GetConsoleMode(h, out m)) { return; }
+        // ENABLE_EXTENDED_FLAGS(0x80) must be set for the change to stick.
+        m = (m | 0x80u) & ~0x40u;
+        SetConsoleMode(h, m);
+    }
+}
+'@ -ErrorAction SilentlyContinue
+    } catch { $null = $_ }
+}
+try { [ClaudeConsoleMode]::DisableQuickEdit() } catch { $null = $_ }
+
 function Format-Duration {
     param([TimeSpan]$Span)
     if ($Span.TotalSeconds -lt 0) { return '00:00:00' }
-    return "{0:00}:{1:00}:{2:00}" -f [int]$Span.TotalHours, $Span.Minutes, $Span.Seconds
+    # [int] は銀行丸めで繰上げてしまうため Math.Floor で切り捨てる
+    return "{0:00}:{1:00}:{2:00}" -f [int][Math]::Floor($Span.TotalHours), $Span.Minutes, $Span.Seconds
 }
 
 function Get-StatusColor {
@@ -128,7 +158,7 @@ function Show-SessionFrame {
     Write-Host ''
     Write-Host ("   開始時刻   : " + $start.ToLocalTime().ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor White
     Write-Host ("   終了予定   : " + $endComputed.ToLocalTime().ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor White
-    Write-Host ("   作業時間   : " + ("{0}h {1:00}m" -f [int]$duration.TotalHours, $duration.Minutes)) -ForegroundColor White
+    Write-Host ("   作業時間   : " + ("{0}h {1:00}m" -f [int][Math]::Floor($duration.TotalHours), $duration.Minutes)) -ForegroundColor White
     if ($showDriftWarn) {
         Write-Host ("   ⚠ end_time_planned ズレ検出: JSON=$($endRaw.ToString('HH:mm:sszzz')) / 計算値=$($endComputed.ToString('HH:mm:sszzz')) / 差={0:F0}分" -f $drift) -ForegroundColor Red
     }
@@ -148,6 +178,11 @@ function Show-SessionFrame {
     }
     Write-Host ("   Now: " + $now.ToString('yyyy-MM-dd HH:mm:ss')) -ForegroundColor DarkGray
     Write-Host '   Ctrl+C でこのタブを閉じる（セッション本体は継続）' -ForegroundColor DarkGray
+    Write-Host '   Enterキーで更新可能' -ForegroundColor DarkGray
+    Write-Host ''
+    Write-Host '   再起動コマンド（コピペ可）:' -ForegroundColor DarkGray
+    $restartCmd = '& "{0}" -SessionId "{1}" -LinuxHost "{2}"' -f $PSCommandPath, $SessionId, $LinuxHost
+    Write-Host ("   " + $restartCmd) -ForegroundColor Gray
     Write-Host ''
 }
 


### PR DESCRIPTION
## 変更内容

cron 監視タブ群に残存していた UX 問題 3 種を同時修正。

### 1. 残り時間表示の +1h ズレ (ロジックバグ)
- `Format-Duration` の `[int]\$Span.TotalHours` が .NET 銀行丸め (`MidpointRounding.ToEven`) で時間成分を繰り上げ、「経過 00:04:06 + 残り 05:55:53 = 6h」のように合計が作業時間 (5h) と一致しない現象。
- `[int][Math]::Floor(\$Span.TotalHours)` で明示的切り捨てに変更。
- v3.2.38 の TZ 修正後も残存していた独立バグ。

### 2. クリック凍結 (UX 問題)
- Windows conhost の QuickEdit モードがタブ内の範囲選択で stdout をブロックし、監視タブが固まったように見える現象。
- `kernel32!SetConsoleMode` を P/Invoke 経由で呼び `ENABLE_QUICK_EDIT_MODE (0x40)` をクリア、`ENABLE_EXTENDED_FLAGS (0x80)` を付与。
- Windows Terminal の独自選択機構は conhost フラグ非依存なのでコピペ操作は従来通り動作。
- `Watch-SessionInfo.ps1` / `Watch-SessionInfoSSH.ps1` / `Watch-ClaudeLog.ps1` の 3 本に同一対処。

### 3. 復旧操作の可視化 (UI 補足)
- `Ctrl+C でこのタブを閉じる` 行の下に `Enterキーで更新可能` と動的生成した再起動コマンドを常時表示。
- `\$PSCommandPath` + 実行時パラメータから自動生成するため、別セッション / 別プロジェクトでも常に正しい再起動コマンドが出る。

## テスト結果

- Pester: **680 PASS / 0 FAIL** (139s、v3.2.38 ベースライン維持)
- PSScriptAnalyzer: **0 件** (空 catch は `\$null = \$_` で明示的無視を表現)

## 影響範囲

- 対象: cron 監視タブ 3 本の表示ロジックと初期化処理のみ
- 後方互換: 既存の session.json / ログフォーマット / SSH 通信プロトコルに変更なし
- 挙動変更: 既に起動中のタブには反映されない → Ctrl+C → 再起動で新コード読込

## 残課題

- **STABLE N=2 2 回目 verify**: 本 PR merge 後に再 Pester で N=2 判定予定
- **v3.2.38 CHANGELOG backfill**: 本 PR レビュー中に発覚したギャップ (TASKS.md エントリ 53 は存在、CHANGELOG.md に欠落)。本 PR ではスコープ外として別 commit 候補とする
- **README L539 の `433件` 記述**: Phase 3 時代の obsolete 数値、別途 docs 整理で対応

## Test plan

- [x] Pester 全件 (680/680 PASS, 139s)
- [x] PSScriptAnalyzer 警告 0 件
- [x] 実機確認: 残り時間表示が `経過 + 残り = 作業時間` で一致
- [x] 実機確認: 再起動コマンドが画面に表示される
- [ ] CI 通過確認 (本 PR で自動実行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v3.2.39

* **Bug Fixes**
  * セッション情報タブの残り時間表示を修正
  * Windows コンソールの QuickEdit による凍結を防止

* **New Features**
  * セッション情報表示に「Enter キーで更新可能」ヒントを追加
  * 再起動コマンドをセッション情報に常時表示

* **Tests**
  * テスト件数を 650 件から 680 件に拡大

<!-- end of auto-generated comment: release notes by coderabbit.ai -->