### PR TITLE
feat(v3.2.51): skills runtime 有効化 (E-3)

### DIFF
--- a/scripts/lib/TemplateSyncManager.ps1
+++ b/scripts/lib/TemplateSyncManager.ps1
@@ -190,6 +190,12 @@ function Sync-LauncherClaudeGlobalConfig {
         -TargetDir (Join-Path $ProjectDir '.claude\commands') `
         -Label '.claude/commands'
 
+    # v3.2.51 (E-3): skills を runtime 有効化 (64 skill ディレクトリ)
+    Sync-ProjectTemplateDirectory `
+        -TemplateDir (Join-Path $StartupRoot 'Claude\templates\claudeos\skills') `
+        -TargetDir (Join-Path $ProjectDir '.claude\skills') `
+        -Label '.claude/skills'
+
     $settingsTemplatePath = Join-Path $StartupRoot 'scripts\templates\claude-settings.json'
     Initialize-ProjectTemplate `
         -TemplatePath $settingsTemplatePath `

--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -462,6 +462,13 @@ chmod +x $(ConvertTo-BashSingleQuoted -Value $remoteBootstrap)
         if ($LASTEXITCODE -eq 0) {
             Write-Ok ".claude/commands/ activated (39 slash commands runtime)"
         }
+
+        # v3.2.51 (E-3): skills を runtime 有効化 (64 skill ディレクトリ)
+        & $sshExeForMkdir -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o ControlMaster=no `
+            $linuxHost "mkdir -p '$linuxProject/.claude/skills' && cp -rf '$linuxProject/.claude/claudeos/skills/.' '$linuxProject/.claude/skills/' 2>/dev/null" 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok ".claude/skills/ activated (64 skills runtime)"
+        }
     }
 
     Write-Info "Connecting via SSH: $linuxHost"


### PR DESCRIPTION
64 skill ディレクトリを .claude/skills/ にも配置し runtime 有効化。E-1 / E-2 と同パターン。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Claude スキル機能のテンプレート同期に対応しました。プロジェクト設定時にスキルテンプレートが自動的に同期され、リモート環境でのスキル実行時アクティベーションが可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->