### PR TITLE
fix(v3.2.41): Watch-ClaudeLog.ps1 マルチ発火対応 — tail -F を Start-Job 化

### DIFF
--- a/scripts/tools/Watch-ClaudeLog.ps1
+++ b/scripts/tools/Watch-ClaudeLog.ps1
@@ -5,7 +5,9 @@
     Linux 側の cron-launcher.sh が出力するログファイルを自動検出し
     Windows Terminal の新規タブで tail -f を開始する。
     cron 実行前に起動しておくと、発火を検知して自動でログ表示を開始する。
-    ClaudeOS v3.2.31
+    v3.2.41 から tail -F をバックグラウンド Job 化し、ライブ表示中にも
+    次の cron 発火を検出 → 自動で次セッションへ切り替える (マルチ発火対応)。
+    ClaudeOS v3.2.41
 .PARAMETER NewTab
     Windows Terminal の新規タブで開く（既定: 現在のウィンドウで実行）。
 .PARAMETER PollIntervalSeconds
@@ -243,15 +245,50 @@ while ($true) {
         }
 
         Write-Host ''
-        # tail -F でリアルタイム表示 — -F はログローテーション (inode 変化) に追従
-        ssh $SshTarget "tail -n 50 -F '$latest'"
-        $sshExitCode = $LASTEXITCODE
-        Write-Host ''
-        if ($sshExitCode -ne 0) {
-            Write-Host "  [WARN] SSH が終了コード $sshExitCode で切断されました。次のポーリングへ戻ります..." -ForegroundColor Yellow
-        } else {
-            Write-Host '  セッション終了を検知しました。次の cron 発火を待機します...' -ForegroundColor Yellow
+        # tail -F をバックグラウンド Job で起動し、メインスレッドで次ログ出現を監視する。
+        # これにより tail -F が永続ブロックしても次の cron 発火を取りこぼさない (v3.2.41)。
+        # stdbuf -oL で tail の line-buffering を強制し、リアルタイム出力を担保する。
+        $tailJob = Start-Job -ArgumentList $SshTarget, $latest -ScriptBlock {
+            param($target, $path)
+            ssh $target "stdbuf -oL tail -n 50 -F '$path'"
         }
+
+        try {
+            while ($true) {
+                # tail の出力を受信してコンソール表示 (非ブロッキング)
+                Receive-Job $tailJob -ErrorAction SilentlyContinue | ForEach-Object {
+                    Write-Host $_
+                }
+
+                # tail Job が落ちた (SSH 切断等) なら抜ける
+                if ($tailJob.State -ne 'Running') { break }
+
+                Start-Sleep -Seconds $PollIntervalSeconds
+
+                # より新しいログが出現したら切り替え
+                $newer = Get-LatestLog
+                if ($newer -and $newer -ne $latest) {
+                    # 残出力を flush
+                    Receive-Job $tailJob -ErrorAction SilentlyContinue | ForEach-Object {
+                        Write-Host $_
+                    }
+                    Write-Host ''
+                    Write-Host "  より新しいセッション検出: $newer" -ForegroundColor Yellow
+                    Write-Host '  次のセッションへ切り替えます...' -ForegroundColor Yellow
+                    break
+                }
+            }
+        }
+        finally {
+            Stop-Job $tailJob -ErrorAction SilentlyContinue
+            Receive-Job $tailJob -ErrorAction SilentlyContinue | ForEach-Object {
+                Write-Host $_
+            }
+            Remove-Job $tailJob -Force -ErrorAction SilentlyContinue
+        }
+
+        Write-Host ''
+        Write-Host '  現セッションの監視を終了しました。次の cron 発火を待機します...' -ForegroundColor Yellow
         Write-Host ''
         $knownLog = $latest
         $dotCount = 0


### PR DESCRIPTION
## Summary

Watch-ClaudeLog.ps1 が 1 度 log を検出すると `tail -F` 永続ブロックで次の cron 発火を拾えない
単発検出バグを修正。Start-Job によるバックグラウンド tail + メインスレッドでの新ログ定期
ポーリングにより、週頭にタブを 1 度起動すれば週全日の cron 発火を連続追跡できる。

## 問題

```powershell
# 旧実装 (blocking):
ssh $SshTarget "tail -n 50 -F '$latest'"
```

- `tail -F` は対象ログが消えるまで exit しない
- cron-*.log は自然に消えない → 永久にブロック
- 結果: 週の始めに Watch タブを開くと**初回 cron 発火しか検出できない**

v3.2.40 の launcher PATH / SAFE_PROJECT 修正 (#196) と併せて、本 PR が本来期待される
「Watch タブを一度開けば全 cron 自動発火を追いかけられる」挙動を完成させる。

## 修正

tail -F を Start-Job でバックグラウンド化し、メインスレッドで:

1. `Receive-Job` で tail 出力をコンソールへストリーム
2. `Get-LatestLog` で新 cron-*.log 出現を定期ポーリング
3. 新ログ検出時に `Stop-Job` で tail を停止 → 次セッションへ切り替え
4. `finally` で Job を確実にクリーンアップ (残出力 flush 込み)

`stdbuf -oL tail` で line-buffering を強制し、ssh 経由でもリアルタイム出力を担保。

## 挙動変更

| シナリオ | 旧 | 新 |
|---|---|---|
| 週頭に Watch タブ起動 → 週次 5 日間の cron 自動発火 | 初日のみ検出 | **全日検出** |
| セッション間の 3 タブ (Live-Log / Claude-UI / Session-Info) 連鎖 open | 初回のみ | **毎回再 open** |
| tail 表示の real-time 性 | OK | OK (stdbuf -oL で担保) |

## Test plan

- [x] PowerShell Parser で syntax 検証通過
- [x] 単発 cron 検出 + 3 タブ連鎖 open: v3.2.40 から挙動変更なし (ロジック維持)
- [ ] マルチ発火 E2E: 週次火曜 Enterprise-AI-HelpDesk-System 発火で検証
- [ ] tail 出力の real-time 性: 実機で数分間 streaming を目視確認

## 依存

PR #196 (v3.2.40 cron-launcher 修正) merge 後に本 PR を merge するのが推奨順。
本 PR 単独でも適用可能だが、launcher 側の fail を検知しても UI で混乱するだけなので
順序を守ることで最短の UX 復旧となる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * ログ監視の実行が非同期化され、ライブ出力を途切れずに継続して取得できるようになりました
  * 新しいログファイル検出時にセッションを自動で切り替え、残存出力を適切に処理するようになりました
  * 終了時のクリーンアップとステータスメッセージを強化し、リソース管理が安定しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->