### PR TITLE
test(v3.2.67): RecentProjects.ps1 ユニットテスト追加 — 17件 / Issue #230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 # CHANGELOG
 
+## [v3.2.67] - 2026-04-22 — RecentProjects.ps1 ユニットテスト追加
+
+### 🎯 概要
+`scripts/lib/RecentProjects.ps1`（173行・3関数）のユニットテストがゼロだった問題を解消。
+`Get-RecentProject`（JSON 正規化・legacy/object 両形式・エラー抑制）、`Update-RecentProject`（先頭挿入・重複削除・MaxHistory 上限）、`Test-RecentProjectsEnabled`（Config 判定）を対象に 17 テストケースを追加。
+
+### 🔧 変更対象
+| ファイル | 変更内容 |
+|---|---|
+| `tests/unit/RecentProjects.Tests.ps1` | 新規作成: `Get-RecentProject` 9件 + `Update-RecentProject` 4件 + `Test-RecentProjectsEnabled` 3件 = 17 テストケース |
+
+### ✅ テスト結果
+- Pester: 17/17 passed
+- PSScriptAnalyzer 0 warnings
+
+---
+
 ## [v3.2.66] - 2026-04-22 — WorktreeManager.psm1 テストカバレッジ拡充
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 > **📌 v3.1.0 で Claude Code 専用ツールに整理**
 > v3.1.0 より、Codex CLI / GitHub Copilot CLI の起動メニュー (S2/S3/L2/L3) は削除されました。本ツールは **Claude Code 専用の自律開発ランチャー** として位置づけを明確化し、Linux crontab 連携・セッション情報タブ・Statusline グローバル適用などの新機能に投資が集中しています。
 
-> **🧪 v3.2.66 — WorktreeManager.psm1 テストカバレッジ拡充**
-> `Get-WorktreeSummary`（`Mock -ModuleName` 注入）と `Get-WorktreeBasePath` edge cases を追加し 14 テストケースに拡充。v3.2.65: New-CloudSchedule.ps1 ユニットテスト 23件追加（dot-source exit→return パッチ戦略）。詳細は [`CHANGELOG.md`](./CHANGELOG.md) を参照。
+> **🧪 v3.2.67 — RecentProjects.ps1 ユニットテスト追加**
+> `Get-RecentProject` 9件 + `Update-RecentProject` 4件 + `Test-RecentProjectsEnabled` 3件 = 17 テストケースを新規追加。v3.2.66: WorktreeManager.psm1 テストカバレッジ拡充 14件。詳細は [`CHANGELOG.md`](./CHANGELOG.md) を参照。
 
 > **📨 v3.2.0 — Cron HTML メールレポート (Visual Recap Mail)**
 > Cron で起動された ClaudeCode セッションの完了時に、**HTML 形式のレポートメール** を Gmail SMTP 経由で送信。アイコン+色付き表組み+実行サマリ(Monitor/Development/Verify/Improvement の出現回数/エラー検出/STABLE 達成)+次フェーズ提案を含む。送信先は `CLAUDEOS_DEFAULT_TO`(未設定時 `CLAUDEOS_SMTP_USER`)で指定し、SMTP 認証情報は `~/.env-claudeos` の Linux 環境変数で管理(config.json には書かない設計)。詳細は [`docs/common/16_HTMLメールレポート設定.md`](./docs/common/16_HTMLメールレポート設定.md) を参照。
@@ -27,8 +27,8 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.2.66** (WorktreeManager.psm1 テストカバレッジ拡充 14件) — 旧: v3.2.65 (New-CloudSchedule.ps1 ユニットテスト 23件追加) |
-| テスト | **714件** — Pester (Unit 18 / Integration 11 / Smoke 1) |
+| バージョン | **v3.2.67** (RecentProjects.ps1 ユニットテスト 17件追加) — 旧: v3.2.66 (WorktreeManager.psm1 テストカバレッジ拡充 14件) |
+| テスト | **731件** — Pester (Unit 19 / Integration 11 / Smoke 1) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | v8 (Opus 4.7 最適化 / Token 1.35x 補正 / Agent Teams 並列 spawn / `/compact` 事前発動 / `task_budget` / 1H cache / `/ultrareview` / PreCompact hook / `/recap` fallback / Push Notification / Effort 動的切替) |
 | Agents | **25体** の特化サブエージェント (2026Q2 棚卸し後、追加復元済み) |

--- a/TASKS.md
+++ b/TASKS.md
@@ -88,6 +88,7 @@
 79. [DONE] [Priority:P1][Owner:Developer][Source:Manual] v3.2.64 管理操作（OFFA/ONA/DELA）をプロジェクトスコープに限定 — 全一括操作が全プロジェクトに影響する問題修正 / 確認ダイアログにプロジェクト名明示 / $script:RepoUrl フィルタ追加
 80. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#226] v3.2.65 New-CloudSchedule.ps1 ユニットテスト追加 — Build-CreatePrompt / New-LoopPreset の 23 テストケース / dot-source exit→return パッチ戦略 / PSScriptAnalyzer 0警告
 81. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#228] v3.2.66 WorktreeManager.psm1 テストカバレッジ拡充 — Get-WorktreeSummary 9件（Mock -ModuleName WorktreeManager）/ Get-WorktreeBasePath edge cases +2件 = 計 14 テストケース / PSScriptAnalyzer 0警告 / STABLE N=3達成
+82. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#230] v3.2.67 RecentProjects.ps1 ユニットテスト追加 — Get-RecentProject 9件（legacy/object 正規化・エラー抑制・env var展開）/ Update-RecentProject 4件（先頭挿入・重複削除・MaxHistory）/ Test-RecentProjectsEnabled 3件 = 計 17 テストケース / PSScriptAnalyzer 0警告
 
 ## Auto Extracted From Agent Teams Matrix
 

--- a/tests/unit/RecentProjects.Tests.ps1
+++ b/tests/unit/RecentProjects.Tests.ps1
@@ -1,0 +1,175 @@
+# ============================================================
+# RecentProjects.Tests.ps1 - RecentProjects.ps1 unit tests
+# Pester 5.x  /  Issue #230
+# ============================================================
+
+BeforeAll {
+    $script:RepoRoot   = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:ScriptPath = Join-Path $script:RepoRoot 'scripts\lib\RecentProjects.ps1'
+    . $script:ScriptPath
+}
+
+# ============================================================
+# Get-RecentProject
+# ============================================================
+Describe 'Get-RecentProject' {
+
+    It 'returns empty array when history file does not exist' {
+        $result = Get-RecentProject -HistoryPath 'C:\nonexistent\path\recent.json'
+        @($result).Count | Should -Be 0
+    }
+
+    It 'returns empty array when projects property is null' {
+        $tmpFile = Join-Path $TestDrive 'no-projects.json'
+        '{"projects":null}' | Set-Content -Path $tmpFile -Encoding UTF8
+        $result = Get-RecentProject -HistoryPath $tmpFile
+        @($result).Count | Should -Be 0
+    }
+
+    It 'returns empty array when projects key is missing' {
+        $tmpFile = Join-Path $TestDrive 'empty-root.json'
+        '{}' | Set-Content -Path $tmpFile -Encoding UTF8
+        $result = Get-RecentProject -HistoryPath $tmpFile
+        @($result).Count | Should -Be 0
+    }
+
+    It 'normalizes a legacy string entry to pscustomobject with null optional fields' {
+        $tmpFile = Join-Path $TestDrive 'legacy-string.json'
+        '{"projects":["MyProject"]}' | Set-Content -Path $tmpFile -Encoding UTF8
+        $result = Get-RecentProject -HistoryPath $tmpFile
+        $result[0].project   | Should -Be 'MyProject'
+        $result[0].tool      | Should -BeNullOrEmpty
+        $result[0].mode      | Should -BeNullOrEmpty
+        $result[0].timestamp | Should -BeNullOrEmpty
+        $result[0].result    | Should -BeNullOrEmpty
+        $result[0].elapsedMs | Should -BeNullOrEmpty
+    }
+
+    It 'normalizes an object entry with all fields' {
+        $tmpFile = Join-Path $TestDrive 'full-object.json'
+        $json = '{"projects":[{"project":"Proj","tool":"claude","mode":"local","timestamp":"2026-01-01T00:00:00Z","result":"success","elapsedMs":1234}]}'
+        $json | Set-Content -Path $tmpFile -Encoding UTF8
+        $result = Get-RecentProject -HistoryPath $tmpFile
+        $result[0].project   | Should -Be 'Proj'
+        $result[0].tool      | Should -Be 'claude'
+        $result[0].mode      | Should -Be 'local'
+        $result[0].result    | Should -Be 'success'
+        $result[0].elapsedMs | Should -Be 1234
+    }
+
+    It 'sets optional fields to null when missing from object entry' {
+        $tmpFile = Join-Path $TestDrive 'partial-object.json'
+        '{"projects":[{"project":"PartialProj"}]}' | Set-Content -Path $tmpFile -Encoding UTF8
+        $result = Get-RecentProject -HistoryPath $tmpFile
+        $result[0].project | Should -Be 'PartialProj'
+        $result[0].tool    | Should -BeNullOrEmpty
+        $result[0].mode    | Should -BeNullOrEmpty
+    }
+
+    It 'casts elapsedMs to int' {
+        $tmpFile = Join-Path $TestDrive 'elapsed.json'
+        '{"projects":[{"project":"P","elapsedMs":500}]}' | Set-Content -Path $tmpFile -Encoding UTF8
+        $result = Get-RecentProject -HistoryPath $tmpFile
+        $result[0].elapsedMs | Should -Be 500
+        $result[0].elapsedMs | Should -BeOfType [int]
+    }
+
+    It 'normalizes empty string tool/mode/result fields to null' {
+        $tmpFile = Join-Path $TestDrive 'empty-strings.json'
+        '{"projects":[{"project":"P","tool":"","mode":"","result":""}]}' | Set-Content -Path $tmpFile -Encoding UTF8
+        $result = Get-RecentProject -HistoryPath $tmpFile
+        $result[0].tool   | Should -BeNullOrEmpty
+        $result[0].mode   | Should -BeNullOrEmpty
+        $result[0].result | Should -BeNullOrEmpty
+    }
+
+    It 'returns empty array on invalid JSON (error suppressed)' {
+        $tmpFile = Join-Path $TestDrive 'bad.json'
+        'NOT_VALID_JSON{{{' | Set-Content -Path $tmpFile -Encoding UTF8
+        $result = Get-RecentProject -HistoryPath $tmpFile
+        @($result).Count | Should -Be 0
+    }
+
+    It 'expands environment variable in HistoryPath' {
+        $tmpDir  = Join-Path $TestDrive 'env-expand'
+        New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+        $tmpFile = Join-Path $tmpDir 'recent.json'
+        '{"projects":["EnvProj"]}' | Set-Content -Path $tmpFile -Encoding UTF8
+        $env:PESTER_TEST_DIR_RP = $tmpDir
+        try {
+            $result = Get-RecentProject -HistoryPath '%PESTER_TEST_DIR_RP%\recent.json'
+            $result[0].project | Should -Be 'EnvProj'
+        }
+        finally {
+            Remove-Item Env:\PESTER_TEST_DIR_RP -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# ============================================================
+# Update-RecentProject
+# ============================================================
+Describe 'Update-RecentProject' {
+
+    It 'creates directory and file when they do not exist' {
+        $histPath = Join-Path $TestDrive 'new-dir\sub\recent.json'
+        Update-RecentProject -ProjectName 'NewProj' -HistoryPath $histPath
+        Test-Path $histPath | Should -BeTrue
+        $result = Get-RecentProject -HistoryPath $histPath
+        $result[0].project | Should -Be 'NewProj'
+    }
+
+    It 'inserts new entry at the front of the list' {
+        $histPath = Join-Path $TestDrive 'insert-front.json'
+        Update-RecentProject -ProjectName 'First'  -HistoryPath $histPath
+        Update-RecentProject -ProjectName 'Second' -HistoryPath $histPath
+        $result = Get-RecentProject -HistoryPath $histPath
+        $result[0].project | Should -Be 'Second'
+        $result[1].project | Should -Be 'First'
+    }
+
+    It 'removes duplicate entry before re-adding at front' {
+        $histPath = Join-Path $TestDrive 'dedup.json'
+        Update-RecentProject -ProjectName 'Alpha' -HistoryPath $histPath
+        Update-RecentProject -ProjectName 'Beta'  -HistoryPath $histPath
+        Update-RecentProject -ProjectName 'Alpha' -HistoryPath $histPath
+        $result = Get-RecentProject -HistoryPath $histPath
+        $result[0].project | Should -Be 'Alpha'
+        $result[1].project | Should -Be 'Beta'
+        @($result).Count   | Should -Be 2
+    }
+
+    It 'trims list to MaxHistory entries' {
+        $histPath = Join-Path $TestDrive 'maxhist.json'
+        1..5 | ForEach-Object { Update-RecentProject -ProjectName "P$_" -HistoryPath $histPath }
+        Update-RecentProject -ProjectName 'OverflowProject' -HistoryPath $histPath -MaxHistory 3
+        $result = Get-RecentProject -HistoryPath $histPath
+        @($result).Count   | Should -Be 3
+        $result[0].project | Should -Be 'OverflowProject'
+    }
+}
+
+# ============================================================
+# Test-RecentProjectsEnabled
+# ============================================================
+Describe 'Test-RecentProjectsEnabled' {
+
+    It 'returns true when enabled=true and historyFile is set' {
+        $config = [pscustomobject]@{
+            recentProjects = [pscustomobject]@{ enabled = $true; historyFile = 'some\path.json' }
+        }
+        Test-RecentProjectsEnabled -Config $config | Should -BeTrue
+    }
+
+    It 'returns false when recentProjects is null' {
+        $config = [pscustomobject]@{ recentProjects = $null }
+        Test-RecentProjectsEnabled -Config $config | Should -BeFalse
+    }
+
+    It 'returns false when enabled is false' {
+        $config = [pscustomobject]@{
+            recentProjects = [pscustomobject]@{ enabled = $false; historyFile = 'some\path.json' }
+        }
+        Test-RecentProjectsEnabled -Config $config | Should -BeFalse
+    }
+}


### PR DESCRIPTION
## 変更内容

`scripts/lib/RecentProjects.ps1`（173行・3関数）のユニットテストがゼロだった問題を解消。
`tests/unit/RecentProjects.Tests.ps1` を新規作成し、17 テストケースを追加。

### 新規テストファイル: `tests/unit/RecentProjects.Tests.ps1`

| Describe | テスト数 | 主なカバレッジ |
|----------|---------|--------------|
| `Get-RecentProject` | 9件 | ファイル不在・null projects・legacy string 正規化・object 正規化・env var 展開・不正 JSON 抑制・elapsedMs int キャスト・空文字→null 正規化 |
| `Update-RecentProject` | 4件 | ディレクトリ自動作成・先頭挿入・重複削除して先頭再挿入・MaxHistory 上限 |
| `Test-RecentProjectsEnabled` | 3件 | enabled=true/null/false の3分岐 |

## テスト結果

- **Pester: 17/17 passed**
- **PSScriptAnalyzer: 0 warnings**（ASCII-only のため UTF-8 BOM 不要）

## 影響範囲

- テストファイル新規追加のみ（`scripts/` 配下の変更なし）
- テスト総数: 714件 → **731件**

## 残課題

なし（Issue #230 クローズ予定）

Closes #230


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v3.2.67 リリースノート

* **Tests**
  * RecentProjects 機能に対する 17 件の新規ユニットテストを追加し、code quality の向上を実現

* **Documentation**
  * CHANGELOG、README、TASKS を v3.2.67 の情報に更新
  * 総テスト数を 731 件に拡大

<!-- end of auto-generated comment: release notes by coderabbit.ai -->