### PR TITLE
test(v3.2.66): WorktreeManager.psm1 テストカバレッジ拡充 — Get-WorktreeSummary / edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 # CHANGELOG
 
+## [v3.2.66] - 2026-04-22 — WorktreeManager.psm1 テストカバレッジ拡充
+
+### 🎯 概要
+`scripts/lib/WorktreeManager.psm1`（375行・7関数）のテストが `Get-WorktreeBasePath` 3件のみだった問題を解消。`Get-WorktreeSummary`（`Mock -ModuleName WorktreeManager` でモック注入）と `Get-WorktreeBasePath` edge cases を追加し、14 テストケースに拡充。
+
+### 🔧 変更対象
+| ファイル | 変更内容 |
+|---|---|
+| `tests/unit/WorktreeManager.Tests.ps1` | `Get-WorktreeBasePath` edge cases +2件 / `Get-WorktreeSummary` 9件追加 = 計 14 テストケース |
+
+### ✅ テスト結果
+- Pester: 14/14 passed
+- PSScriptAnalyzer 0 warnings (PSUseBOMForUnicodeEncodedFile 対応済み)
+
+---
+
 ## [v3.2.65] - 2026-04-21 — New-CloudSchedule.ps1 ユニットテスト追加
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 > **📌 v3.1.0 で Claude Code 専用ツールに整理**
 > v3.1.0 より、Codex CLI / GitHub Copilot CLI の起動メニュー (S2/S3/L2/L3) は削除されました。本ツールは **Claude Code 専用の自律開発ランチャー** として位置づけを明確化し、Linux crontab 連携・セッション情報タブ・Statusline グローバル適用などの新機能に投資が集中しています。
 
-> **☁️ v3.2.64 — 管理操作（OFFA/ONA/DELA）をプロジェクトスコープに限定**
-> `[4] 管理` の全一括操作が全プロジェクトに作用していた問題を修正。現在選択中のプロジェクトのみを対象とするよう変更し、確認ダイアログにプロジェクト名を明示。v3.2.63: PSScriptAnalyzer 0警告達成 / `[1] 一覧表示` プロジェクト別フィルタ改善。詳細は [`CHANGELOG.md`](./CHANGELOG.md) を参照。
+> **🧪 v3.2.66 — WorktreeManager.psm1 テストカバレッジ拡充**
+> `Get-WorktreeSummary`（`Mock -ModuleName` 注入）と `Get-WorktreeBasePath` edge cases を追加し 14 テストケースに拡充。v3.2.65: New-CloudSchedule.ps1 ユニットテスト 23件追加（dot-source exit→return パッチ戦略）。詳細は [`CHANGELOG.md`](./CHANGELOG.md) を参照。
 
 > **📨 v3.2.0 — Cron HTML メールレポート (Visual Recap Mail)**
 > Cron で起動された ClaudeCode セッションの完了時に、**HTML 形式のレポートメール** を Gmail SMTP 経由で送信。アイコン+色付き表組み+実行サマリ(Monitor/Development/Verify/Improvement の出現回数/エラー検出/STABLE 達成)+次フェーズ提案を含む。送信先は `CLAUDEOS_DEFAULT_TO`(未設定時 `CLAUDEOS_SMTP_USER`)で指定し、SMTP 認証情報は `~/.env-claudeos` の Linux 環境変数で管理(config.json には書かない設計)。詳細は [`docs/common/16_HTMLメールレポート設定.md`](./docs/common/16_HTMLメールレポート設定.md) を参照。
@@ -27,8 +27,8 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.2.65** (New-CloudSchedule.ps1 ユニットテスト 23件追加) — 旧: v3.2.64 (管理OFFA/ONA/DELA操作をプロジェクトスコープに限定) |
-| テスト | **703件** — Pester (Unit 18 / Integration 11 / Smoke 1) |
+| バージョン | **v3.2.66** (WorktreeManager.psm1 テストカバレッジ拡充 14件) — 旧: v3.2.65 (New-CloudSchedule.ps1 ユニットテスト 23件追加) |
+| テスト | **714件** — Pester (Unit 18 / Integration 11 / Smoke 1) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | v8 (Opus 4.7 最適化 / Token 1.35x 補正 / Agent Teams 並列 spawn / `/compact` 事前発動 / `task_budget` / 1H cache / `/ultrareview` / PreCompact hook / `/recap` fallback / Push Notification / Effort 動的切替) |
 | Agents | **25体** の特化サブエージェント (2026Q2 棚卸し後、追加復元済み) |

--- a/TASKS.md
+++ b/TASKS.md
@@ -87,6 +87,7 @@
 78. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.63 PSScriptAnalyzer 0警告達成・一覧表示プロジェクト別フィルタ改善 — 空catchブロック $null=$_ / UTF-8 BOM / New-LoopPreset 改名 / SuppressMessage 関数内移動 / Watch-ClaudeLog $using: / Invoke-CloudList プロジェクトフィルタ
 79. [DONE] [Priority:P1][Owner:Developer][Source:Manual] v3.2.64 管理操作（OFFA/ONA/DELA）をプロジェクトスコープに限定 — 全一括操作が全プロジェクトに影響する問題修正 / 確認ダイアログにプロジェクト名明示 / $script:RepoUrl フィルタ追加
 80. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#226] v3.2.65 New-CloudSchedule.ps1 ユニットテスト追加 — Build-CreatePrompt / New-LoopPreset の 23 テストケース / dot-source exit→return パッチ戦略 / PSScriptAnalyzer 0警告
+81. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#228] v3.2.66 WorktreeManager.psm1 テストカバレッジ拡充 — Get-WorktreeSummary 9件（Mock -ModuleName WorktreeManager）/ Get-WorktreeBasePath edge cases +2件 = 計 14 テストケース / PSScriptAnalyzer 0警告 / STABLE N=3達成
 
 ## Auto Extracted From Agent Teams Matrix
 

--- a/tests/unit/WorktreeManager.Tests.ps1
+++ b/tests/unit/WorktreeManager.Tests.ps1
@@ -1,6 +1,6 @@
-# ============================================================
+﻿# ============================================================
 # WorktreeManager.Tests.ps1 - WorktreeManager.psm1 unit tests
-# Pester 5.x  /  Phase 4 unit tests
+# Pester 5.x  /  Issue #228
 # ============================================================
 
 BeforeAll {
@@ -9,6 +9,9 @@ BeforeAll {
     Import-Module $script:ModulePath -Force
 }
 
+# ============================================================
+# Get-WorktreeBasePath
+# ============================================================
 Describe 'Get-WorktreeBasePath' {
 
     It 'returns path ending with .worktrees when RepoRoot is supplied' {
@@ -25,5 +28,99 @@ Describe 'Get-WorktreeBasePath' {
         $result = Get-WorktreeBasePath -RepoRoot 'C:\Users\kensan\repos\my-project'
         $result | Should -Match 'my-project'
         $result | Should -Match '\.worktrees$'
+    }
+
+    It 'handles paths with spaces correctly' {
+        $result = Get-WorktreeBasePath -RepoRoot 'C:\my repos\project'
+        $result | Should -Be (Join-Path 'C:\my repos\project' '.worktrees')
+    }
+
+    It 'preserves deep nested paths and appends .worktrees' {
+        $result = Get-WorktreeBasePath -RepoRoot 'D:\a\b\c\d\project'
+        $result | Should -Match 'project'
+        $result | Should -Match '\.worktrees$'
+    }
+}
+
+# ============================================================
+# Get-WorktreeSummary
+# ============================================================
+Describe 'Get-WorktreeSummary' {
+
+    It 'returns one summary object per worktree' {
+        Mock -ModuleName WorktreeManager Get-Worktree {
+            @(
+                [pscustomobject]@{ Path = 'C:\repo'; Commit = 'abc1234def0'; Branch = 'main';       IsBare = $false; IsMain = $true  },
+                [pscustomobject]@{ Path = 'C:\repo\.worktrees\feat'; Commit = 'xyz5678abc0'; Branch = 'feat/my-feat'; IsBare = $false; IsMain = $false }
+            )
+        }
+        $result = Get-WorktreeSummary -RepoRoot 'C:\repo'
+        $result.Count | Should -Be 2
+    }
+
+    It 'sets Label to [MAIN] for the main worktree' {
+        Mock -ModuleName WorktreeManager Get-Worktree {
+            @([pscustomobject]@{ Path = 'C:\repo'; Commit = 'abc1234def0'; Branch = 'main'; IsBare = $false; IsMain = $true })
+        }
+        $result = Get-WorktreeSummary -RepoRoot 'C:\repo'
+        $result[0].Label | Should -Be '[MAIN]'
+    }
+
+    It 'sets Label to empty string for non-main worktrees' {
+        Mock -ModuleName WorktreeManager Get-Worktree {
+            @([pscustomobject]@{ Path = 'C:\repo\.worktrees\feat'; Commit = 'abc1234def0'; Branch = 'feat/test'; IsBare = $false; IsMain = $false })
+        }
+        $result = Get-WorktreeSummary -RepoRoot 'C:\repo'
+        $result[0].Label | Should -Be ''
+    }
+
+    It 'truncates Commit hash to 7 characters' {
+        Mock -ModuleName WorktreeManager Get-Worktree {
+            @([pscustomobject]@{ Path = 'C:\repo'; Commit = 'abc1234def567'; Branch = 'main'; IsBare = $false; IsMain = $true })
+        }
+        $result = Get-WorktreeSummary -RepoRoot 'C:\repo'
+        $result[0].Commit | Should -Be 'abc1234'
+        $result[0].Commit.Length | Should -Be 7
+    }
+
+    It 'returns (detached) when Branch is null' {
+        Mock -ModuleName WorktreeManager Get-Worktree {
+            @([pscustomobject]@{ Path = 'C:\repo\.worktrees\detach'; Commit = 'abc1234def0'; Branch = $null; IsBare = $false; IsMain = $false })
+        }
+        $result = Get-WorktreeSummary -RepoRoot 'C:\repo'
+        $result[0].Branch | Should -Be '(detached)'
+    }
+
+    It 'returns unknown when Commit is null' {
+        Mock -ModuleName WorktreeManager Get-Worktree {
+            @([pscustomobject]@{ Path = 'C:\repo'; Commit = $null; Branch = 'main'; IsBare = $false; IsMain = $true })
+        }
+        $result = Get-WorktreeSummary -RepoRoot 'C:\repo'
+        $result[0].Commit | Should -Be 'unknown'
+    }
+
+    It 'preserves the Path property from worktree data' {
+        Mock -ModuleName WorktreeManager Get-Worktree {
+            @([pscustomobject]@{ Path = 'C:\repo\.worktrees\my-feat'; Commit = 'abc1234def0'; Branch = 'feat/x'; IsBare = $false; IsMain = $false })
+        }
+        $result = Get-WorktreeSummary -RepoRoot 'C:\repo'
+        $result[0].Path | Should -Be 'C:\repo\.worktrees\my-feat'
+    }
+
+    It 'returns empty array when no worktrees exist' {
+        Mock -ModuleName WorktreeManager Get-Worktree { @() }
+        $result = Get-WorktreeSummary -RepoRoot 'C:\repo'
+        @($result).Count | Should -Be 0
+    }
+
+    It 'each summary object has Branch Commit Path Label properties' {
+        Mock -ModuleName WorktreeManager Get-Worktree {
+            @([pscustomobject]@{ Path = 'C:\repo'; Commit = 'abc1234def0'; Branch = 'main'; IsBare = $false; IsMain = $true })
+        }
+        $result = Get-WorktreeSummary -RepoRoot 'C:\repo'
+        $result[0].PSObject.Properties.Name | Should -Contain 'Branch'
+        $result[0].PSObject.Properties.Name | Should -Contain 'Commit'
+        $result[0].PSObject.Properties.Name | Should -Contain 'Path'
+        $result[0].PSObject.Properties.Name | Should -Contain 'Label'
     }
 }


### PR DESCRIPTION
## 概要

`scripts/lib/WorktreeManager.psm1`（375行・7関数）のテストが `Get-WorktreeBasePath` 3件のみだった問題を解消します（Issue #228）。

`Mock -ModuleName WorktreeManager Get-Worktree` を使い、git コマンドに依存せず `Get-WorktreeSummary` の変換ロジックを純粋に検証。

## 変更内容

- `tests/unit/WorktreeManager.Tests.ps1` 拡充（3 → 14 テストケース）
  - `Get-WorktreeBasePath`: edge cases +2件（スペース入りパス / 深いネスト）
  - `Get-WorktreeSummary`: 9件新規（`[MAIN]` ラベル / コミット7文字切り詰め / `(detached)` フォールバック / `unknown` コミット / Path 保持 / 空配列 / プロパティ検証）
- `CHANGELOG.md`: v3.2.66 エントリ追加
- `README.md`: バージョン v3.2.66、テスト件数 714 件に更新
- `TASKS.md`: タスク #81 追加

## テスト結果

- Pester: **14/14 passed**
- PSScriptAnalyzer: **0 warnings**

## 影響範囲

テストファイル更新のみ。既存スクリプトへの変更なし。

## Closes

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v3.2.66 リリースノート

* **Tests**
  * テストカバレッジを拡充し、合計テストケース数を 703 から 714 に増加しました。エッジケースを含む包括的な検証により、品質を向上させました。

* **Documentation**
  * バージョン情報をv3.2.66に更新し、各ドキュメントの内容を最新化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->