### PR TITLE
improve(v3.2.76): P1-3 ローカル cron レジストリ + P1-7 Agent Teams 使用ログ

### DIFF
--- a/.claude/claudeos/scripts/hooks/usage-tracker.js
+++ b/.claude/claudeos/scripts/hooks/usage-tracker.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// PostToolUse hook (ClaudeOS v8.2) — P1-7
+// Agent ツール呼び出しを検出し、learning.usage_history.agents に使用実績を記録する。
+// settings.json の PostToolUse で matcher: "Agent" として登録する。
+
+const fs = require("fs");
+const path = require("path");
+
+const STATE_FILE = path.join(process.cwd(), "state.json");
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonAtomic(file, data) {
+  const tmp = `${file}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n", "utf8");
+  fs.renameSync(tmp, file);
+}
+
+// Claude Code は PostToolUse hook 起動時に stdin から tool 情報を JSON で渡す
+let input = "";
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  try {
+    const hookData = JSON.parse(input);
+    const toolName  = hookData.tool_name || hookData.tool || "";
+    const toolInput = hookData.tool_input || hookData.input || {};
+
+    // Agent ツール以外はスキップ
+    if (!toolName.toLowerCase().includes("agent")) {
+      process.exit(0);
+    }
+
+    // subagent_type や description からエージェントロール名を推定
+    const subagentType = toolInput.subagent_type || "general-purpose";
+    const description  = (toolInput.description || "").slice(0, 80);
+    const agentKey     = subagentType.replace(/[^a-zA-Z0-9_-]/g, "_");
+
+    const state = readJson(STATE_FILE);
+    if (!state) { process.exit(0); }
+
+    state.learning = state.learning || {};
+    state.learning.usage_history = state.learning.usage_history || {};
+    state.learning.usage_history.agents = state.learning.usage_history.agents || {};
+
+    const agents = state.learning.usage_history.agents;
+    const now = new Date().toISOString();
+
+    if (!agents[agentKey]) {
+      agents[agentKey] = { call_count: 0, last_used: null, last_description: "" };
+    }
+    agents[agentKey].call_count += 1;
+    agents[agentKey].last_used = now;
+    if (description) agents[agentKey].last_description = description;
+
+    // セッション全体のカウンターも更新
+    agents._total_agent_calls = (agents._total_agent_calls || 0) + 1;
+    agents._last_agent_call_at = now;
+
+    writeJsonAtomic(STATE_FILE, state);
+    console.log(`[UsageTracker] agent=${agentKey} total_calls=${agents[agentKey].call_count}`);
+  } catch (err) {
+    // hook 失敗はサイレント（tool 実行をブロックしない）
+    console.error(`[UsageTracker] error: ${err.message}`);
+  }
+  process.exit(0);
+});
+
+// stdin が pipe されていない場合（直接実行）は即時終了
+if (process.stdin.isTTY) {
+  process.exit(0);
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/claudeos/scripts/hooks/usage-tracker.js"
+          }
+        ]
+      }
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 # CHANGELOG
 
+## [v3.2.76] - 2026-04-22 — P1-3 ローカル cron レジストリ + P1-7 Agent Teams 使用ログ
+
+### 🎯 概要
+P1-3: CronManager.psm1 にローカルレジストリ機能を追加し、SSH なしで Windows 側から登録済みプロジェクトを参照可能に。P1-7: usage-tracker.js を新規作成し、Agent ツール呼び出しを state.json の learning.usage_history.agents に記録する PostToolUse hook を実装。
+
+### 🔧 変更対象
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/lib/CronManager.psm1` | P1-3: Get-LocalCronRegistry / Add-LocalCronRegistryEntry / Remove-LocalCronRegistryEntry 追加。Add/Remove-ClaudeOSCronEntry から自動呼び出し |
+| `.claude/claudeos/scripts/hooks/usage-tracker.js` | P1-7: 新規作成。Agent ツール呼び出しを検出し learning.usage_history.agents に記録 |
+| `.claude/settings.json` | P1-7: PostToolUse[Agent] hook として usage-tracker.js を登録 |
+| `Claude/templates/claude/settings.json` | P1-7: テンプレートにも同設定を反映 |
+| `tests/unit/CronManager.Tests.ps1` | P1-3: Get-LocalCronRegistry テスト 6件追加 (33 → 39件) |
+| `README.md` | Hooks 構成を 4個に更新（usage-tracker 追加）、バージョン・テスト件数更新 |
+
+### ✅ テスト結果
+- Pester: 776/776 passed (新規 6件含む)
+- PSScriptAnalyzer: Error 0件
+
+---
+
 ## [v3.2.75] - 2026-04-22 — P1-2/4/5 state.json 連携強化 + P2-1/2/4 docs 整備
 
 ### 🎯 概要

--- a/Claude/templates/claude/settings.json
+++ b/Claude/templates/claude/settings.json
@@ -55,6 +55,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/claudeos/scripts/hooks/usage-tracker.js"
+          }
+        ]
+      }
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.2.75** (P1-2 state.json 自動生成 / P1-4 セッション状態復元 / P1-5 hooks 書き込み昇格 / P2-2 Codex optional / P2-4 タイムライン図) — 旧: v3.2.74 |
-| テスト | **768件** — Pester (Unit 21 / Integration 11 / Smoke 1) |
+| バージョン | **v3.2.76** (P1-3 ローカル cron レジストリ / P1-7 Agent Teams 使用ログ) — 旧: v3.2.75 |
+| テスト | **776件** — Pester (Unit 21 / Integration 11 / Smoke 1) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | v8 (Opus 4.7 最適化 / Token 1.35x 補正 / Agent Teams 並列 spawn / `/compact` 事前発動 / `task_budget` / 1H cache / `/ultrareview` / PreCompact hook / `/recap` fallback / Push Notification / Effort 動的切替) |
 | Agents | **25体** の特化サブエージェント (2026Q2 棚卸し後、追加復元済み) |
@@ -70,7 +70,7 @@
 | Orchestration | 1 | orchestrator |
 | Testing | 1 | qa |
 
-### Hooks 構成 (3個)
+### Hooks 構成 (4個)
 
 > `.claude/settings.json` の `hooks` セクションに登録済み。スクリプト本体は `.claude/claudeos/scripts/hooks/` に配置。
 
@@ -79,6 +79,7 @@
 | `session-start` | SessionStart | `session-start.js` | state.json から前回フェーズ・STABLE状態を読み込み表示。`current_session_start_at` と trigger (cron/manual) を書き込み |
 | `pre-compact` | PreCompact | `pre-compact.js` | compact 直前に state.json へタイムスタンプを記録 |
 | `session-end` | Stop | `session-end.js` | `last_stop_at` を state.json へ書き込み後、STABLE 通知を実行 |
+| `usage-tracker` | PostToolUse (Agent) | `usage-tracker.js` | Agent ツール呼び出しを検出し `learning.usage_history.agents` へ使用実績を記録 |
 
 ### Skills 構成
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -92,8 +92,8 @@
 83. [DONE] [Priority:P2][Owner:Developer][Source:GitHub#232] v3.2.68 ConfigSchema.ps1 ユニットテスト追加 + 完全自立開発対応確認 — Test-IntegerValueInRange 8件 / Test-StartupConfigSchema 22件 / Assert-StartupConfigSchema 4件 = 計 37 テストケース / テンプレート settings.json にフック定義追加 / CLAUDE.md スケジュール条件付き登録対応 / Start-ClaudeCode.ps1 START_PROMPT.md 自動再ビルド統合
 84. [DONE] [Priority:P1][Owner:Developer][Source:Manual] v3.2.74 P1-6 Codex optional化 + P2-3 完全自立チェックリスト + P1-1 Boot Sequence Step 5/6/8 実装 (PR #241)
 85. [DONE] [Priority:P1][Owner:Developer][Source:Manual] v3.2.75 P1-2 state.json 自動生成(New-CronSchedule) + P1-4 セッション状態復元(cron-launcher.sh) + P1-5 session-start.js 書き込み昇格 + P2-2 _header.md Codex optional + P2-4 README タイムライン図 + P2-1 テスト具体化
-86. [Priority:P2][Owner:Architect][Source:Manual] P1-3 登録プロジェクトレジストリ集中管理 — crontab ではなく Windows 側の registry.json で管理し SSH なしで確認できる仕組みの設計・実装
-87. [Priority:P2][Owner:Developer][Source:Manual] P1-7 Agent Teams 使用実績を state.json に記録 — usage_history.agents へのロギング実装（session-end.js または PostToolUse hook）
+86. [DONE] [Priority:P2][Owner:Architect][Source:Manual] v3.2.76 P1-3 登録プロジェクトレジストリ集中管理 — CronManager.psm1 に Get/Add/Remove-LocalCronRegistryEntry 追加。~/.claudeos/cron-registry.json を cron 登録/削除時に自動更新。ユニットテスト 6件 (776 PASS)
+87. [DONE] [Priority:P2][Owner:Developer][Source:Manual] v3.2.76 P1-7 Agent Teams 使用実績を state.json に記録 — usage-tracker.js 新規作成 / settings.json PostToolUse[Agent] hook 登録。learning.usage_history.agents に agentKey / call_count / last_used を記録 (776 PASS)
 
 ## Auto Extracted From Agent Teams Matrix
 
@@ -101,6 +101,9 @@
 ## GitHub Issues Sync
 
 (No open issues)
+
+
+
 
 
 

--- a/scripts/lib/CronManager.psm1
+++ b/scripts/lib/CronManager.psm1
@@ -14,6 +14,9 @@ $script:EntryPrefix = 'CLAUDEOS'
 $script:LauncherPath = '/home/kensan/.claudeos/cron-launcher.sh'
 $script:LogsDir = '/home/kensan/.claudeos/logs'
 
+# P1-3: ローカルレジストリパス（Windows 側キャッシュ）
+$script:LocalRegistryPath = Join-Path $env:USERPROFILE '.claudeos\cron-registry.json'
+
 <#
 .SYNOPSIS
     Overrides module-scope defaults for cron entry prefix, launcher path, and logs directory.
@@ -177,6 +180,12 @@ function Add-ClaudeOSCronEntry {
         throw "crontab 更新に失敗 (exit=$exitCode)"
     }
 
+    # P1-3: Windows 側のローカルレジストリにも記録
+    try {
+        Add-LocalCronRegistryEntry -Id $id -Project $Project -LinuxHost $LinuxHost `
+            -DayOfWeek $DayOfWeek -Time $Time -DurationMinutes $DurationMinutes
+    } catch { <# registry 更新失敗はサイレント無視 #> }
+
     return [pscustomobject]@{
         Id = $id
         Project = $Project
@@ -221,6 +230,10 @@ function Remove-ClaudeOSCronEntry {
     if ($exitCode -ne 0) {
         throw "crontab 更新に失敗 (exit=$exitCode)"
     }
+
+    # P1-3: Windows 側のローカルレジストリからも削除
+    try { Remove-LocalCronRegistryEntry -Id $Id } catch { <# サイレント無視 #> }
+
     return $removed
 }
 
@@ -238,6 +251,73 @@ function Remove-AllClaudeOSCronEntry {
         $count += Remove-ClaudeOSCronEntry -LinuxHost $LinuxHost -Id $e.Id
     }
     return $count
+}
+
+<#
+.SYNOPSIS
+    Reads the local Windows-side cron registry cache (~/.claudeos/cron-registry.json).
+#>
+function Get-LocalCronRegistry {
+    [OutputType([object[]])]
+    param()
+    if (-not (Test-Path $script:LocalRegistryPath)) { return @() }
+    try {
+        $raw = Get-Content $script:LocalRegistryPath -Raw -Encoding UTF8
+        $entries = $raw | ConvertFrom-Json
+        if ($null -eq $entries) { return @() }
+        return @($entries)
+    } catch {
+        return @()
+    }
+}
+
+<#
+.SYNOPSIS
+    Adds or updates a project entry in the local cron registry cache.
+#>
+function Add-LocalCronRegistryEntry {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal registry cache update; no user-facing state change')]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory)][string]$Id,
+        [Parameter(Mandatory)][string]$Project,
+        [Parameter(Mandatory)][string]$LinuxHost,
+        [int[]]$DayOfWeek = @(),
+        [string]$Time = '',
+        [int]$DurationMinutes = 300
+    )
+    $dir = Split-Path $script:LocalRegistryPath
+    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+
+    $entries = @(Get-LocalCronRegistry)
+    $entries = @($entries | Where-Object { $_.Id -ne $Id })
+    $entries += [pscustomobject]@{
+        Id              = $Id
+        Project         = $Project
+        LinuxHost       = $LinuxHost
+        DayOfWeek       = $DayOfWeek
+        Time            = $Time
+        DurationMinutes = $DurationMinutes
+        RegisteredAt    = (Get-Date -Format 'yyyy-MM-ddTHH:mm:ss')
+    }
+    $entries | ConvertTo-Json -Depth 5 | Set-Content $script:LocalRegistryPath -Encoding UTF8
+}
+
+<#
+.SYNOPSIS
+    Removes a project entry from the local cron registry cache by its ID.
+#>
+function Remove-LocalCronRegistryEntry {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal registry cache update; no user-facing state change')]
+    [OutputType([void])]
+    param([Parameter(Mandatory)][string]$Id)
+    $entries = @(Get-LocalCronRegistry)
+    $entries = @($entries | Where-Object { $_.Id -ne $Id })
+    if ($entries.Count -eq 0) {
+        Set-Content $script:LocalRegistryPath -Value '[]' -Encoding UTF8
+    } else {
+        $entries | ConvertTo-Json -Depth 5 | Set-Content $script:LocalRegistryPath -Encoding UTF8
+    }
 }
 
 <#
@@ -274,4 +354,7 @@ Export-ModuleMember -Function `
     Format-CronExpression, `
     Format-CronEntryForDisplay, `
     New-CronEntryId, `
-    Get-DayOfWeekLabel
+    Get-DayOfWeekLabel, `
+    Get-LocalCronRegistry, `
+    Add-LocalCronRegistryEntry, `
+    Remove-LocalCronRegistryEntry

--- a/tests/unit/CronManager.Tests.ps1
+++ b/tests/unit/CronManager.Tests.ps1
@@ -179,3 +179,80 @@ Describe 'Get-ClaudeOSCronEntry' {
         $result[0].Id | Should -Be 'myentry01'
     }
 }
+
+Describe 'Get-LocalCronRegistry (P1-3)' {
+
+    BeforeEach {
+        # テスト用一時ディレクトリにレジストリパスを向ける（$TestDrive を先に変数に捕捉してからスコープに渡す）
+        $tmpDir = Join-Path $TestDrive 'claudeos-registry'
+        New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+        $tmpRegistry = Join-Path $tmpDir 'cron-registry.json'
+        # 前回テストの残骸を削除
+        Remove-Item $tmpRegistry -Force -ErrorAction SilentlyContinue
+        # モジュールスコープ変数を差し替え
+        InModuleScope CronManager -Parameters @{ RegPath = $tmpRegistry } {
+            param($RegPath)
+            $script:LocalRegistryPath = $RegPath
+        }
+    }
+
+    It 'returns empty array when registry file does not exist' {
+        $result = Get-LocalCronRegistry
+        $result | Should -HaveCount 0
+    }
+
+    It 'returns entries written by Add-LocalCronRegistryEntry' {
+        Add-LocalCronRegistryEntry -Id 'test001' -Project 'MyProj' -LinuxHost 'server1' `
+            -DayOfWeek @(1, 3) -Time '21:00' -DurationMinutes 300
+
+        $result = Get-LocalCronRegistry
+        $result | Should -HaveCount 1
+        $result[0].Project | Should -Be 'MyProj'
+        $result[0].Id | Should -Be 'test001'
+        $result[0].LinuxHost | Should -Be 'server1'
+        $result[0].DurationMinutes | Should -Be 300
+    }
+
+    It 'Remove-LocalCronRegistryEntry removes the specified entry' {
+        Add-LocalCronRegistryEntry -Id 'del001' -Project 'DelProj' -LinuxHost 'srv' `
+            -DayOfWeek @(5) -Time '09:00' -DurationMinutes 120
+        Add-LocalCronRegistryEntry -Id 'keep001' -Project 'KeepProj' -LinuxHost 'srv' `
+            -DayOfWeek @(6) -Time '10:00' -DurationMinutes 60
+
+        Remove-LocalCronRegistryEntry -Id 'del001'
+
+        $result = Get-LocalCronRegistry
+        $result | Should -HaveCount 1
+        $result[0].Id | Should -Be 'keep001'
+    }
+
+    It 'Add-LocalCronRegistryEntry overwrites existing entry with same Id' {
+        Add-LocalCronRegistryEntry -Id 'upd001' -Project 'OldName' -LinuxHost 'h' `
+            -DayOfWeek @(1) -Time '08:00' -DurationMinutes 60
+        Add-LocalCronRegistryEntry -Id 'upd001' -Project 'NewName' -LinuxHost 'h' `
+            -DayOfWeek @(1) -Time '09:00' -DurationMinutes 120
+
+        $result = Get-LocalCronRegistry
+        $result | Should -HaveCount 1
+        $result[0].Project | Should -Be 'NewName'
+        $result[0].DurationMinutes | Should -Be 120
+    }
+
+    It 'Remove-LocalCronRegistryEntry on last entry writes empty array' {
+        Add-LocalCronRegistryEntry -Id 'only001' -Project 'Solo' -LinuxHost 'h' `
+            -DayOfWeek @(2) -Time '12:00' -DurationMinutes 300
+
+        Remove-LocalCronRegistryEntry -Id 'only001'
+
+        $result = Get-LocalCronRegistry
+        $result | Should -HaveCount 0
+    }
+
+    It 'RegisteredAt is set automatically' {
+        Add-LocalCronRegistryEntry -Id 'ts001' -Project 'TimeTest' -LinuxHost 'h' `
+            -DayOfWeek @(1) -Time '00:00' -DurationMinutes 300
+
+        $result = Get-LocalCronRegistry
+        $result[0].RegisteredAt | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary

- **P1-3**: `CronManager.psm1` にローカルレジストリ機能を追加。Windows 側 `~/.claudeos/cron-registry.json` に登録プロジェクトをキャッシュ。cron 登録/削除と同期して更新されるため SSH なしで確認可能。
- **P1-7**: `usage-tracker.js` 新規作成。`settings.json` に `PostToolUse[Agent]` hook として登録。Agent ツール呼び出し時に `learning.usage_history.agents` へ `agentKey / call_count / last_used` を記録。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `scripts/lib/CronManager.psm1` | Get/Add/Remove-LocalCronRegistryEntry 追加 |
| `.claude/claudeos/scripts/hooks/usage-tracker.js` | 新規作成 |
| `.claude/settings.json` + `Claude/templates/claude/settings.json` | PostToolUse[Agent] hook 追加 |
| `tests/unit/CronManager.Tests.ps1` | P1-3 テスト 6件追加 |

## Test plan

- [x] `Invoke-Pester` — 776/776 pass
- [x] `PSScriptAnalyzer` — 新規 Error なし
- [x] CronManager ユニットテスト 33 → 39件 (全 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Agent ツール呼び出しの使用実績を自動追跡し、学習履歴に記録
  * Windows 側でのローカル cron レジストリ管理機能を追加
* **テスト**
  * ユニットテスト 6 件を追加、全 776 テスト合格
* **ドキュメント**
  * v3.2.75 → v3.2.76 へ更新、ドキュメント改訂

<!-- end of auto-generated comment: release notes by coderabbit.ai -->