### PR TITLE
fix(v3.2.101): cron-launcher.sh Permission denied 修正（bash明示 + 登録時デプロイ）

### DIFF
--- a/scripts/lib/CronManager.psm1
+++ b/scripts/lib/CronManager.psm1
@@ -164,7 +164,9 @@ function Add-ClaudeOSCronEntry {
     $id = New-CronEntryId
     $created = (Get-Date).ToString('yyyy-MM-ddTHH:mm:ss')
     $logFilePattern = "$($script:LogsDir)/cron-`$(date +\%Y\%m\%d-\%H\%M\%S).log"
-    $command = "$($script:LauncherPath) $Project $DurationMinutes >> $logFilePattern 2>&1"
+    # Use "bash script" explicitly so the cron entry works even if the execute bit
+    # is lost (e.g. after re-deploy without chmod +x).
+    $command = "bash $($script:LauncherPath) $Project $DurationMinutes >> $logFilePattern 2>&1"
 
     $commentLine = "# $($script:EntryPrefix):$id project=$Project duration=$DurationMinutes created=$created"
     $cronLine = "$cronExpr $command"

--- a/scripts/main/New-CronSchedule.ps1
+++ b/scripts/main/New-CronSchedule.ps1
@@ -145,6 +145,9 @@ function Invoke-Register {
         Write-Host "  [OK] Cron エントリを登録しました: ID=$($entry.Id)" -ForegroundColor Green
         Write-Host "  Linux cron が月〜土 / プロジェクト別 / 300分で自律実行します。" -ForegroundColor DarkGreen
 
+        # cron-launcher.sh を同期（chmod +x 含む）— 未デプロイだと cron が Permission denied で失敗するため必須
+        Write-Host "  [同期中] cron-launcher.sh を Linux へ転送..." -ForegroundColor Cyan
+        Invoke-SyncLauncher
         # P1-2: state.json が存在しない場合は自動生成
         Invoke-EnsureStateJson -Project $project
         # START_PROMPT.md を最新テンプレートで同期（Invoke-EnsureStateJson 未呼出し時のフォールバック）


### PR DESCRIPTION
## Summary

`cron-launcher.sh Permission denied` エラーの根本原因を2層で修正。

| 層 | 修正内容 | ファイル |
|---|---|---|
| ① | `Invoke-Register` に `Invoke-SyncLauncher` 追加 — 新規登録時に chmod+x 付きデプロイを保証 | `scripts/main/New-CronSchedule.ps1` |
| ② | cron コマンドを `bash /path/script` 形式に変更 — execute bit が失われても動作する | `scripts/lib/CronManager.psm1` |
| ③ | 既存 9 件の cron エントリを SSH sed で即時 `bash` 付きに更新済み | Linux crontab (直接適用済み) |

## 根本原因

`Invoke-Register` は `Invoke-SyncStartPrompt` を呼ぶが `Invoke-SyncLauncher` を呼ばなかった。
cron 登録後に `cron-launcher.sh` が未デプロイのまま、または execute bit なしの状態で cron が発火し、
`/bin/sh: 1: /home/kensan/.claudeos/cron-launcher.sh: Permission denied` が発生していた。

## Test plan

- [ ] 新規 cron 登録後に `cron-launcher.sh` が Linux へ転送・chmod+x されることを確認
- [ ] `0 19 * * 1,4 bash /home/kensan/.claudeos/cron-launcher.sh ...` 形式になることを確認
- [ ] 次回 cron 発火時に Permission denied が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Cron登録時のランチャー実行の安定性を向上。スクリプトの実行権限設定がない環境でも正常に動作するよう改善しました。
  * Cron登録後のランチャー同期処理を追加。環境設定がより確実に反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->