### PR TITLE
fix(v3.2.98): Watch-ClaudeLog 起動時の15分制限を撤廃して即監視開始

### DIFF
--- a/scripts/tools/Watch-ClaudeLog.ps1
+++ b/scripts/tools/Watch-ClaudeLog.ps1
@@ -16,7 +16,9 @@
     Start-Process -ArgumentList で split される問題を回避)。
     v3.2.89 で stdbuf 依存を廃止。tail -F のみ SSH 実行し ANSI・\r フィルタを
     PowerShell 受信側で処理 (Linux 環境依存解消 / cron 発火タイミング修正)。
-    ClaudeOS v3.2.89
+    v3.2.98 で起動時の 15 分制限を撤廃。既存ログの有無・経過時間に関わらず
+    起動直後に最新ログを即監視開始するよう変更。
+    ClaudeOS v3.2.98
 .PARAMETER NewTab
     Windows Terminal の新規タブで開く（既定: 現在のウィンドウで実行）。
 .PARAMETER PollIntervalSeconds
@@ -286,16 +288,11 @@ function Open-SessionInfoTab {
 
 Write-WaitHeader
 
-$knownLog = Get-LatestLog
-# 起動時に15分以内のログがある場合は実行中と見なして即監視
-if ($knownLog -match 'cron-(\d{8}-\d{6})\.log$') {
-    $logTime = [datetime]::MinValue
-    $parsed  = [datetime]::TryParseExact($Matches[1], 'yyyyMMdd-HHmmss', $null,
-        [System.Globalization.DateTimeStyles]::None, [ref]$logTime)
-    if ($parsed -and ((Get-Date) - $logTime -lt [timespan]::FromMinutes(15))) {
-        $knownLog = ''  # 新規扱いにして直後のループで検出させる
-    }
-}
+# Always start with empty knownLog so the first loop iteration detects any existing
+# log as "new" and starts tailing immediately, regardless of how old it is.
+# This covers both: (a) opened before cron fires → waits then auto-tails,
+# (b) opened after cron already fired → tails the latest log right away.
+$knownLog = ''
 $dotCount = 0
 
 while ($true) {


### PR DESCRIPTION
## Summary

- `Watch-ClaudeLog.ps1` 起動時の 15分制限ロジックを撤廃
- `$knownLog = ''` に固定し、起動直後のループで最新ログを即検出・tail 開始するよう変更
- cron 発火時刻を過ぎてからメニュー 13 を開いた場合でも即座にログ表示される

## 変更内容

| ケース | 旧動作 | 新動作 |
|---|---|---|
| cron 発火前 3 分前に開く | 待機 → 発火で自動表示 ✅ | 同じ ✅ |
| cron 発火後 15 分以内に開く | 即監視開始 ✅ | 同じ ✅ |
| cron 発火後 15 分超えに開く | 次の cron まで永久待機 ❌ | 即監視開始 ✅ |

## 修正箇所

`scripts/tools/Watch-ClaudeLog.ps1` L289-298 → L291-295

旧コードは `Get-LatestLog` で既存ログを取得し、15 分以内のみ即監視していた。
新コードは `$knownLog = ''` 固定により、起動後の最初のループ反復で
`$latest ≠ ''` が成立して必ず即 tail 開始する。

## Test plan

- [ ] cron 発火前に開き → 発火後に自動でログ表示されることを確認
- [ ] cron 発火後（15 分超）に開き → 即座に最新ログが表示されることを確認
- [ ] 次の cron 発火時に自動切り替えされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)