### PR TITLE
fix(v3.2.46): Watch-ClaudeLog spawn タブアイコンを PowerShell 化

### DIFF
--- a/scripts/tools/Watch-ClaudeLog.ps1
+++ b/scripts/tools/Watch-ClaudeLog.ps1
@@ -8,7 +8,8 @@
     v3.2.41 から tail -F をバックグラウンド Job 化し、ライブ表示中にも
     次の cron 発火を検出 → 自動で次セッションへ切り替える (マルチ発火対応)。
     v3.2.42 で spawn タブを強制 pwsh 7 化 + Start-Job 内 UTF-8 化 (文字化け解消)。
-    ClaudeOS v3.2.42
+    v3.2.46 で wt new-tab に -p "PowerShell" を付与してタブアイコンを PS 化。
+    ClaudeOS v3.2.46
 .PARAMETER NewTab
     Windows Terminal の新規タブで開く（既定: 現在のウィンドウで実行）。
 .PARAMETER PollIntervalSeconds
@@ -99,6 +100,11 @@ function Get-PwshExe {
 }
 $PwshExe = Get-PwshExe
 
+# wt.exe に渡す profile 名 (タブアイコン・配色を PowerShell 化する)。
+# 指定 profile がユーザー WT 設定になければ wt は既定 profile へ fallback するため安全。
+# AI_STARTUP_WT_PROFILE で上書き可能。
+$WtProfileName = if ($env:AI_STARTUP_WT_PROFILE) { $env:AI_STARTUP_WT_PROFILE } else { 'PowerShell' }
+
 # NewTab モード: 自身を新しい Windows Terminal タブで再起動
 if ($NewTab) {
     $psExe  = $PwshExe
@@ -119,7 +125,7 @@ if ($NewTab) {
     if ($WithSessionInfoTab) { $psArgs += '-WithSessionInfoTab' }
 
     if ($wtExe) {
-        $wtArgs = @('-w', '0', 'new-tab', '--title', 'Claude-Live-Log', '--', $psExe) + $psArgs
+        $wtArgs = @('-w', '0', 'new-tab', '-p', $WtProfileName, '--title', 'Claude-Live-Log', '--', $psExe) + $psArgs
         Start-Process -FilePath $wtExe.Source -ArgumentList $wtArgs -WindowStyle Hidden
         Write-Host '[INFO] Claude-Live-Log タブを開きました。' -ForegroundColor Cyan
     } else {
@@ -194,7 +200,7 @@ function Open-TmuxAttachTab {
         '-NoExit', '-NoProfile', '-ExecutionPolicy', 'Bypass',
         '-Command', $sshCmd
     )
-    $wtArgs = @('-w', '0', 'new-tab', '--title', 'Claude-UI', '--', $psExe) + $psArgs
+    $wtArgs = @('-w', '0', 'new-tab', '-p', $script:WtProfileName, '--title', 'Claude-UI', '--', $psExe) + $psArgs
     Start-Process -FilePath $wtExe.Source -ArgumentList $wtArgs -WindowStyle Hidden
     Write-Host "  Claude UI タブを開きました: tmux attach-session -t $tmuxSession" -ForegroundColor Magenta
 }
@@ -220,7 +226,7 @@ function Open-SessionInfoTab {
         '-LinuxUser', $LinuxUser,
         '-SessionsDir', $SessionsDir
     )
-    $wtArgs = @('-w', '0', 'new-tab', '--title', 'Session-Info', '--', $psExe) + $psArgs
+    $wtArgs = @('-w', '0', 'new-tab', '-p', $script:WtProfileName, '--title', 'Session-Info', '--', $psExe) + $psArgs
     Start-Process -FilePath $wtExe.Source -ArgumentList $wtArgs -WindowStyle Hidden
     Write-Host "  Session Info タブを開きました: $SessionId" -ForegroundColor Cyan
 }


### PR DESCRIPTION
## Summary

Watch-ClaudeLog が spawn する 3 タブ (Live-Log / Claude-UI / Session-Info) の
アイコン・styling を PowerShell 化する。v3.2.42 で中身は pwsh 7 強制済みだが、
wt.exe の profile 指定がなく default profile 依存だったため、
ユーザー WT が CMD default だとアイコンが CMD のままだった問題を解消。

A→B→C→D シリーズの **D ステップ (最終)**。

## 問題

```powershell
# v3.2.42:
$wtArgs = @('-w', '0', 'new-tab', '--title', 'Claude-Live-Log', '--', $psExe) + $psArgs
```

`-p` 省略 → WT default profile (ユーザー環境で Command Prompt) の styling が
適用される。中身は pwsh だがタブの見た目は CMD。

## 修正

```powershell
$WtProfileName = if ($env:AI_STARTUP_WT_PROFILE) { $env:AI_STARTUP_WT_PROFILE } else { 'PowerShell' }

# 3 箇所の wt new-tab 引数に -p $WtProfileName を追加
$wtArgs = @('-w', '0', 'new-tab', '-p', $WtProfileName, '--title', '...', '--', $psExe) + $psArgs
```

## 挙動

| 観点 | Before (v3.2.42) | After (v3.2.46) |
|---|---|---|
| タブアイコン | 🖥️ CMD | 🟦 PowerShell |
| 中身 | pwsh 7.6.0 | pwsh 7.6.0 (変更なし) |
| profile 不在時 | — | wt が既定 profile へ fallback (安全) |

## 環境変数

`AI_STARTUP_WT_PROFILE` で profile 名を上書き可能:

```
$env:AI_STARTUP_WT_PROFILE = 'Windows PowerShell'  # 5.1 profile を使いたい場合
```

## Test plan

- [x] PowerShell Parser syntax 検証通過
- [x] CI (lint / test / security)
- [ ] 実機確認: Watch タブ起動 → 3 タブ全てが PowerShell アイコンで表示

## A→B→C→D シリーズ完了

| Ver | 内容 | PR |
|---|---|---|
| v3.2.43 (A) | `CLAUDE-Back20260331.md` 死蔵 backup 削除 | #199 ✅ |
| v3.2.44 (B) | `Claude/templates/claudeos/` 全体を `.claude/claudeos/` に deploy | #200 ✅ |
| v3.2.45 (C) | `scripts/templates/claudeos/` 削除・一本化 | #201 ✅ |
| v3.2.46 (D) | wt タブアイコンの PowerShell 化 | 本 PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * Windows Terminalのタブ作成時に、PowerShellプロファイル設定をより明示的に指定するようにしました。複数のタブシナリオで指定されたプロファイルが確実に適用されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->