### PR TITLE
feat(v3.2.49): Agent Teams runtime 有効化 — .claude/agents/ にも配置 (E-1)

### DIFF
--- a/scripts/lib/TemplateSyncManager.ps1
+++ b/scripts/lib/TemplateSyncManager.ps1
@@ -176,6 +176,14 @@ function Sync-LauncherClaudeGlobalConfig {
         -TargetDir (Join-Path $ProjectDir '.claude\claudeos') `
         -Label '.claude/claudeos'
 
+    # v3.2.49 (E-1): Agent Teams を runtime 有効化。
+    # Claude Code は .claude/agents/ のみを自動 discovery するため、
+    # .claude/claudeos/agents/ とは別に標準 path にも同期する。
+    Sync-ProjectTemplateDirectory `
+        -TemplateDir (Join-Path $StartupRoot 'Claude\templates\claudeos\agents') `
+        -TargetDir (Join-Path $ProjectDir '.claude\agents') `
+        -Label '.claude/agents'
+
     $settingsTemplatePath = Join-Path $StartupRoot 'scripts\templates\claude-settings.json'
     Initialize-ProjectTemplate `
         -TemplatePath $settingsTemplatePath `

--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -444,6 +444,17 @@ chmod +x $(ConvertTo-BashSingleQuoted -Value $remoteBootstrap)
         } else {
             Write-Warn "scp -r exit=$LASTEXITCODE — .claude/claudeos/ bulk sync をスキップ"
         }
+
+        # v3.2.49 (E-1): Agent Teams を runtime 有効化。
+        # Claude Code は .claude/agents/ のみを自動 discovery するため、scp 済みの
+        # .claude/claudeos/agents/ を .claude/agents/ にも複製する。
+        & $sshExeForMkdir -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o ControlMaster=no `
+            $linuxHost "mkdir -p '$linuxProject/.claude/agents' && cp -rf '$linuxProject/.claude/claudeos/agents/.' '$linuxProject/.claude/agents/' 2>/dev/null" 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok ".claude/agents/ activated (Agent Teams runtime)"
+        } else {
+            Write-Warn ".claude/agents/ activation exit=$LASTEXITCODE — Agent Teams は reference のみ"
+        }
     }
 
     Write-Info "Connecting via SSH: $linuxHost"


### PR DESCRIPTION
## Summary

v3.2.44 (#200) で `Claude/templates/claudeos/agents/` (37 files) は
`.claude/claudeos/agents/` に配置済みだが、Claude Code は
**`.claude/agents/` のみを自動 discovery** するため、Agent Teams 定義は
**reference のみで runtime 未有効** だった。

本 PR で `.claude/agents/` にも配置して 37 agents を runtime 有効化する。

## 変更

### Local mode — `scripts/lib/TemplateSyncManager.ps1`

```powershell
Sync-ProjectTemplateDirectory `
    -TemplateDir (Join-Path $StartupRoot 'Claude\templates\claudeos\agents') `
    -TargetDir (Join-Path $ProjectDir '.claude\agents') `
    -Label '.claude/agents'
```

### SSH mode — `scripts/main/Start-ClaudeCode.ps1`

既存の `scp -r` で Linux 側 `.claude/claudeos/agents/` が既に配置済みなので、
それを remote cp で `.claude/agents/` にも複製:

```powershell
& ssh $linuxHost "mkdir -p '$linuxProject/.claude/agents' && cp -rf '$linuxProject/.claude/claudeos/agents/.' '$linuxProject/.claude/agents/'"
```

## 効果

プロジェクト起動時に以下 37 agents が `.claude/agents/` から自動 discovery:

- architect, code-reviewer, security-reviewer, tdd-guide, docs-lookup
- ops, planner, release-manager, orchestrator, chief-of-staff
- api-designer, build-error-resolver, cpp-/go-/java-/kotlin-/python-/rust-/typescript-reviewer
- e2e-runner, harness-optimizer, incident-triager, refactor-cleaner
- 他

→ Agent Teams 機能が完全な定義セットで動作可能に。

## Test plan

- [x] PowerShell Parser syntax 検証通過
- [x] CI (lint / test / security)
- [ ] 実機確認: プロジェクト起動後 `.claude/agents/*.md` が 37 ファイル配置される

## 残課題 (別 PR)

| 優先 | 内容 |
|---|---|
| E-2 | `commands/` 残 33 ファイルを `.claude/commands/` にも配置 |
| E-3 | `skills/` 64 ファイルを `.claude/skills/` にも配置 |
| E-4 | `hooks/` を `.claude/hooks/` + settings.json 登録 |
| F | settings.json 二重管理 (Local と SSH) 解消 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Agent Teamsのテンプレートが自動的に同期され、プロジェクトで利用可能になりました。
  * スタートアップ時にAgent Teams用の環境が確実にセットアップされるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->