### PR TITLE
fix(v3.2.40): cron-launcher PATH 注入 + SAFE_PROJECT 末尾アンダースコア解消

### DIFF
--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -37,13 +37,16 @@ chmod 700 "$CLAUDEOS_HOME" "$SESSIONS_DIR" "$LOGS_DIR" 2>/dev/null || true
 # Load optional env overrides (SMTP credentials, EMAIL_ENABLED, etc.)
 [[ -f "$HOME/.env-claudeos" ]] && source "$HOME/.env-claudeos"
 
+# cron の最小 PATH には claude (~/.local/bin) などが含まれないため明示的に注入
+export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$HOME/.bun/bin:$PATH"
+
 if [[ ! -d "$PROJECT_DIR" ]]; then
   echo "[ERROR] プロジェクトディレクトリが存在しません: $PROJECT_DIR" >&2
   exit 3
 fi
 
 DURATION_SEC=$((DURATION_MIN * 60))
-SAFE_PROJECT=$(echo "$PROJECT" | tr -c 'A-Za-z0-9_-' '_')
+SAFE_PROJECT=$(printf '%s' "$PROJECT" | tr -c 'A-Za-z0-9_-' '_')
 STAMP=$(date +'%Y%m%d-%H%M%S')
 SESSION_ID="${STAMP}-${SAFE_PROJECT}"
 SESSION_FILE="$SESSIONS_DIR/${SESSION_ID}.json"


### PR DESCRIPTION
## Summary

Linux 側 cron から ClaudeCode を自動起動する `cron-launcher.sh` の 2 つの致命バグを修正。
auto cron 発火が「見かけ上発火しない」症状 (実際は launcher が exit=127 で即死) を解消。

## 真因

### 1. exit=127 (command not found) — PATH 問題

cron の最小 PATH (`/usr/bin:/bin`) には `claude` (`~/.local/bin/claude`) が含まれず、
tmux 内の wrapper で `claude --dangerously-skip-permissions` が command not found に
なっていた。`~/.env-claudeos` は SMTP 設定のみで PATH を export していない。

### 2. SAFE_PROJECT 末尾 `_` バグ

`echo "$PROJECT" | tr -c 'A-Za-z0-9_-' '_'` は `echo` が付加する末尾改行を
`_` に変換するため、session_id / tmux セッション名の末尾に不要な `_` が付与されていた
(例: `claudeos-ITSM-System_`)。Watch-ClaudeLog.ps1 の `parts[2]` (SAFE_PROJECT) との
不整合で Claude UI タブ attach 失敗の一因にもなっていた。

## 修正

```diff
 # Load optional env overrides (SMTP credentials, EMAIL_ENABLED, etc.)
 [[ -f "$HOME/.env-claudeos" ]] && source "$HOME/.env-claudeos"

+# cron の最小 PATH には claude (~/.local/bin) などが含まれないため明示的に注入
+export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$HOME/.bun/bin:$PATH"
+

-SAFE_PROJECT=$(echo "$PROJECT" | tr -c 'A-Za-z0-9_-' '_')
+SAFE_PROJECT=$(printf '%s' "$PROJECT" | tr -c 'A-Za-z0-9_-' '_')
```

## 影響範囲

- `Claude/templates/linux/cron-launcher.sh` のみ変更
- Linux 側の `/home/kensan/.claudeos/cron-launcher.sh` は既に手動デプロイ済み
- 既存の週次 6 件の cron エントリはそのまま利用可能

## Test plan

- [x] PATH 解決検証: `env -i HOME=~ PATH=/usr/bin:/bin bash -c '...export PATH...; command -v claude'` で `/home/kensan/.local/bin/claude` 解決確認
- [x] SAFE_PROJECT: `printf '%s' "ITSM-System" | tr ...` で末尾 `_` が付かないことを確認
- [x] **E2E 検証 (2026-04-20 08:55)**: Backup-management-system duration=1m で cron 発火 → launcher → tmux → claude → timeout → finalize → mail の全パイプラインが `status=timeout exit=124` で完走
- [x] tmux セッション名に `_` が付かないことを本番ログで確認 (`claudeos-Backup-management-system`)
- [x] report-and-mail の送信完了確認

## 残課題 (別 PR で対応予定)

Watch-ClaudeLog.ps1 が `tail -F` の永続ブロックにより初回検出セッション後の cron 発火を
拾えない単発検出限界。次の PR で Start-Job + ポーリングによるマルチ発火対応に改修予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * cronタスク環境における変数処理の信頼性を向上させました。
  * cronスクリプト実行時の環境パス設定を改善し、追加のツールおよびパッケージマネージャーへのアクセスを確保しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->