### PR TITLE
feat(v3.2.64): 管理操作（OFFA/ONA/DELA）をプロジェクトスコープに限定

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 # CHANGELOG
 
+## [v3.2.64] - 2026-04-21 — 管理操作（OFFA/ONA/DELA）をプロジェクトスコープに限定
+
+### 🎯 概要
+`[4] 管理` の全一括操作（OFFA/ONA/DELA）が全プロジェクトのトリガーに影響していた問題を修正。現在選択中のプロジェクトのトリガーのみを対象とするようプロンプトを変更。確認ダイアログにプロジェクト名を明示して誤操作を防止。
+
+### 🔧 変更対象
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/main/New-CloudSchedule.ps1` | Invoke-CloudManage: OFFA/ONA/DELA プロンプトに `$script:RepoShortName` / `$script:RepoUrl` フィルタ追加 / 確認ダイアログにプロジェクト名明示 / 操作ヘッダーにプロジェクト名表示 |
+
+### ✅ テスト結果
+- PSScriptAnalyzer 0 warnings (non-WriteHost)
+
+---
+
 ## [v3.2.63] - 2026-04-21 — PSScriptAnalyzer 0警告達成・一覧表示をプロジェクト別フィルタに改善
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 > **📌 v3.1.0 で Claude Code 専用ツールに整理**
 > v3.1.0 より、Codex CLI / GitHub Copilot CLI の起動メニュー (S2/S3/L2/L3) は削除されました。本ツールは **Claude Code 専用の自律開発ランチャー** として位置づけを明確化し、Linux crontab 連携・セッション情報タブ・Statusline グローバル適用などの新機能に投資が集中しています。
 
-> **☁️ v3.2.63 — PSScriptAnalyzer 0警告達成・一覧表示をプロジェクト別フィルタに改善**
-> `New-CloudSchedule.ps1` / `New-CronSchedule.ps1` / `Watch-ClaudeLog.ps1` の PSScriptAnalyzer 警告を全解消（空catchブロック・BOM・関数名・SuppressMessage・`$using:`）。`[1] 一覧表示` を現在プロジェクトのみ表示するよう改善。v3.2.62: Cron全同期をプロジェクト選択画面に移動・空URL/関数順序バグ修正。詳細は [`CHANGELOG.md`](./CHANGELOG.md) を参照。
+> **☁️ v3.2.64 — 管理操作（OFFA/ONA/DELA）をプロジェクトスコープに限定**
+> `[4] 管理` の全一括操作が全プロジェクトに作用していた問題を修正。現在選択中のプロジェクトのみを対象とするよう変更し、確認ダイアログにプロジェクト名を明示。v3.2.63: PSScriptAnalyzer 0警告達成 / `[1] 一覧表示` プロジェクト別フィルタ改善。詳細は [`CHANGELOG.md`](./CHANGELOG.md) を参照。
 
 > **📨 v3.2.0 — Cron HTML メールレポート (Visual Recap Mail)**
 > Cron で起動された ClaudeCode セッションの完了時に、**HTML 形式のレポートメール** を Gmail SMTP 経由で送信。アイコン+色付き表組み+実行サマリ(Monitor/Development/Verify/Improvement の出現回数/エラー検出/STABLE 達成)+次フェーズ提案を含む。送信先は `CLAUDEOS_DEFAULT_TO`(未設定時 `CLAUDEOS_SMTP_USER`)で指定し、SMTP 認証情報は `~/.env-claudeos` の Linux 環境変数で管理(config.json には書かない設計)。詳細は [`docs/common/16_HTMLメールレポート設定.md`](./docs/common/16_HTMLメールレポート設定.md) を参照。
@@ -27,7 +27,7 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.2.63** (PSScriptAnalyzer 0警告達成 / 一覧表示プロジェクト別フィルタ改善) — 旧: v3.2.62 (Cron全同期→プロジェクト選択画面 / 空URL・関数順序バグ修正) |
+| バージョン | **v3.2.64** (管理OFFA/ONA/DELA操作をプロジェクトスコープに限定) — 旧: v3.2.63 (PSScriptAnalyzer 0警告達成 / 一覧表示プロジェクト別フィルタ改善) |
 | テスト | **680件** — Pester (Unit 17 / Integration 11 / Smoke 1) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | v8 (Opus 4.7 最適化 / Token 1.35x 補正 / Agent Teams 並列 spawn / `/compact` 事前発動 / `task_budget` / 1H cache / `/ultrareview` / PreCompact hook / `/recap` fallback / Push Notification / Effort 動的切替) |

--- a/TASKS.md
+++ b/TASKS.md
@@ -85,6 +85,7 @@
 76. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.61 Cron登録後Cloud Schedule自動同期 / [6]一括同期 / owner抽出修正 — Invoke-CloudRegister後Invoke-CronAllSync呼出 / Show-CloudScheduleMenu [6]追加 / SSH URL正規表現修正 / CI SUCCESS (commit 5a0124d, PR #221)
 77. [DONE] [Priority:P1][Owner:Developer][Source:Manual] v3.2.62 Cron全同期をプロジェクト選択画面に移動・空URL/関数順序バグ修正 — Select-Project に [S] + while ループ / Invoke-CronAllSync を Select-Project より前に移動 / 空URL exit 0 ガード / Show-CloudScheduleMenu から [6] 削除 / CI SUCCESS (commit e5ee3a0, PR #222)
 78. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.63 PSScriptAnalyzer 0警告達成・一覧表示プロジェクト別フィルタ改善 — 空catchブロック $null=$_ / UTF-8 BOM / New-LoopPreset 改名 / SuppressMessage 関数内移動 / Watch-ClaudeLog $using: / Invoke-CloudList プロジェクトフィルタ
+79. [DONE] [Priority:P1][Owner:Developer][Source:Manual] v3.2.64 管理操作（OFFA/ONA/DELA）をプロジェクトスコープに限定 — 全一括操作が全プロジェクトに影響する問題修正 / 確認ダイアログにプロジェクト名明示 / $script:RepoUrl フィルタ追加
 
 ## Auto Extracted From Agent Teams Matrix
 

--- a/scripts/main/New-CloudSchedule.ps1
+++ b/scripts/main/New-CloudSchedule.ps1
@@ -551,13 +551,13 @@ function Invoke-CloudRegisterAll {
 function Invoke-CloudManage {
     Invoke-CloudList
     Write-Host ""
-    Write-Host "  -- 操作を選択 --" -ForegroundColor Cyan
+    Write-Host "  -- 操作を選択 (プロジェクト: $script:RepoShortName) --" -ForegroundColor Cyan
     Write-Host "    [OFF]  無効化       (ID 指定 → enabled=false)" -ForegroundColor Yellow
     Write-Host "    [ON]   有効化       (ID 指定 → enabled=true)" -ForegroundColor Green
     Write-Host "    [DEL]  完全削除     (ID 指定 → API delete)" -ForegroundColor Red
-    Write-Host "    [OFFA] 全無効化     (全トリガー → enabled=false)" -ForegroundColor Yellow
-    Write-Host "    [ONA]  全有効化     (全トリガー → enabled=true)" -ForegroundColor Green
-    Write-Host "    [DELA] 全完全削除   (全トリガー → API delete)" -ForegroundColor Red
+    Write-Host "    [OFFA] 全無効化     (このプロジェクトの全トリガー → enabled=false)" -ForegroundColor Yellow
+    Write-Host "    [ONA]  全有効化     (このプロジェクトの全トリガー → enabled=true)" -ForegroundColor Green
+    Write-Host "    [DELA] 全完全削除   (このプロジェクトの全トリガー → API delete)" -ForegroundColor Red
     Write-Host "    [Enter] キャンセル" -ForegroundColor Gray
     Write-Host ""
     $op = (Read-Host "  操作を入力").Trim().ToUpper()
@@ -566,11 +566,13 @@ function Invoke-CloudManage {
 
     switch ($op) {
         'OFFA' {
-            $confirm = Read-Host "  全トリガーを無効化します。よろしいですか? [y/N]"
+            $confirm = Read-Host "  '$script:RepoShortName' の全トリガーを無効化します。よろしいですか? [y/N]"
             if ($confirm -notmatch '^[yY]') { Write-Host "  キャンセルしました。" -ForegroundColor Yellow; return }
-            Write-Host "  全無効化中..." -ForegroundColor Yellow
+            Write-Host "  全無効化中（プロジェクト: $script:RepoShortName）..." -ForegroundColor Yellow
             $out = Invoke-CloudCLI @"
-Use RemoteTrigger action='list', then for each trigger call action='update' with body={"enabled":false}.
+Use RemoteTrigger action='list'.
+Filter triggers to only those belonging to project '$script:RepoShortName' (repository: $script:RepoUrl).
+For each matching trigger, call action='update' with body={"enabled":false}.
 Output ONE line: DONE_ALL=<count>
 "@
             $line = $out | Where-Object { $_ -match '^DONE_ALL=' } | Select-Object -First 1
@@ -579,11 +581,13 @@ Output ONE line: DONE_ALL=<count>
             return
         }
         'ONA' {
-            $confirm = Read-Host "  全トリガーを有効化します。よろしいですか? [y/N]"
+            $confirm = Read-Host "  '$script:RepoShortName' の全トリガーを有効化します。よろしいですか? [y/N]"
             if ($confirm -notmatch '^[yY]') { Write-Host "  キャンセルしました。" -ForegroundColor Yellow; return }
-            Write-Host "  全有効化中..." -ForegroundColor Green
+            Write-Host "  全有効化中（プロジェクト: $script:RepoShortName）..." -ForegroundColor Green
             $out = Invoke-CloudCLI @"
-Use RemoteTrigger action='list', then for each trigger call action='update' with body={"enabled":true}.
+Use RemoteTrigger action='list'.
+Filter triggers to only those belonging to project '$script:RepoShortName' (repository: $script:RepoUrl).
+For each matching trigger, call action='update' with body={"enabled":true}.
 Output ONE line: DONE_ALL=<count>
 "@
             $line = $out | Where-Object { $_ -match '^DONE_ALL=' } | Select-Object -First 1
@@ -592,12 +596,13 @@ Output ONE line: DONE_ALL=<count>
             return
         }
         'DELA' {
-            $confirm = Read-Host "  全トリガーを完全削除します。元に戻せません。よろしいですか? [y/N]"
+            $confirm = Read-Host "  '$script:RepoShortName' の全トリガーを完全削除します。元に戻せません。よろしいですか? [y/N]"
             if ($confirm -notmatch '^[yY]') { Write-Host "  キャンセルしました。" -ForegroundColor Yellow; return }
-            Write-Host "  全完全削除中..." -ForegroundColor Red
+            Write-Host "  全完全削除中（プロジェクト: $script:RepoShortName）..." -ForegroundColor Red
             $out = Invoke-CloudCLI @"
-Use RemoteTrigger action='list' to get all trigger IDs.
-For each trigger ID, attempt to permanently delete it using RemoteTrigger.
+Use RemoteTrigger action='list'.
+Filter triggers to only those belonging to project '$script:RepoShortName' (repository: $script:RepoUrl).
+For each matching trigger ID, attempt to permanently delete it using RemoteTrigger.
 If permanent deletion is not supported by the API, disable it with action='update' body={"enabled":false} instead.
 Output ONE line: DONE_ALL=<count>
 "@


### PR DESCRIPTION
## Summary

- **OFFA/ONA/DELA が全プロジェクトのトリガーに作用していた問題を修正**: 現在選択中のプロジェクト (`$script:RepoShortName`) のトリガーのみを操作するよう変更
- **確認ダイアログにプロジェクト名明示**: `'ITSM-System' の全トリガーを無効化します` のように表示して誤操作を防止
- **操作ヘッダーにプロジェクト名表示**: `-- 操作を選択 (プロジェクト: ITSM-System) --`
- **メニュー説明文を更新**: `全トリガー` → `このプロジェクトの全トリガー`

## 修正背景

v3.2.63 で `[1] 一覧表示` をプロジェクト別フィルタにしたが、`[4] 管理` の OFFA/ONA/DELA は引き続き全プロジェクトの全トリガーを操作していた。例えば ITSM-System を選択して `DELA` を実行すると Construction-DX-OS の有効な 4 本のトリガーまで削除されるリスクがあった。

## Test plan

- [x] PSScriptAnalyzer 0 warnings (non-WriteHost) 確認済み
- [x] doc-version check PASSED (README=v3.2.64, CHANGELOG=v3.2.64)
- [ ] CI SUCCESS 待ち

🤖 Generated with [Claude Code](https://claude.com/claude-code)