### PR TITLE
fix(v3.2.48): wt profile は GUID を優先 — 空白入り名称の ArgList split 回避

### DIFF
--- a/scripts/tools/Watch-ClaudeLog.ps1
+++ b/scripts/tools/Watch-ClaudeLog.ps1
@@ -12,7 +12,9 @@
     v3.2.47 で WT settings.json から pwsh profile 名を動的検出 + GUID fallback
     (ユーザー環境で profile 名が "PowerShell version 7" / "PowerShell 7" 等の
     場合にも確実にアイコンが PS 7 になるよう改善)。
-    ClaudeOS v3.2.47
+    v3.2.48 で profile 識別子を GUID 優先に変更 (空白を含む profile 名が
+    Start-Process -ArgumentList で split される問題を回避)。
+    ClaudeOS v3.2.48
 .PARAMETER NewTab
     Windows Terminal の新規タブで開く（既定: 現在のウィンドウで実行）。
 .PARAMETER PollIntervalSeconds
@@ -105,15 +107,17 @@ $PwshExe = Get-PwshExe
 
 # wt.exe に渡す profile 識別子 (タブアイコン・配色を PowerShell 7 化する)。
 #
-# WT settings.json の profile 名は環境ごとに異なるため動的検出が必要:
-#   - stable Microsoft 自動生成: "PowerShell version 7"
-#   - Preview Microsoft 自動生成: "PowerShell 7"
-#   - ユーザー手動追加: 任意 ("PowerShell", "pwsh" 等)
+# GUID を優先返却する理由 (v3.2.48):
+#   profile 名は "PowerShell version 7" のように空白を含むことがあり、
+#   Start-Process -ArgumentList の配列要素は自動クォートされないため
+#   wt.exe 側で `-p PowerShell` + `version` + `7 ...` に split されて失敗する
+#   (ERROR 0x80070002: 指定されたファイルが見つかりません)。
+#   GUID (`{574e775e-...}`) は空白を含まないためこの問題を回避できる。
 #
 # 検出順:
-#   1. 環境変数 AI_STARTUP_WT_PROFILE (明示指定)
-#   2. WT settings.json から pwsh.exe を commandline に持つ profile 名
-#   3. Microsoft fragment 由来の PS 7 固定 GUID (pwsh.exe パスから決定的に計算される)
+#   1. 環境変数 AI_STARTUP_WT_PROFILE (明示指定; 名前でも GUID でも可)
+#   2. WT settings.json から pwsh.exe を commandline に持つ profile の GUID
+#   3. Microsoft fragment 由来の PS 7 固定 GUID (pwsh.exe パスから決定的)
 function Get-WtPwshProfile {
     $settingsPaths = @(
         "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json",
@@ -126,7 +130,11 @@ function Get-WtPwshProfile {
             $profiles = @($s.profiles.list) | Where-Object {
                 $_.commandline -and $_.commandline -match 'pwsh\.exe' -and -not $_.hidden
             }
-            if ($profiles.Count -gt 0 -and $profiles[0].name) { return $profiles[0].name }
+            if ($profiles.Count -gt 0) {
+                # GUID 優先 (空白なし、シェル安全)
+                if ($profiles[0].guid) { return $profiles[0].guid }
+                if ($profiles[0].name) { return $profiles[0].name }
+            }
         } catch { $null = $_ }
     }
     # Microsoft fragment 経由で pwsh.exe から生成される固定 GUID


### PR DESCRIPTION
## Summary

v3.2.47 で profile 名を返していたが、`"PowerShell version 7"` のように空白を含む場合
`Start-Process -ArgumentList` の配列要素が自動クォートされず、wt.exe 側で:

```
-p PowerShell version 7 --title ...
         ^^^^^^^^^^              <- 空白で split、wt は 'version' を command と誤認
```

として解釈され起動失敗 (`ERROR 0x80070002: 指定されたファイルが見つかりません`)。

空白を含まない GUID (`{574e775e-...}`) を返すことで回避。

## 修正

```diff
 if ($profiles.Count -gt 0) {
-    if ($profiles[0].name) { return $profiles[0].name }
+    # GUID 優先 (空白なし、シェル安全)
+    if ($profiles[0].guid) { return $profiles[0].guid }
+    if ($profiles[0].name) { return $profiles[0].name }
 }
```

## 動作検証

- [x] 実機検出結果: `{574e775e-4f2a-5b96-ac1e-a2962a402336}` (PS 7 固定 GUID)
- [x] Parser syntax 検証通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ClaudeOS v3.2.47 から v3.2.48 に更新
  * Windows Terminal の PowerShell プロファイル選択ロジックを変更：プロファイル GUID が利用可能な場合、GUID を優先して使用するようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->