### PR TITLE
fix(v3.2.79): tmux pipe-pane でログ可視化 + cron-launcher.sh 自動同期

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 # CHANGELOG
 
+## [v3.2.79] - 2026-04-22 — tmux pipe-pane によるログ可視化 / cron-launcher.sh 自動同期
+
+### 🎯 概要
+`今すぐ実行` ([6]) 後に Watch-ClaudeLog.ps1 タブが空白になり Claude が起動していないように見える問題を修正。原因は `cron-launcher.sh` が Claude を tmux セッション内で起動するため stdout がログファイルに流れていなかったこと。`tmux pipe-pane` を追加して Claude の tmux pane 出力をログファイルに流すよう修正した。合わせて `cron-launcher.sh` の自動 Linux 同期機能を追加。
+
+### 🔧 変更対象
+| ファイル | 変更内容 |
+|---|---|
+| `Claude/templates/linux/cron-launcher.sh` | `tmux new-session` 直後に `tmux pipe-pane -t "$TMUX_SESSION" -o "cat >> '$LOG_FILE'"` を追加 |
+| `scripts/main/New-CronSchedule.ps1` | `Invoke-SyncLauncher` / `Invoke-SyncLauncherMenu` 追加。`Invoke-CronTest` から自動呼び出し。メニュー `[8] cron-launcher.sh を同期` 追加 |
+
+### 🔑 設計ポイント
+- `tmux pipe-pane -o` の `-o` フラグで pane 出力のみをキャプチャ（入力はキャプチャしない）
+- Claude の ANSI 出力がそのままログファイルに流れるため Windows Terminal の VT100 解釈でカラー表示
+- cron-launcher.sh の同期は START_PROMPT.md と同じ SSH stdin pipe 方式（SCP 非依存）
+
+### ✅ テスト結果
+- 稼働中セッションへの `tmux pipe-pane` 手動適用で cron-20260422-173116.log が 233B → 95KB に増加することを確認
+
+---
+
 ## [v3.2.78] - 2026-04-22 — Linux側 START_PROMPT.md 自動同期 / /loop スキルトリガー根本解消
 
 ### 🎯 概要

--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -254,6 +254,8 @@ if command -v tmux >/dev/null 2>&1 && [[ "${CLAUDEOS_TMUX:-1}" == "1" ]]; then
     -e "_CLAUDEOS_TMUX_DONE=$_TMUX_DONE" \
     -e "_CLAUDEOS_PROMPT_FILE=$PROMPT_FILE" \
     "$CLAUDE_WRAPPER" 2>>"$LOG_FILE"
+  # pipe-pane: tmux pane の出力をログファイルにも流す（Windows 側の Watch-ClaudeLog.ps1 で可視化するため）
+  tmux pipe-pane -t "$TMUX_SESSION" -o "cat >> '$LOG_FILE'" 2>>"$LOG_FILE" || true
   echo "[cron-launcher] tmux attach -t $TMUX_SESSION  (UI閲覧用)" >> "$LOG_FILE"
   # tmux セッション終了まで待機（タイムアウト付き: keeper消滅後の二重防護）
   if ! timeout $((DURATION_SEC + 60)) tmux wait-for "$_TMUX_DONE" 2>>"$LOG_FILE"; then

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.2.78** (START_PROMPT.md 自動 Linux 同期 / /loop スキル誤起動修正) — 旧: v3.2.76 |
+| バージョン | **v3.2.79** (tmux pipe-pane ログ可視化 / cron-launcher.sh 自動同期) — 旧: v3.2.78 |
 | テスト | **776件** — Pester (Unit 21 / Integration 11 / Smoke 1) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | v8 (Opus 4.7 最適化 / Token 1.35x 補正 / Agent Teams 並列 spawn / `/compact` 事前発動 / `task_budget` / 1H cache / `/ultrareview` / PreCompact hook / `/recap` fallback / Push Notification / Effort 動的切替) |

--- a/scripts/main/New-CronSchedule.ps1
+++ b/scripts/main/New-CronSchedule.ps1
@@ -61,6 +61,7 @@ function Show-CronMenu {
     Write-Host "    [5] 全解除" -ForegroundColor Yellow
     Write-Host "    [6] 今すぐ実行" -ForegroundColor Green
     Write-Host "    [7] START_PROMPT を同期" -ForegroundColor Cyan
+    Write-Host "    [8] cron-launcher.sh を同期" -ForegroundColor Cyan
     Write-Host "    [0] 戻る" -ForegroundColor Gray
     Write-Host ""
 }
@@ -232,6 +233,33 @@ function Invoke-SyncMenu {
     Invoke-SyncStartPrompt -Project $project
 }
 
+function Invoke-SyncLauncher {
+    $localFile = Join-Path $ScriptRoot 'Claude\templates\linux\cron-launcher.sh'
+    if (-not (Test-Path $localFile)) {
+        Write-Host "  [LAUNCHER] テンプレートが見つかりません: $localFile" -ForegroundColor Yellow
+        return
+    }
+    $sshExe  = if ($env:AI_STARTUP_SSH_EXE) { $env:AI_STARTUP_SSH_EXE } else { 'ssh' }
+    $sshOpts = @('-T', '-o', 'ConnectTimeout=10', '-o', 'StrictHostKeyChecking=accept-new', '-o', 'ControlMaster=no')
+    $claudeosDir = '/home/kensan/.claudeos'
+    & $sshExe @sshOpts $LinuxHost "mkdir -p '$claudeosDir'" 2>$null
+    $content = (Get-Content $localFile -Raw -Encoding UTF8) -replace "`r`n", "`n"
+    $content | & $sshExe @sshOpts $LinuxHost "cat > '$claudeosDir/cron-launcher.sh' && chmod +x '$claudeosDir/cron-launcher.sh'"
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  [LAUNCHER] Linux に同期しました: $claudeosDir/cron-launcher.sh" -ForegroundColor Green
+    } else {
+        Write-Host "  [LAUNCHER] 同期失敗 (exit=$LASTEXITCODE) — 手動で配備してください" -ForegroundColor Red
+    }
+}
+
+function Invoke-SyncLauncherMenu {
+    Write-Host ""
+    Write-Host "  cron-launcher.sh を Linux へ同期します" -ForegroundColor Cyan
+    $confirm = Read-Host "  実行しますか? [y/N]"
+    if ($confirm -ne 'y' -and $confirm -ne 'Y') { return }
+    Invoke-SyncLauncher
+}
+
 function Invoke-List {
     $entries = Get-ClaudeOSCronEntry -LinuxHost $LinuxHost
     Write-Host ""
@@ -350,10 +378,12 @@ function Invoke-CronTest {
         return
     }
 
-    # 起動前に START_PROMPT.md を最新テンプレートで同期
+    # 起動前に START_PROMPT.md と cron-launcher.sh を最新テンプレートで同期
     Write-Host ""
     Write-Host "  [同期中] START_PROMPT.md を Linux へ転送..." -ForegroundColor Cyan
     Invoke-SyncStartPrompt -Project $project
+    Write-Host "  [同期中] cron-launcher.sh を Linux へ転送..." -ForegroundColor Cyan
+    Invoke-SyncLauncher
 
     # SSH でバックグラウンド起動 (nohup で SSH 切断後も継続)
     $sshExe    = if ($env:AI_STARTUP_SSH_EXE) { $env:AI_STARTUP_SSH_EXE } else { 'ssh' }
@@ -410,6 +440,7 @@ while ($true) {
         '5' { Invoke-RemoveAll; Read-Host "  Enter で戻ります" | Out-Null }
         '6' { Invoke-CronTest; Read-Host "  Enter で戻ります" | Out-Null }
         '7' { Invoke-SyncMenu; Read-Host "  Enter で戻ります" | Out-Null }
+        '8' { Invoke-SyncLauncherMenu; Read-Host "  Enter で戻ります" | Out-Null }
         '0' { exit 0 }
         default {
             Write-Host "  無効な入力" -ForegroundColor Red


### PR DESCRIPTION
## 変更内容

### 問題
`[6] 今すぐ実行` 後に Watch-ClaudeLog.ps1 の Live-Log タブが空白のまま表示され、ユーザーには「Claudeが実行されていない」ように見えていた。

### 原因
`cron-launcher.sh` が Claude を **tmux セッション内**で起動するため、Claude の出力が tmux pane にのみ表示され、ログファイル（`cron-*.log`）には流れていなかった。Watch-ClaudeLog.ps1 はログファイルを `tail -F` で監視するため、実質何も表示されない状態になっていた。

### 修正
1. **`Claude/templates/linux/cron-launcher.sh`**: `tmux new-session` 直後に `tmux pipe-pane -t "$TMUX_SESSION" -o "cat >> '$LOG_FILE'"` を追加。Claude の tmux pane 出力がリアルタイムでログファイルに流れるようになる。
2. **`scripts/main/New-CronSchedule.ps1`**: `Invoke-SyncLauncher` / `Invoke-SyncLauncherMenu` を追加。メニュー `[8] cron-launcher.sh を同期` で手動同期可能。`[6] 今すぐ実行` 時に START_PROMPT.md と同時に自動同期。

## テスト結果
- 稼働中セッションへ手動で `tmux pipe-pane` を適用し、`cron-20260422-173116.log` が 233B → 95KB に増加することを確認
- PSScriptAnalyzer / Secrets scan / CodeRabbit — CI pass 予定

## 影響範囲
- `Claude/templates/linux/cron-launcher.sh` — 新規 Linux 展開時および `[8]` 手動同期で反映
- `scripts/main/New-CronSchedule.ps1` — `[6]` 実行時に cron-launcher.sh を自動同期

## 残課題
- なし（既存プロジェクトは `[8] cron-launcher.sh を同期` で更新可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v3.2.79 リリースノート

* **バグ修正**
  * tmux 環境での Claude ログ表示の可視性問題を改善しました。

* **新機能**
  * Linux 環境への cron-launcher スクリプト同期機能を追加しました。
  * 新しい同期メニューオプションを追加し、設定の一括管理が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->