### PR TITLE
feat(v3.2.50): slash commands runtime 有効化 (E-2)

### DIFF
--- a/scripts/lib/TemplateSyncManager.ps1
+++ b/scripts/lib/TemplateSyncManager.ps1
@@ -184,6 +184,12 @@ function Sync-LauncherClaudeGlobalConfig {
         -TargetDir (Join-Path $ProjectDir '.claude\agents') `
         -Label '.claude/agents'
 
+    # v3.2.50 (E-2): slash commands を runtime 有効化 (39 ファイル)
+    Sync-ProjectTemplateDirectory `
+        -TemplateDir (Join-Path $StartupRoot 'Claude\templates\claudeos\commands') `
+        -TargetDir (Join-Path $ProjectDir '.claude\commands') `
+        -Label '.claude/commands'
+
     $settingsTemplatePath = Join-Path $StartupRoot 'scripts\templates\claude-settings.json'
     Initialize-ProjectTemplate `
         -TemplatePath $settingsTemplatePath `

--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -455,6 +455,13 @@ chmod +x $(ConvertTo-BashSingleQuoted -Value $remoteBootstrap)
         } else {
             Write-Warn ".claude/agents/ activation exit=$LASTEXITCODE — Agent Teams は reference のみ"
         }
+
+        # v3.2.50 (E-2): slash commands を runtime 有効化 (39 ファイル)
+        & $sshExeForMkdir -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o ControlMaster=no `
+            $linuxHost "mkdir -p '$linuxProject/.claude/commands' && cp -rf '$linuxProject/.claude/claudeos/commands/.' '$linuxProject/.claude/commands/' 2>/dev/null" 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok ".claude/commands/ activated (39 slash commands runtime)"
+        }
     }
 
     Write-Info "Connecting via SSH: $linuxHost"


### PR DESCRIPTION
v3.2.49 (E-1) と同パターン。Claude/templates/claudeos/commands/ の 39 ファイル全体を .claude/commands/ にも配置し、slash command として runtime 有効化。Local / SSH 両対応。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * スラッシュコマンド機能をサポートしました。プロジェクト環境でスラッシュコマンド用のテンプレートが自動的に同期・初期化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->