### PR TITLE
docs(v3.2.62): CHANGELOG / README / TASKS を v3.2.60〜v3.2.62 で補完

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 # CHANGELOG
 
+## [v3.2.62] - 2026-04-21 — Cron全同期をプロジェクト選択画面に移動・空URL/関数順序バグ修正
+
+### 🎯 概要
+`[S] Cron全プロジェクトをCloud Scheduleに同期` を `Show-CloudScheduleMenu` から `Select-Project` に移動。PowerShell関数定義順序バグ（`Invoke-CronAllSync` が `Select-Project` より後に定義されていた問題）を修正。`[0] 戻る` 選択時の空URL渡しバグ修正。`Select-Project` に `while($true)` ループを追加し [S] 同期後にリスト再表示（☁バッジ更新）を実現。
+
+### 🔧 変更対象
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/main/New-CloudSchedule.ps1` | 関数定義順序修正 / Select-Project に [S] 同期 + while ループ / 空URL exit 0 ガード / Show-CloudScheduleMenu から [6] 削除 |
+
+### ✅ テスト結果
+- CI SUCCESS / Security Scan SUCCESS (commit e5ee3a0, PR #222)
+
+---
+
+## [v3.2.61] - 2026-04-21 — Cron登録後Cloud Schedule自動同期 / [6]一括同期 / owner抽出修正
+
+### 🎯 概要
+Cron登録直後に Cloud Schedule へ自動同期する機能を追加。`Show-CloudScheduleMenu` に `[6] Cron全プロジェクトをCloud Scheduleに同期` を追加。`Invoke-CronAllSync` 内の owner 抽出バグ（`git remote get-url origin` → SSH 形式URLで空文字になる問題）を正規表現で修正。
+
+### 🔧 変更対象
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/main/New-CloudSchedule.ps1` | Invoke-CloudRegister: 登録後 Invoke-CronAllSync 呼出し / Show-CloudScheduleMenu: [6] 追加 / Invoke-CronAllSync: owner 抽出修正 |
+
+### ✅ テスト結果
+- CI SUCCESS / Security Scan SUCCESS (commit 5a0124d, PR #221)
+
+---
+
+## [v3.2.60] - 2026-04-21 — プロジェクト選択に戻る・Cron登録状況バッジを追加
+
+### 🎯 概要
+`Select-Project` に `[0] 戻る` オプションと Cron 登録状況バッジ（☁/⏱）を追加。Cron バッジは RemoteTrigger 動的取得と CronManager SSH 確認を組み合わせて表示。
+
+### 🔧 変更対象
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/main/New-CloudSchedule.ps1` | Select-Project: [0]戻る追加 / ☁⏱バッジ表示 / 空URL戻り値対応 |
+
+### ✅ テスト結果
+- CI SUCCESS / Security Scan SUCCESS (commit ce19dbd, PR #219)
+
+---
+
 ## [v3.2.59] - 2026-04-21 — Cloud Schedule プロジェクト選択を動的読み込みに変更
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 > **📌 v3.1.0 で Claude Code 専用ツールに整理**
 > v3.1.0 より、Codex CLI / GitHub Copilot CLI の起動メニュー (S2/S3/L2/L3) は削除されました。本ツールは **Claude Code 専用の自律開発ランチャー** として位置づけを明確化し、Linux crontab 連携・セッション情報タブ・Statusline グローバル適用などの新機能に投資が集中しています。
 
-> **☁️ v3.2.59 — Cloud Schedule プロジェクト選択 動的読み込み / Cron登録状況バッジ / 戻るボタン追加**
-> `[int]$Span.TotalHours` の .NET 銀行丸めで残り時間が +1h 繰り上がる表示バグを `[Math]::Floor` で修正。Windows conhost QuickEdit モードをタブ起動時に P/Invoke で無効化しクリック凍結を防止。画面下部に `Enterキーで更新可能` + 動的生成した再起動コマンドを常時表示。v3.2.38: SessionLogger / TemplateSyncManager ユニットテスト 30 件追加（Pester 680 件）。詳細は [`CHANGELOG.md`](./CHANGELOG.md) を参照。
+> **☁️ v3.2.62 — Cron全同期をプロジェクト選択画面に移動・空URL/関数順序バグ修正**
+> `[S] Cron全同期` を `Show-CloudScheduleMenu` から `Select-Project` に移動。PowerShell 関数定義順序バグ修正・`[0] 戻る` 時の空URL渡しバグ修正・`while($true)` ループで [S] 同期後にリスト再表示（☁バッジ更新）。v3.2.61: Cron登録後 Cloud Schedule 自動同期 / [6] 一括同期追加。v3.2.60: プロジェクト選択に戻る・Cron登録状況バッジ追加。詳細は [`CHANGELOG.md`](./CHANGELOG.md) を参照。
 
 > **📨 v3.2.0 — Cron HTML メールレポート (Visual Recap Mail)**
 > Cron で起動された ClaudeCode セッションの完了時に、**HTML 形式のレポートメール** を Gmail SMTP 経由で送信。アイコン+色付き表組み+実行サマリ(Monitor/Development/Verify/Improvement の出現回数/エラー検出/STABLE 達成)+次フェーズ提案を含む。送信先は `CLAUDEOS_DEFAULT_TO`(未設定時 `CLAUDEOS_SMTP_USER`)で指定し、SMTP 認証情報は `~/.env-claudeos` の Linux 環境変数で管理(config.json には書かない設計)。詳細は [`docs/common/16_HTMLメールレポート設定.md`](./docs/common/16_HTMLメールレポート設定.md) を参照。
@@ -27,7 +27,7 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.2.59** (Cloud Schedule 動的プロジェクト選択 / Cron バッジ / 戻るボタン) — 旧: v3.2.58 ([4]管理メニュー拡張) / v3.2.57 (Cloud Schedule 移行) |
+| バージョン | **v3.2.62** (Cron全同期→プロジェクト選択画面 / 空URL・関数順序バグ修正) — 旧: v3.2.61 (Cron登録後自動同期) / v3.2.60 (戻るボタン・Cronバッジ) |
 | テスト | **680件** — Pester (Unit 17 / Integration 11 / Smoke 1) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | v8 (Opus 4.7 最適化 / Token 1.35x 補正 / Agent Teams 並列 spawn / `/compact` 事前発動 / `task_budget` / 1H cache / `/ultrareview` / PreCompact hook / `/recap` fallback / Push Notification / Effort 動的切替) |

--- a/TASKS.md
+++ b/TASKS.md
@@ -81,6 +81,9 @@
 72. [DONE] [Priority:P1][Owner:Developer][Source:Manual] v3.2.57 /loop → Cloud Schedule 移行 — New-CloudSchedule.ps1 新規作成 / S1専用・週6日・300分制限 / Cloudflare 403 を claude -p 中継で回避 / CI SUCCESS (commit ee6f79b, PR #213)
 73. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.58 Cloud Schedule [4] 管理メニュー拡張 — OFF/ON/DEL/OFFA/ONA/DELA の6操作追加 / CI SUCCESS (commit 9b0e56a, PR #217)
 74. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.59 プロジェクト選択を Cloud Schedule から動的読み込みに変更 — RemoteTrigger + Cron バッジ表示 / [0]戻る追加 / CI SUCCESS (commit c5987fb, PR #218)
+75. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.60 プロジェクト選択に戻る・Cron登録状況バッジを追加 — Select-Project: [0]戻る / ☁⏱バッジ表示 / 空URL戻り値対応 / CI SUCCESS (commit ce19dbd, PR #219)
+76. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.61 Cron登録後Cloud Schedule自動同期 / [6]一括同期 / owner抽出修正 — Invoke-CloudRegister後Invoke-CronAllSync呼出 / Show-CloudScheduleMenu [6]追加 / SSH URL正規表現修正 / CI SUCCESS (commit 5a0124d, PR #221)
+77. [DONE] [Priority:P1][Owner:Developer][Source:Manual] v3.2.62 Cron全同期をプロジェクト選択画面に移動・空URL/関数順序バグ修正 — Select-Project に [S] + while ループ / Invoke-CronAllSync を Select-Project より前に移動 / 空URL exit 0 ガード / Show-CloudScheduleMenu から [6] 削除 / CI SUCCESS (commit e5ee3a0, PR #222)
 
 ## Auto Extracted From Agent Teams Matrix
 


### PR DESCRIPTION
## Summary
- `CHANGELOG.md`: v3.2.60 / v3.2.61 / v3.2.62 のエントリを追加（Monitor フェーズで検出したドキュメントドリフト解消）
- `README.md`: バージョンバッジを v3.2.59 → v3.2.62 に更新、最新変更内容の説明文を反映
- `TASKS.md`: タスク75〜77 (v3.2.60〜v3.2.62) を追加

## 背景
CI の `check-doc-versions.js` は README ↔ CHANGELOG のバージョン番号一致のみを検証するため、両方が v3.2.59 のままでも CI が通ってしまっていた。Monitor フェーズで実際の最新コミット (e5ee3a0 = v3.2.62) との乖離を検出し、本PRで補完。

## Test plan
- [ ] CI (`test-and-validate`) が SUCCESS であること
- [ ] `check-doc-versions.js` が README v3.2.62 ↔ CHANGELOG v3.2.62 で一致を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v3.2.60-v3.2.62

* **新機能**
  * プロジェクト選択画面に「戻る」オプションを追加
  * Cron登録状況をバッジで表示
  * Cron全同期をプロジェクト選択画面に移動し、同期後にリストを自動更新

* **バグ修正**
  * 「戻る」選択時の空URL処理を改善
  * SSH形式URLでのCron情報抽出の不具合を修正
  * Cron登録後の自動同期機能を実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->