### PR TITLE
fix(v3.2.55): start.bat を pure ASCII 化 — cmd.exe parse エラー修正

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -3,7 +3,7 @@ cd /d "%~dp0"
 chcp 65001 >nul
 title AI CLI Universal Startup Tool
 
-rem PowerShell 7 (pwsh) を優先。PATH 不通でも既知インストール先を検査する。
+rem Prefer PowerShell 7 (pwsh). Check known install paths when PATH lookup fails.
 set "PWSH_EXE="
 where pwsh >nul 2>&1 && set "PWSH_EXE=pwsh.exe"
 if not defined PWSH_EXE if exist "C:\Program Files\PowerShell\7\pwsh.exe" set "PWSH_EXE=C:\Program Files\PowerShell\7\pwsh.exe"


### PR DESCRIPTION
v3.2.42 で追加した日本語コメントが CP932 ロケール cmd.exe で mis-decode され、'not was unexpected at this time.' exit 255 エラーが発生していた。英語コメントに置換し pure ASCII 化して解消。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の更新**
  * 内部ドキュメンテーションの表記を更新しました。

このリリースには、エンドユーザーに対する機能変更や改善はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->