### PR TITLE
fix(v3.2.42): pwsh 7 強制 + Start-Job UTF-8 化 (タブ表示 / 文字化け)

### DIFF
--- a/scripts/tools/Watch-ClaudeLog.ps1
+++ b/scripts/tools/Watch-ClaudeLog.ps1
@@ -7,7 +7,8 @@
     cron 実行前に起動しておくと、発火を検知して自動でログ表示を開始する。
     v3.2.41 から tail -F をバックグラウンド Job 化し、ライブ表示中にも
     次の cron 発火を検出 → 自動で次セッションへ切り替える (マルチ発火対応)。
-    ClaudeOS v3.2.41
+    v3.2.42 で spawn タブを強制 pwsh 7 化 + Start-Job 内 UTF-8 化 (文字化け解消)。
+    ClaudeOS v3.2.42
 .PARAMETER NewTab
     Windows Terminal の新規タブで開く（既定: 現在のウィンドウで実行）。
 .PARAMETER PollIntervalSeconds
@@ -82,9 +83,25 @@ if ([string]::IsNullOrWhiteSpace($LinuxHost) -or $LinuxHost -eq '<your-linux-hos
     exit 1
 }
 
+# spawn タブ用の PowerShell exe 解決: PowerShell 7 (pwsh.exe) を最優先。
+# PATH 不通でも既知インストール先を検査し、最終 fallback は親プロセス。
+function Get-PwshExe {
+    $cmd = Get-Command pwsh -ErrorAction SilentlyContinue
+    if ($cmd -and $cmd.Source) { return $cmd.Source }
+    foreach ($p in @(
+        'C:\Program Files\PowerShell\7\pwsh.exe',
+        "$env:ProgramFiles\PowerShell\7\pwsh.exe",
+        "$env:LOCALAPPDATA\Microsoft\PowerShell\7\pwsh.exe"
+    )) {
+        if ($p -and (Test-Path $p)) { return $p }
+    }
+    return (Get-Process -Id $PID).Path
+}
+$PwshExe = Get-PwshExe
+
 # NewTab モード: 自身を新しい Windows Terminal タブで再起動
 if ($NewTab) {
-    $psExe  = (Get-Process -Id $PID).Path
+    $psExe  = $PwshExe
     $wtExe  = Get-Command wt.exe -ErrorAction SilentlyContinue
     $myPath = $PSCommandPath
 
@@ -172,7 +189,7 @@ function Open-TmuxAttachTab {
     $tmuxSession  = "claudeos-$safeProject"
     # attach-session: セッションが存在しなければエラー終了 (new-session -A はゴーストセッションを作るため使わない)
     $sshCmd       = "ssh -t $SshTarget tmux attach-session -t $tmuxSession"
-    $psExe        = (Get-Process -Id $PID).Path
+    $psExe        = $script:PwshExe
     $psArgs = @(
         '-NoExit', '-NoProfile', '-ExecutionPolicy', 'Bypass',
         '-Command', $sshCmd
@@ -189,7 +206,7 @@ function Open-SessionInfoTab {
         Write-Host '  [INFO] wt.exe が非検出のため Session Info タブを開けません。' -ForegroundColor Yellow
         return
     }
-    $psExe    = (Get-Process -Id $PID).Path
+    $psExe    = $script:PwshExe
     $siScript = Join-Path $PSScriptRoot 'Watch-SessionInfoSSH.ps1'
     if (-not (Test-Path $siScript)) {
         Write-Host "  [WARN] Watch-SessionInfoSSH.ps1 が見つかりません: $siScript" -ForegroundColor Yellow
@@ -250,6 +267,11 @@ while ($true) {
         # stdbuf -oL で tail の line-buffering を強制し、リアルタイム出力を担保する。
         $tailJob = Start-Job -ArgumentList $SshTarget, $latest -ScriptBlock {
             param($target, $path)
+            # Job は新規 runspace のため親 console のエンコーディング継承なし。
+            # 明示的に UTF-8 化しないと ssh 経由の日本語出力 (例: "UI閲覧用") が文字化ける (v3.2.42)。
+            [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+            [Console]::InputEncoding  = [System.Text.Encoding]::UTF8
+            $OutputEncoding = [System.Text.Encoding]::UTF8
             ssh $target "stdbuf -oL tail -n 50 -F '$path'"
         }
 

--- a/start.bat
+++ b/start.bat
@@ -1,9 +1,18 @@
 @echo off
 cd /d "%~dp0"
+chcp 65001 >nul
 title AI CLI Universal Startup Tool
-where pwsh >nul 2>&1
-if %ERRORLEVEL% == 0 (
-    pwsh.exe -NoProfile -ExecutionPolicy Bypass -File "scripts\main\Start-Menu.ps1"
+
+rem PowerShell 7 (pwsh) を優先。PATH 不通でも既知インストール先を検査する。
+set "PWSH_EXE="
+where pwsh >nul 2>&1 && set "PWSH_EXE=pwsh.exe"
+if not defined PWSH_EXE if exist "C:\Program Files\PowerShell\7\pwsh.exe" set "PWSH_EXE=C:\Program Files\PowerShell\7\pwsh.exe"
+if not defined PWSH_EXE if exist "%ProgramFiles%\PowerShell\7\pwsh.exe" set "PWSH_EXE=%ProgramFiles%\PowerShell\7\pwsh.exe"
+if not defined PWSH_EXE if exist "%LOCALAPPDATA%\Microsoft\PowerShell\7\pwsh.exe" set "PWSH_EXE=%LOCALAPPDATA%\Microsoft\PowerShell\7\pwsh.exe"
+
+if defined PWSH_EXE (
+    "%PWSH_EXE%" -NoProfile -ExecutionPolicy Bypass -File "scripts\main\Start-Menu.ps1"
 ) else (
+    echo [WARN] PowerShell 7 (pwsh) not found. Using Windows PowerShell 5.1 fallback.
     powershell.exe -NoProfile -ExecutionPolicy Bypass -File "scripts\main\Start-Menu.ps1"
 )


### PR DESCRIPTION
## Summary

ユーザー報告の 3 点を一括修正:
1. **タブ表示が CMD プロンプトになる** → start.bat pwsh 検出堅牢化 + Watch-ClaudeLog の spawn タブが pwsh 7 を明示使用
2. **Live-Log タブの文字化け** → Start-Job 内で UTF-8 エンコーディング明示設定
3. **start.bat 実行時も PS 7** → 既知インストール先 (`C:\Program Files\PowerShell\7\pwsh.exe` 等) を直接探査

## 問題分析

### CMD プロンプト問題

- `(Get-Process -Id $PID).Path` は親プロセスに依存。起動チェーン (cmd → powershell 5.1 → wt → pwsh) の途中で Windows PowerShell 5.1 が挟まると spawn タブも 5.1 になる
- start.bat の `where pwsh` は PATH 不通時に silently 失敗 → powershell.exe 5.1 fallback

### 文字化け問題

- v3.2.41 で導入した Start-Job は**新規 runspace** を作るため、親スクリプト冒頭で設定した `[Console]::OutputEncoding = UTF8` が Job 内に**継承されない**
- Job 内の ssh tail -F 出力の日本語 (例: cron-launcher の `"UI閲覧用"`) や矢印 `"→"` が Shift-JIS/ANSI デコードで文字化け

## 修正

### start.bat

```batch
@echo off
cd /d "%~dp0"
chcp 65001 >/dev/null                     ← UTF-8 code page
title AI CLI Universal Startup Tool

set "PWSH_EXE="
where pwsh >/dev/null 2>&1 && set "PWSH_EXE=pwsh.exe"
if not defined PWSH_EXE if exist "C:\Program Files\PowerShell\7\pwsh.exe" set "PWSH_EXE=C:\Program Files\PowerShell\7\pwsh.exe"
if not defined PWSH_EXE if exist "%ProgramFiles%\PowerShell\7\pwsh.exe" set "PWSH_EXE=%ProgramFiles%\PowerShell\7\pwsh.exe"
if not defined PWSH_EXE if exist "%LOCALAPPDATA%\Microsoft\PowerShell\7\pwsh.exe" set "PWSH_EXE=%LOCALAPPDATA%\Microsoft\PowerShell\7\pwsh.exe"

if defined PWSH_EXE (
    "%PWSH_EXE%" -NoProfile -ExecutionPolicy Bypass -File "scripts\main\Start-Menu.ps1"
) else (
    echo [WARN] PowerShell 7 (pwsh) not found. Using Windows PowerShell 5.1 fallback.
    powershell.exe -NoProfile -ExecutionPolicy Bypass -File "scripts\main\Start-Menu.ps1"
)
```

### Watch-ClaudeLog.ps1

pwsh 7 ヘルパ:

```powershell
function Get-PwshExe {
    $cmd = Get-Command pwsh -ErrorAction SilentlyContinue
    if ($cmd -and $cmd.Source) { return $cmd.Source }
    foreach ($p in @(
        'C:\Program Files\PowerShell\7\pwsh.exe',
        "$env:ProgramFiles\PowerShell\7\pwsh.exe",
        "$env:LOCALAPPDATA\Microsoft\PowerShell\7\pwsh.exe"
    )) {
        if ($p -and (Test-Path $p)) { return $p }
    }
    return (Get-Process -Id $PID).Path
}
$PwshExe = Get-PwshExe
```

→ `Open-TmuxAttachTab` / `Open-SessionInfoTab` / NewTab モードで `$psExe = $PwshExe` を使用。

Start-Job UTF-8 化:

```powershell
$tailJob = Start-Job -ArgumentList $SshTarget, $latest -ScriptBlock {
    param($target, $path)
    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8   ← 追加
    [Console]::InputEncoding  = [System.Text.Encoding]::UTF8   ← 追加
    $OutputEncoding = [System.Text.Encoding]::UTF8              ← 追加
    ssh $target "stdbuf -oL tail -n 50 -F '$path'"
}
```

## Test plan

- [x] PowerShell Parser で syntax 検証通過
- [x] start.bat で pwsh 7 起動確認 (手動)
- [ ] Live-Log タブ日本語表示 (`"UI閲覧用"`, `"→"`) 文字化け解消の実機確認
- [ ] spawn Claude-UI / Session-Info タブが pwsh 7 プロンプト表示の実機確認
- [ ] v3.2.41 マルチ発火機能の継続動作確認 (退行なし)

## 影響範囲

- `start.bat` (bat 構文)
- `scripts/tools/Watch-ClaudeLog.ps1` (ヘルパ追加・既存 3 箇所参照置換・Start-Job 内 3 行追加)
- バックエンド (cron-launcher / session.json / tmux) は無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 日本語テキストの出力エンコーディングの問題を修正しました。

* **チェア**
  * PowerShell 7の検出と実行の信頼性を向上させました。
  * スタートアップスクリプトでUTF-8コンソールエンコーディングのサポートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->