### PR TITLE
fix(v3.2.56): start.bat の if/else 括弧ネストを goto 化 (not was unexpected 再発修正)

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -3,16 +3,17 @@ cd /d "%~dp0"
 chcp 65001 >nul
 title AI CLI Universal Startup Tool
 
-rem Prefer PowerShell 7 (pwsh). Check known install paths when PATH lookup fails.
+rem Prefer PowerShell 7 pwsh. Check known install paths when PATH lookup fails.
 set "PWSH_EXE="
 where pwsh >nul 2>&1 && set "PWSH_EXE=pwsh.exe"
 if not defined PWSH_EXE if exist "C:\Program Files\PowerShell\7\pwsh.exe" set "PWSH_EXE=C:\Program Files\PowerShell\7\pwsh.exe"
 if not defined PWSH_EXE if exist "%ProgramFiles%\PowerShell\7\pwsh.exe" set "PWSH_EXE=%ProgramFiles%\PowerShell\7\pwsh.exe"
 if not defined PWSH_EXE if exist "%LOCALAPPDATA%\Microsoft\PowerShell\7\pwsh.exe" set "PWSH_EXE=%LOCALAPPDATA%\Microsoft\PowerShell\7\pwsh.exe"
 
-if defined PWSH_EXE (
-    "%PWSH_EXE%" -NoProfile -ExecutionPolicy Bypass -File "scripts\main\Start-Menu.ps1"
-) else (
-    echo [WARN] PowerShell 7 (pwsh) not found. Using Windows PowerShell 5.1 fallback.
-    powershell.exe -NoProfile -ExecutionPolicy Bypass -File "scripts\main\Start-Menu.ps1"
-)
+if defined PWSH_EXE goto :RUN_PWSH
+echo [WARN] PowerShell 7 pwsh not found. Using Windows PowerShell 5.1 fallback.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "scripts\main\Start-Menu.ps1"
+goto :EOF
+
+:RUN_PWSH
+"%PWSH_EXE%" -NoProfile -ExecutionPolicy Bypass -File "scripts\main\Start-Menu.ps1"


### PR DESCRIPTION
v3.2.55 の ASCII 化後も 'not was unexpected at this time.' が再発。原因は else ブロック内の echo '[WARN] PowerShell 7 (pwsh) not found.' の **リテラル (pwsh) の括弧**が cmd.exe の paren matching を破綻させ、直後の 'not' が 'if not' と誤解釈されていた。if/else ブロックを goto ラベルパターンに置換し、ネストした括弧を完全排除して解決。