### PR TITLE
feat(v3.2.44): Claude/templates/claudeos/ 全体を .claude/claudeos/ に deploy

### DIFF
--- a/scripts/lib/TemplateSyncManager.ps1
+++ b/scripts/lib/TemplateSyncManager.ps1
@@ -169,8 +169,16 @@ function Sync-LauncherClaudeGlobalConfig {
         -TargetPath (Join-Path $ProjectDir 'CLAUDE.md') `
         -Label 'CLAUDE.md'
 
+    # v3.2.44: Claude/templates/claudeos/ を .claude/claudeos/ の正本として採用
+    # (以前は scripts/templates/claudeos/ を使用していたが、agents / skills / commands 等の
+    #  完全版テンプレートは Claude/templates/claudeos/ 側にあるため正本を切替)
+    $claudeosSource = Join-Path $StartupRoot 'Claude\templates\claudeos'
+    if (-not (Test-Path $claudeosSource)) {
+        # 後方互換 fallback
+        $claudeosSource = Join-Path $StartupRoot 'scripts\templates\claudeos'
+    }
     Sync-ProjectTemplateDirectory `
-        -TemplateDir (Join-Path $StartupRoot 'scripts\templates\claudeos') `
+        -TemplateDir $claudeosSource `
         -TargetDir (Join-Path $ProjectDir '.claude\claudeos') `
         -Label '.claude/claudeos'
 

--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -422,6 +422,30 @@ chmod +x $(ConvertTo-BashSingleQuoted -Value $remoteBootstrap)
         exit 0
     }
 
+    # v3.2.44: Claude/templates/claudeos/ 全体を .claude/claudeos/ に bulk sync (scp -r)
+    # ~345 ファイル (agents / skills / commands / rules / 等) を一括転送する。
+    # 既存の 6 ファイル .claude/commands/ deploy は Claude Code slash command として
+    # 別途必要なので保持 (下で heredoc から実行)。
+    $claudeosSource = Join-Path $ScriptRoot 'Claude\templates\claudeos'
+    if (Test-Path $claudeosSource) {
+        Write-Info "Syncing .claude/claudeos/ (bulk scp -r)"
+        $scpExe = if ($env:AI_STARTUP_SCP_EXE) { $env:AI_STARTUP_SCP_EXE } else { 'scp' }
+        $sshExeForMkdir = if ($env:AI_STARTUP_SSH_EXE) { $env:AI_STARTUP_SSH_EXE } else { 'ssh' }
+
+        # 事前に .claude/ 親ディレクトリを確保
+        & $sshExeForMkdir -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o ControlMaster=no `
+            $linuxHost "mkdir -p '$linuxProject/.claude'" 2>$null
+
+        # scp -r: 既存の .claude/claudeos/ 内容を上書きする (テンプレートが正本)
+        & $scpExe -r -q -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o ControlMaster=no `
+            $claudeosSource "${linuxHost}:$linuxProject/.claude/" 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok ".claude/claudeos/ synced from Claude/templates/claudeos/"
+        } else {
+            Write-Warn "scp -r exit=$LASTEXITCODE — .claude/claudeos/ bulk sync をスキップ"
+        }
+    }
+
     Write-Info "Connecting via SSH: $linuxHost"
     $deployExitCode = Invoke-ClaudeSshViaStdin -LinuxHost $linuxHost -ScriptText $deployScript
     if ($deployExitCode -ne 0) {


### PR DESCRIPTION
## Summary

`Claude/templates/claudeos/` 配下 345+ ファイル (agents/37, skills/64, commands/39, rules/14 等) を
Local / SSH 両モードで `.claude/claudeos/` に sync する仕組みを追加。
これまで**どこからも deploy されずデッドストック**だったテンプレートを活用可能にする。

## 背景

- テンプレート CLAUDE.md は `.claude/claudeos/` を「正規構成」と宣言
- 実態: 旧 deploy ルートは `scripts/templates/claudeos/` (21 ファイルの部分版)
- 豊富な内容 (agents 37 / skills 64 / commands 39 等) を持つ `Claude/templates/claudeos/` は
  どこからも読まれていなかった

A→B→C→D シリーズの **B ステップ**。

## 変更

### 1. Local mode — `scripts/lib/TemplateSyncManager.ps1`

```diff
+    # v3.2.44: Claude/templates/claudeos/ を .claude/claudeos/ の正本として採用
+    $claudeosSource = Join-Path $StartupRoot 'Claude\templates\claudeos'
+    if (-not (Test-Path $claudeosSource)) {
+        # 後方互換 fallback
+        $claudeosSource = Join-Path $StartupRoot 'scripts\templates\claudeos'
+    }
     Sync-ProjectTemplateDirectory `
-        -TemplateDir (Join-Path $StartupRoot 'scripts\templates\claudeos') `
+        -TemplateDir $claudeosSource `
         -TargetDir (Join-Path $ProjectDir '.claude\claudeos') `
         -Label '.claude/claudeos'
```

### 2. SSH mode — `scripts/main/Start-ClaudeCode.ps1`

`Invoke-ClaudeSshViaStdin` 前に `scp -r` bulk 転送を追加:

```powershell
$claudeosSource = Join-Path $ScriptRoot 'Claude\templates\claudeos'
if (Test-Path $claudeosSource) {
    & ssh $linuxHost "mkdir -p '$linuxProject/.claude'"
    & scp -r -q $claudeosSource "${linuxHost}:$linuxProject/.claude/"
}
```

- 既存の `.claude/commands/` 6 ファイル deploy は保持 (Claude Code slash command 認識先)
- scp 失敗時は WARN を出してスキップ (セッション起動は継続)
- `AI_STARTUP_SCP_EXE` 環境変数で上書き可能 (test 対応)

## 影響範囲

| ファイル | 規模 | 備考 |
|---|---|---|
| `scripts/lib/TemplateSyncManager.ps1` | +8 / -1 | fallback 含む |
| `scripts/main/Start-ClaudeCode.ps1` | +24 | SSH bulk deploy 追加 |

## Test plan

- [x] PowerShell Parser で 2 ファイル syntax 検証通過
- [x] fallback 動作: `Claude/templates/claudeos/` 不在時は旧 path を使用
- [ ] Local 実行: プロジェクト `.claude/claudeos/` 配下に agents/, skills/, commands/ 等が展開される
- [ ] SSH 実行: Linux 側 `$linuxProject/.claude/claudeos/` に同様の展開
- [x] CI (lint / test / security) pass

## 後続 (計画)

- **v3.2.45 (C)**: `scripts/templates/claudeos/` を廃止し一本化
- **v3.2.46 (D)**: wt タブアイコンの PowerShell 化

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * テンプレートの読み込み方式を最適化しました
  * デプロイ時にテンプレートがリモートシステムに自動同期されるようになりました。これにより、デプロイメント処理がより確実になります

<!-- end of auto-generated comment: release notes by coderabbit.ai -->