### PR TITLE
feat(v3.2.52): hooks を .claude/hooks/ に配置 (E-4)

### DIFF
--- a/scripts/lib/TemplateSyncManager.ps1
+++ b/scripts/lib/TemplateSyncManager.ps1
@@ -196,6 +196,15 @@ function Sync-LauncherClaudeGlobalConfig {
         -TargetDir (Join-Path $ProjectDir '.claude\skills') `
         -Label '.claude/skills'
 
+    # v3.2.52 (E-4): hooks 定義と hook scripts を .claude/ に配置。
+    # 注: 現状 hook scripts は stub (console.log のみ)。完全な runtime 有効化には
+    # (1) 実装を詰める、(2) settings.json の hooks セクションで登録、の両方が必要。
+    # 本 PR ではファイル配置までを担当し、runtime 登録は settings.json 統合 (F) 側で扱う。
+    Sync-ProjectTemplateDirectory `
+        -TemplateDir (Join-Path $StartupRoot 'Claude\templates\claudeos\hooks') `
+        -TargetDir (Join-Path $ProjectDir '.claude\hooks') `
+        -Label '.claude/hooks'
+
     $settingsTemplatePath = Join-Path $StartupRoot 'scripts\templates\claude-settings.json'
     Initialize-ProjectTemplate `
         -TemplatePath $settingsTemplatePath `

--- a/scripts/main/Start-ClaudeCode.ps1
+++ b/scripts/main/Start-ClaudeCode.ps1
@@ -469,6 +469,13 @@ chmod +x $(ConvertTo-BashSingleQuoted -Value $remoteBootstrap)
         if ($LASTEXITCODE -eq 0) {
             Write-Ok ".claude/skills/ activated (64 skills runtime)"
         }
+
+        # v3.2.52 (E-4): hooks 定義と hook scripts を配置 (runtime 登録は F 側)
+        & $sshExeForMkdir -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o ControlMaster=no `
+            $linuxHost "mkdir -p '$linuxProject/.claude/hooks' && cp -rf '$linuxProject/.claude/claudeos/hooks/.' '$linuxProject/.claude/hooks/' 2>/dev/null" 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok ".claude/hooks/ placed (runtime 登録は settings.json で別途実施)"
+        }
     }
 
     Write-Info "Connecting via SSH: $linuxHost"


### PR DESCRIPTION
hooks 定義 (hooks.json + memory-persistence/README + strategic-compact/README) と hook stub scripts を .claude/hooks/ にも配置。

**注意**: 実 hook scripts は現状 stub (console.log のみ) で、settings.json への hooks 登録も未実施のため、ファイル配置のみの PR。runtime 登録は v3.2.53 (F) で扱う。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**Chores**
- 開発環境設定テンプレートの同期プロセスを拡張し、追加のディレクトリ管理に対応
- Linux ホスト上でのリモートランタイムプロビジョニング処理を強化し、環境準備の信頼性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->