### PR TITLE
fix(v3.2.102): Watch-ClaudeLog 起動時検出とライブ検出を区別

### DIFF
--- a/scripts/tools/Watch-ClaudeLog.ps1
+++ b/scripts/tools/Watch-ClaudeLog.ps1
@@ -24,7 +24,10 @@
     v3.2.100 で3点修正: ①DisableQuickEdit 撤廃（コピペ可能化）、
     ②New-LocalLogFile を try/catch + fallback 化（Permission denied 解消）、
     ③Get-SessionIdForLog にリトライ追加（Session ID 取得競合解消）。
-    ClaudeOS v3.2.100
+    v3.2.102 で起動時検出とライブ検出を区別。起動時は既存ログを tail -n 0
+    （過去エラー再表示なし）+ Session ID スキップ、新規発火時は tail -n 50
+    で従来通り直近ログを表示する。
+    ClaudeOS v3.2.102
 .PARAMETER NewTab
     Windows Terminal の新規タブで開く（既定: 現在のウィンドウで実行）。
 .PARAMETER PollIntervalSeconds
@@ -306,12 +309,12 @@ function Open-SessionInfoTab {
 
 Write-WaitHeader
 
-# Always start with empty knownLog so the first loop iteration detects any existing
-# log as "new" and starts tailing immediately, regardless of how old it is.
-# This covers both: (a) opened before cron fires → waits then auto-tails,
-# (b) opened after cron already fired → tails the latest log right away.
-$knownLog = ''
-$dotCount = 0
+# $knownLog = '' causes the first loop iteration to detect any existing log as "new"
+# and start tailing immediately (v3.2.98). $isStartupDetection tracks whether the
+# upcoming detection is the on-startup one (existing log) vs a real live cron fire.
+$knownLog           = ''
+$isStartupDetection = $true
+$dotCount           = 0
 
 while ($true) {
     $latest = Get-LatestLog
@@ -319,18 +322,35 @@ while ($true) {
     # 新しいログが現れたら監視開始
     if ($latest -and ($latest -ne $knownLog)) {
         try { $null = New-LocalLogFile } catch { $script:LocalLogFile = '' }   # create a fresh local mirror file for this session
-        Write-LiveHeader -LogFile $latest
-        Write-Host "  新しいセッション検出: $latest" -ForegroundColor Green
 
-        if ($WithSessionInfoTab) {
-            Write-Host '  Session ID を取得中...' -ForegroundColor DarkGray
-            $sessionId = Get-SessionIdForLog -LogPath $latest
-            if ($sessionId) {
-                Open-TmuxAttachTab -SessionId $sessionId   # Tab ②: Claude UI (tmux attach)
-                Start-Sleep -Seconds 1
-                Open-SessionInfoTab -SessionId $sessionId  # Tab ③: Session Info
-            } else {
-                Write-Host '  [WARN] Session ID が見つかりませんでした。' -ForegroundColor Yellow
+        # Capture before modifying so the flag is correct in both branches.
+        $thisIsStartup      = $isStartupDetection
+        $isStartupDetection = $false   # all subsequent detections are live
+
+        if ($thisIsStartup) {
+            # Existing log found on startup: do NOT re-display historical content
+            # (tail -n 0) and skip Session ID lookup (session likely already over).
+            $tailLines = 0
+            Write-LiveHeader -LogFile $latest
+            Write-Host "  既存ログ接続中 (起動時検出)" -ForegroundColor DarkYellow
+            Write-Host "  過去ログの再表示はスキップします。新規書き込みを監視中..." -ForegroundColor DarkGray
+            Write-Host "  ログ内容確認は Local ファイルを参照してください。" -ForegroundColor DarkGray
+        } else {
+            # New log appeared while monitoring: real cron fire.
+            $tailLines = 50
+            Write-LiveHeader -LogFile $latest
+            Write-Host "  新しいセッション検出: $latest" -ForegroundColor Green
+
+            if ($WithSessionInfoTab) {
+                Write-Host '  Session ID を取得中...' -ForegroundColor DarkGray
+                $sessionId = Get-SessionIdForLog -LogPath $latest
+                if ($sessionId) {
+                    Open-TmuxAttachTab -SessionId $sessionId   # Tab ②: Claude UI (tmux attach)
+                    Start-Sleep -Seconds 1
+                    Open-SessionInfoTab -SessionId $sessionId  # Tab ③: Session Info
+                } else {
+                    Write-Host '  [WARN] Session ID が見つかりませんでした。' -ForegroundColor Yellow
+                }
             }
         }
 
@@ -344,7 +364,7 @@ while ($true) {
             [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
             [Console]::InputEncoding  = [System.Text.Encoding]::UTF8
             $OutputEncoding = [System.Text.Encoding]::UTF8
-            ssh $using:SshTarget "tail -n 50 -F '$($using:latest)'"
+            ssh $using:SshTarget "tail -n $($using:tailLines) -F '$($using:latest)'"
         }
 
         try {


### PR DESCRIPTION
## Summary

起動時に既存の古い失敗ログを毎回「新セッション」として検出し、
`tail -n 50` で過去のエラー内容（Permission denied 等）を再表示し続ける問題を修正。

## 変更内容

`$isStartupDetection` フラグで2ケースを明確に区別:

| 検出タイプ | tail 行数 | Session ID | ヘッダー |
|---|---|---|---|
| 起動時 (既存ログ) | `tail -n 0` | スキップ | "既存ログ接続中 (起動時検出)" |
| ライブ (cron 発火) | `tail -n 50` | ルックアップあり | "新しいセッション検出" |

## 解消される問題

- 19:00 の失敗ログが開くたびに Permission denied として再表示される問題
- 失敗済みログで "Session ID が見つかりませんでした" が毎回出る問題
- Session ID ルックアップの 4 秒待機（3回×2秒）が不要に発生する問題

## Test plan

- [ ] 既存ログがある状態で開く → "既存ログ接続中" が表示され、過去エラー内容が再表示されないことを確認
- [ ] cron 発火後に新ログが出現 → "新しいセッション検出" + tail -n 50 + Session ID 取得が行われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ログ監視機能が初回スタートアップと新規セッション検出を区別するようになりました。スタートアップ時は履歴ログの再表示を抑制し、セッション検出処理をスキップするため、不要なUI表示が解消されます。その後のセッション検出では従来通りの動作を維持し、最新ログを表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->