### PR TITLE
feat(v3.2.61): Cron登録後に Cloud Schedule 自動同期 / owner 抽出バグ修正

### DIFF
--- a/scripts/main/New-CloudSchedule.ps1
+++ b/scripts/main/New-CloudSchedule.ps1
@@ -567,6 +567,93 @@ After the call output ONE line: DONE or ERROR
 }
 
 # ─────────────────────────────────────────────────
+# [6] Cron 全プロジェクトを Cloud Schedule に一括同期
+# ─────────────────────────────────────────────────
+function Invoke-CronAllSync {
+    Write-Host ""
+    Write-Host "  Cron 登録済みプロジェクトを Cloud Schedule に一括同期します。" -ForegroundColor Cyan
+    Write-Host "  SSH 経由で Cron エントリを取得中..." -ForegroundColor DarkGray
+
+    # CronManager から Cron 登録済みプロジェクト一覧を取得
+    $cronProjects = @()
+    try {
+        $ScriptRootCS = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+        $cronMgr      = Join-Path $ScriptRootCS 'scripts\lib\CronManager.psm1'
+        $cfgPath      = Join-Path $ScriptRootCS 'config\config.json'
+        if ((Test-Path $cronMgr) -and (Test-Path $cfgPath)) {
+            Import-Module $cronMgr -Force -DisableNameChecking -ErrorAction SilentlyContinue
+            $cfg = Get-Content $cfgPath -Raw | ConvertFrom-Json
+            $linuxHost = $cfg.linuxHost
+            if ($linuxHost -and $linuxHost -ne '<your-linux-host>') {
+                $entries = Get-ClaudeOSCronEntry -LinuxHost $linuxHost -ErrorAction SilentlyContinue
+                $cronProjects = @($entries | Where-Object { -not [string]::IsNullOrWhiteSpace($_.Project) } | Select-Object -ExpandProperty Project -Unique)
+            }
+        }
+    } catch { }
+
+    if ($cronProjects.Count -eq 0) {
+        Write-Host "  [INFO] Cron 登録済みプロジェクトが見つかりませんでした。" -ForegroundColor Yellow
+        Write-Host "         (SSH 接続エラーまたは Cron エントリなし)" -ForegroundColor DarkGray
+        return
+    }
+
+    # GitHub owner を git remote から取得
+    $owner = ''
+    try {
+        $raw = (& git remote get-url origin 2>$null) -join ''
+        if ($raw -match 'github\.com[:/]([^/]+)/') { $owner = $matches[1] }
+    } catch { }
+
+    Write-Host ""
+    Write-Host "  -- Cron 登録済みプロジェクト ($($cronProjects.Count) 件) --" -ForegroundColor Cyan
+    $syncList = @()
+    foreach ($proj in $cronProjects) {
+        $url = if ($owner) { "https://github.com/$owner/$proj" } else { '' }
+        Write-Host ("    {0,-40} {1}" -f $proj, $(if ($url) { $url } else { '(URL 不明)' })) -ForegroundColor White
+        $syncList += [pscustomobject]@{ Project = $proj; Url = $url }
+    }
+
+    if (-not $owner) {
+        Write-Host ""
+        Write-Host "  GitHub owner が取得できませんでした。" -ForegroundColor Yellow
+        $owner = (Read-Host "  GitHub ユーザー名 / org 名を入力 (例: Kensan196948G)").Trim()
+        foreach ($item in $syncList) {
+            if ([string]::IsNullOrWhiteSpace($item.Url)) {
+                $item.Url = "https://github.com/$owner/$($item.Project)"
+            }
+        }
+    }
+
+    Write-Host ""
+    $confirm = Read-Host "  上記 $($syncList.Count) 件を Cloud Schedule に登録しますか? [y/N]"
+    if ($confirm -notmatch '^[yY]') { Write-Host "  キャンセルしました。" -ForegroundColor Yellow; return }
+
+    $psExe       = (Get-Process -Id $PID).Path
+    $cloudScript = $PSCommandPath  # 自分自身のスクリプト
+    $ok = 0; $ng = 0
+
+    foreach ($item in $syncList) {
+        Write-Host ""
+        Write-Host "  >> $($item.Project) ($($item.Url)) を登録中..." -ForegroundColor Cyan
+        if ([string]::IsNullOrWhiteSpace($item.Url)) {
+            Write-Host "  [SKIP] URL が空のためスキップ。" -ForegroundColor Yellow
+            $ng++
+            continue
+        }
+        try {
+            & $psExe -NoProfile -ExecutionPolicy Bypass -File $cloudScript -RepoUrl $item.Url -QuickSetup
+            $ok++
+        } catch {
+            Write-Host "  [ERROR] $($_.Exception.Message)" -ForegroundColor Red
+            $ng++
+        }
+    }
+
+    Write-Host ""
+    Write-Host "  [完了] 登録 $ok 件 / スキップ/エラー $ng 件" -ForegroundColor $(if ($ng -eq 0) { 'Green' } else { 'Yellow' })
+}
+
+# ─────────────────────────────────────────────────
 # メニュー（プロジェクト名をヘッダーに表示）
 # ─────────────────────────────────────────────────
 function Show-CloudScheduleMenu {
@@ -585,6 +672,7 @@ function Show-CloudScheduleMenu {
     Write-Host "    [3] 全 4 標準ループを一括登録" -ForegroundColor Green
     Write-Host "    [4] 管理（無効化 / 有効化 / 完全削除）" -ForegroundColor Yellow
     Write-Host "    [5] 今すぐ実行（Trigger ID 指定）" -ForegroundColor Green
+    Write-Host "    [6] Cron 全プロジェクトを Cloud Schedule に同期" -ForegroundColor Cyan
     Write-Host "    [P] プロジェクトを切り替え" -ForegroundColor Magenta
     Write-Host "    [0] 戻る" -ForegroundColor Gray
     Write-Host ""
@@ -644,6 +732,7 @@ while ($true) {
         '3' { Invoke-CloudRegisterAll; Read-Host "  Enter で戻ります" | Out-Null }
         '4' { Invoke-CloudManage;      Read-Host "  Enter で戻ります" | Out-Null }
         '5' { Invoke-CloudRun;         Read-Host "  Enter で戻ります" | Out-Null }
+        '6' { Invoke-CronAllSync;      Read-Host "  Enter で戻ります" | Out-Null }
         'P' {
             $newUrl = Select-Project
             if (-not [string]::IsNullOrWhiteSpace($newUrl) -and $newUrl -ne $RepoUrl) {

--- a/scripts/main/New-CloudSchedule.ps1
+++ b/scripts/main/New-CloudSchedule.ps1
@@ -93,12 +93,16 @@ Example: REPO_URL:https://github.com/user/repo
             $linuxHost = $cfg.linuxHost
             if ($linuxHost -and $linuxHost -ne '<your-linux-host>') {
                 $entries = Get-ClaudeOSCronEntry -LinuxHost $linuxHost -ErrorAction SilentlyContinue
+                # owner を git remote から1回だけ取得してループ内で使いまわす
+                $cronOwner = ''
+                try {
+                    $cronRemote = (& git remote get-url origin 2>$null) -join ''
+                    if ($cronRemote -match 'github\.com[:/]([^/]+)/') { $cronOwner = $matches[1] }
+                } catch { }
+
                 foreach ($e in @($entries)) {
                     if ([string]::IsNullOrWhiteSpace($e.Project)) { continue }
-                    # プロジェクト名から GitHub URL を推定 (owner は git remote から取得)
-                    $owner  = ''
-                    try { $owner = (& git remote get-url origin 2>$null) -join '' | Select-String -Pattern 'github\.com[:/]([^/]+)/' | ForEach-Object { $_.Matches[0].Groups[1].Value } } catch { }
-                    $guessUrl = if ($owner) { "https://github.com/$owner/$($e.Project)" } else { '' }
+                    $guessUrl = if ($cronOwner) { "https://github.com/$cronOwner/$($e.Project)" } else { '' }
 
                     # 既存エントリを Cron 有りにマーク or 新規追加
                     $existing = $projects | Where-Object { $_.Label -eq $e.Project -or ($guessUrl -and $_.Url -eq $guessUrl) } | Select-Object -First 1

--- a/scripts/main/New-CronSchedule.ps1
+++ b/scripts/main/New-CronSchedule.ps1
@@ -141,6 +141,39 @@ function Invoke-Register {
         $entry = Add-ClaudeOSCronEntry -LinuxHost $LinuxHost -Project $project -DayOfWeek $dow -Time $time -DurationMinutes $duration
         Write-Host ""
         Write-Host "  [OK] Cron エントリを登録しました: ID=$($entry.Id)" -ForegroundColor Green
+
+        # ─── Cloud Schedule にも同期登録 ───
+        Write-Host ""
+        Write-Host "  Cloud Schedule (Anthropic クラウド) にも同期しますか?" -ForegroundColor Cyan
+        Write-Host "  ※ Cloud Schedule は永続動作 / Cron は 5h 強制終了の補完" -ForegroundColor DarkGray
+        $syncChoice = Read-Host "  Cloud Schedule に登録する? [y/N]"
+        if ($syncChoice -match '^[yY]') {
+            $cloudScript = Join-Path $ScriptRoot 'scripts\main\New-CloudSchedule.ps1'
+            if (Test-Path $cloudScript) {
+                # GitHub owner を git remote から取得
+                $owner = ''
+                try {
+                    $rawUrl = (& git remote get-url origin 2>$null) -join ''
+                    if ($rawUrl -match 'github\.com[:/]([^/]+)/') { $owner = $matches[1] }
+                } catch { }
+
+                $githubUrl = if ($owner) { "https://github.com/$owner/$project" } else { '' }
+
+                if ([string]::IsNullOrWhiteSpace($githubUrl)) {
+                    $githubUrl = (Read-Host "  GitHub URL を入力 (例: https://github.com/user/$project)").Trim()
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($githubUrl)) {
+                    Write-Host "  [Cloud] $githubUrl を QuickSetup で登録中..." -ForegroundColor Cyan
+                    $psExe = (Get-Process -Id $PID).Path
+                    & $psExe -NoProfile -ExecutionPolicy Bypass -File $cloudScript -RepoUrl $githubUrl -QuickSetup
+                } else {
+                    Write-Host "  [SKIP] GitHub URL が空のため Cloud Schedule 登録をスキップしました。" -ForegroundColor Yellow
+                }
+            } else {
+                Write-Host "  [WARN] New-CloudSchedule.ps1 が見つかりません。" -ForegroundColor Yellow
+            }
+        }
     }
     catch {
         Write-Host "  [ERROR] $($_.Exception.Message)" -ForegroundColor Red


### PR DESCRIPTION
## 問題

1. Cron (メニュー15) で登録したプロジェクトが Cloud Schedule (メニュー14) に表示されない
2. `Select-Project` の `$owner` 抽出に `Select-String` を使用していたバグ

## 修正内容

### New-CronSchedule.ps1 — Cron登録後に Cloud Schedule 自動同期

```
登録しますか? [y/N]: y
[OK] Cron エントリを登録しました: ID=...

Cloud Schedule (Anthropic クラウド) にも同期しますか?
※ Cloud Schedule は永続動作 / Cron は 5h 強制終了の補完
Cloud Schedule に登録する? [y/N]: y
[Cloud] https://github.com/Kensan196948G/ITSM-System を QuickSetup で登録中...
```

- GitHub owner を `git remote get-url origin` から動的取得 → URL 自動生成
- `New-CloudSchedule.ps1 -RepoUrl $url -QuickSetup` を呼び出し

### New-CloudSchedule.ps1 — Select-Project バグ修正

```powershell
# Before (バグ): Select-String は文字列ではなくファイル向けのコマンド
$owner = ... | Select-String -Pattern '...' | ForEach-Object { $_.Matches[0].Groups[1].Value }

# After (正): 正規表現マッチを直接使用
if ($rawUrl -match 'github\.com[:/]([^/]+)/') { $owner = $matches[1] }
```

## Test plan
- [ ] Cron 登録後に Cloud Schedule 同期の提案が表示される
- [ ] owner が自動取得されて URL が正しく生成される
- [ ] URL が取得できない場合は手動入力を促す

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Cronスケジュール登録後、Anthropicクラウドスケジュールへの同期をオプションで選択可能になりました。GitHubリポジトリ情報を自動取得してクラウド環境に反映できます。

* **パフォーマンス改善**
  * GitHub所有者情報取得のキャッシング機構を導入。複数エントリ処理時のスクリプト実行速度が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->