### PR TITLE
chore: update ReasoningBank with v8.2.5 release pattern

### DIFF
--- a/.claude/claudeos/data/reasoning-bank.json
+++ b/.claude/claudeos/data/reasoning-bank.json
@@ -22,6 +22,27 @@
       "confidence": 1,
       "used_count": 2,
       "last_used": "2026-05-10T02:35:22.623Z"
+    },
+    {
+      "id": "rb-2026-05-11T11-46-21-wp26",
+      "timestamp": "2026-05-11T11:46:21.255Z",
+      "project": "ClaudeCode-StartUpTools-New",
+      "phase": "Improve",
+      "problem_pattern": "修正 (v3.2.80→v3.2.89) + Watch-ClaudeLog.ps1 FilterLine 名前付き関数化",
+      "approach": "v3.2.89 (PR #251) merge 完了。README バージョンドリフト修正 (v3.2.80→v3.2.89) + Watch-ClaudeLog.ps1 FilterLine 名前付き関数化 (CodeRabbit Medium対応)。CI 4/4 SUCCESS。",
+      "tags": [
+        "ci",
+        "pr",
+        "docs",
+        "powershell"
+      ],
+      "outcome": "success",
+      "stable_achieved": true,
+      "ci_passed": true,
+      "consecutive_success": 5,
+      "confidence": 1,
+      "used_count": 9,
+      "last_used": "2026-05-11T12:22:24.654Z"
     }
   ]
 }


### PR DESCRIPTION
## 📌 Summary

ClaudeOS v8.2.5 リリース (PR #267-#270 merge) で session-end hook が自動記録した
**学習パターン 1 件**を保存。次セッションが「v8 系大型リリースは成功パターン」
として参照できるようにする。

## 📊 差分

- 1 ファイル / 21 行追加
- \`.claude/claudeos/data/reasoning-bank.json\`

## 🤖 追加 entry

| 項目 | 値 |
|---|---|
| id | \`rb-2026-05-11T11-46-21-wp26\` |
| phase | Improve |
| outcome | success |
| stable_achieved | true |
| consecutive_success | 5 |
| confidence | 1.00 |
| tags | ci / pr / docs / powershell |

## 💡 運用方針

\`reasoning-bank.json\` は session-end hook (ReasoningBank モジュール) が自動更新する
学習データ。頻繁な commit はノイズになるため、**リリースなどの節目でまとめて commit**
する運用とする。

セッション開始時に \`[ReasoningBank] 過去の有効パターン (参考)\` として読み込まれ、
過去成功パターンを意思決定の参考に活用する。

## ✅ Test plan

- [x] session-end hook が記録した entry が正しい構造であることを確認
- [x] 既存 entry を壊さずに append されていることを diff で確認
- [ ] 次セッション起動時に \`[ReasoningBank]\` が新 entry を読み込むことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)