### PR TITLE
feat(v9.0): 残タスク全対応 — state.json v9.0 / upgrade スクリプト / examples v9.0 化

### DIFF
--- a/.claude/claudeos/data/reasoning-bank.json
+++ b/.claude/claudeos/data/reasoning-bank.json
@@ -62,8 +62,8 @@
       "ci_passed": true,
       "consecutive_success": 5,
       "confidence": 1,
-      "used_count": 1,
-      "last_used": "2026-05-12T09:23:05.421Z"
+      "used_count": 6,
+      "last_used": "2026-05-12T09:52:28.357Z"
     }
   ]
 }

--- a/Claude/templates/claudeos/examples/CLAUDE.md
+++ b/Claude/templates/claudeos/examples/CLAUDE.md
@@ -1,10 +1,37 @@
-# Example CLAUDE.md
+# Example CLAUDE.md — ClaudeOS v9.0
 
-プロジェクトのルートに置く最小構成例です。
+プロジェクトルートに置く最小構成例（ClaudeOS v9.0 スタータープレート）。
+フル仕様は `Claude/templates/claude/CLAUDE.md` を参照。
 
-- 言語
-- ブランチ戦略
-- テスト手順
-- README 更新方針
+## セッション開始時
 
-を短く定義します。
+```bash
+# 状態確認
+cat state.json 2>/dev/null || echo "{}"
+gh issue list --state open --limit 20
+
+# /goal 設定
+/goal "Issue #XX を実装し、全テスト通過・CI成功・PR作成済み、または stop after 20 turns"
+```
+
+## 言語と対応
+
+- 日本語で対応・解説する
+- コード内コメントは英語可
+
+## 基本ルール
+
+- `/goal` コマンドでゴールを設定し CTO に全権委任
+- `claude agents` で Agent View を起動しセッション監視
+- main 直接 push 禁止 / PR 必須 / CI 通過のみ merge 許可
+- 同一原因エラー 2 回 → Issue 化して次タスクへ
+
+## STABLE 判定
+
+test + lint + build + CI + security + review がすべて OK で STABLE。
+STABLE 未達は merge 禁止。
+
+## 参照先
+
+- フル仕様: `Claude/templates/claude/CLAUDE.md`
+- state.json テンプレート: `scripts/setup/state-template.json`

--- a/Claude/templates/claudeos/examples/django-api-CLAUDE.md
+++ b/Claude/templates/claudeos/examples/django-api-CLAUDE.md
@@ -1,3 +1,5 @@
+> ClaudeOS v9.0 適用: /goal 駆動 + Agent Teams + Agent View。汎用例は CLAUDE.md を参照。
+
 # Django API Example
 
 DRF、Celery、PostgreSQL を使う Django API 向けの運用例です。

--- a/Claude/templates/claudeos/examples/go-microservice-CLAUDE.md
+++ b/Claude/templates/claudeos/examples/go-microservice-CLAUDE.md
@@ -1,3 +1,5 @@
+> ClaudeOS v9.0 適用: /goal 駆動 + Agent Teams + Agent View。汎用例は CLAUDE.md を参照。
+
 # Go Microservice Example
 
 gRPC と PostgreSQL を使う Go マイクロサービス向けの運用例です。

--- a/Claude/templates/claudeos/examples/laravel-api-CLAUDE.md
+++ b/Claude/templates/claudeos/examples/laravel-api-CLAUDE.md
@@ -1,3 +1,5 @@
+> ClaudeOS v9.0 適用: /goal 駆動 + Agent Teams + Agent View。汎用例は CLAUDE.md を参照。
+
 # Laravel API Example
 
 Laravel、PostgreSQL、Redis を使う API 向けの運用例です。

--- a/Claude/templates/claudeos/examples/rust-api-CLAUDE.md
+++ b/Claude/templates/claudeos/examples/rust-api-CLAUDE.md
@@ -1,3 +1,5 @@
+> ClaudeOS v9.0 適用: /goal 駆動 + Agent Teams + Agent View。汎用例は CLAUDE.md を参照。
+
 # Rust API Example
 
 Axum、SQLx、PostgreSQL を使う Rust API 向けの運用例です。

--- a/Claude/templates/claudeos/examples/saas-nextjs-CLAUDE.md
+++ b/Claude/templates/claudeos/examples/saas-nextjs-CLAUDE.md
@@ -1,3 +1,5 @@
+> ClaudeOS v9.0 適用: /goal 駆動 + Agent Teams + Agent View。汎用例は CLAUDE.md を参照。
+
 # SaaS Next.js Example
 
 Next.js、Supabase、Stripe を使う SaaS 向けの運用例です。

--- a/scripts/main/New-CronSchedule.ps1
+++ b/scripts/main/New-CronSchedule.ps1
@@ -173,20 +173,43 @@ function Invoke-EnsureStateJson {
         return
     }
 
-    Write-Host "  [state.json] 未検出 — 最小構成を生成中..." -ForegroundColor Cyan
+    Write-Host "  [state.json] 未検出 — v9.0 スキーマで生成中..." -ForegroundColor Cyan
+    $today = (Get-Date -Format 'yyyy-MM-dd')
+    $releaseDeadline = (Get-Date).AddMonths(6).ToString('yyyy-MM-dd')
     $minimalState = @"
 {
-  "goal": { "title": "$Project 自律開発" },
-  "kpi": { "success_rate_target": 0.9 },
+  "project": {
+    "name": "$Project",
+    "start_date": "$today",
+    "release_deadline": "$releaseDeadline",
+    "phase_mode": "development"
+  },
+  "goal": "$Project 自律開発",
+  "phase": "Monitor",
+  "kpi": {
+    "success_rate_target": 0.9,
+    "ci_success_rate": 0.0,
+    "test_pass_rate": 0.0,
+    "security_critical": 0,
+    "blocker_count": 0
+  },
   "execution": {
     "max_duration_minutes": $duration,
+    "repair_count": 0,
+    "max_repair": 3,
+    "same_error_limit": 2,
     "phase": "Monitor",
-    "auto_stop_threshold": 5,
-    "graceful_shutdown": true,
     "last_session_summary": ""
   },
+  "automation": { "auto_issue_generation": true, "self_evolution": true },
   "stable": { "consecutive_success": 0, "target_n": 3, "stable_achieved": false },
-  "automation": { "auto_issue_generation": true, "self_evolution": true }
+  "completed_issues": [],
+  "blocked_issues": [],
+  "learning": { "failure_patterns": [], "success_patterns": [] },
+  "quality_gates": {
+    "lint": { "warning_threshold": 10, "error_threshold": 0 },
+    "coverage": { "line_min": 70, "changed_files_min": 80 }
+  }
 }
 "@
     $escapedState = $minimalState.Replace("'", "'\''")

--- a/scripts/setup/upgrade-state-json-v9.sh
+++ b/scripts/setup/upgrade-state-json-v9.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# upgrade-state-json-v9.sh
+# Linux (192.168.0.185) 上の登録プロジェクト state.json を v9.0 スキーマへアップグレードする
+# Usage: bash upgrade-state-json-v9.sh [PROJECTS_BASE]
+# Default PROJECTS_BASE: $HOME/Projects
+
+set -euo pipefail
+
+PROJECTS_BASE="${1:-$HOME/Projects}"
+TODAY=$(date +%Y-%m-%d)
+RELEASE_DEADLINE=$(date -d "+6 months" +%Y-%m-%d 2>/dev/null || date -v+6m +%Y-%m-%d)
+
+echo "=== ClaudeOS v9.0 state.json アップグレード ==="
+echo "Projects base: $PROJECTS_BASE"
+echo "Today: $TODAY / Release deadline: $RELEASE_DEADLINE"
+echo ""
+
+upgraded=0
+skipped=0
+errors=0
+
+for project_dir in "$PROJECTS_BASE"/*/; do
+    [ -d "$project_dir" ] || continue
+    project=$(basename "$project_dir")
+    state_file="$project_dir/state.json"
+
+    if [ ! -f "$state_file" ]; then
+        echo "[$project] state.json なし — スキップ"
+        ((skipped++)) || true
+        continue
+    fi
+
+    # v9.0 スキーマ確認（project.start_date があれば v9.0 済み）
+    if python3 -c "import json,sys; d=json.load(open('$state_file')); sys.exit(0 if 'project' in d and 'start_date' in d.get('project',{}) else 1)" 2>/dev/null; then
+        echo "[$project] ✅ v9.0 スキーマ済み — スキップ"
+        ((skipped++)) || true
+        continue
+    fi
+
+    echo "[$project] v8 スキーマ検出 → v9.0 へアップグレード中..."
+
+    # バックアップ作成
+    cp "$state_file" "${state_file}.bak.$(date +%Y%m%d%H%M%S)"
+
+    # Python で v9.0 フィールドをマージ（既存値を保持しつつ不足フィールドを追加）
+    python3 << PYEOF
+import json, sys
+
+with open("$state_file", "r") as f:
+    state = json.load(f)
+
+# project セクション（v9.0）
+if "project" not in state or not isinstance(state["project"], dict):
+    state["project"] = {}
+state["project"].setdefault("name", "$project")
+state["project"].setdefault("start_date", "$TODAY")
+state["project"].setdefault("release_deadline", "$RELEASE_DEADLINE")
+state["project"].setdefault("phase_mode", "development")
+
+# goal を文字列に正規化（v8 では dict の場合あり）
+if isinstance(state.get("goal"), dict):
+    state["goal"] = state["goal"].get("title", "$project 自律開発")
+elif not state.get("goal"):
+    state["goal"] = "$project 自律開発"
+
+# phase をトップレベルに設定
+state.setdefault("phase", "Monitor")
+
+# kpi フィールド追加
+if "kpi" not in state:
+    state["kpi"] = {}
+state["kpi"].setdefault("success_rate_target", 0.9)
+state["kpi"].setdefault("ci_success_rate", 0.0)
+state["kpi"].setdefault("test_pass_rate", 0.0)
+state["kpi"].setdefault("security_critical", 0)
+state["kpi"].setdefault("blocker_count", 0)
+
+# execution フィールド追加
+if "execution" not in state:
+    state["execution"] = {}
+state["execution"].setdefault("repair_count", 0)
+state["execution"].setdefault("max_repair", 3)
+state["execution"].setdefault("same_error_limit", 2)
+
+# 新規フィールド追加
+state.setdefault("completed_issues", [])
+state.setdefault("blocked_issues", [])
+
+# learning を標準化
+if "learning" not in state or not isinstance(state["learning"], dict):
+    state["learning"] = {}
+state["learning"].setdefault("failure_patterns", [])
+state["learning"].setdefault("success_patterns", [])
+
+# quality_gates 追加
+if "quality_gates" not in state:
+    state["quality_gates"] = {
+        "lint": {"warning_threshold": 10, "error_threshold": 0},
+        "coverage": {"line_min": 70, "changed_files_min": 80}
+    }
+
+with open("$state_file", "w") as f:
+    json.dump(state, f, ensure_ascii=False, indent=2)
+    f.write("\n")
+
+print("  v9.0 アップグレード完了")
+PYEOF
+
+    if [ $? -eq 0 ]; then
+        echo "  [$project] ✅ 完了"
+        ((upgraded++)) || true
+    else
+        echo "  [$project] ❌ エラー"
+        ((errors++)) || true
+    fi
+done
+
+echo ""
+echo "=== 完了 ==="
+echo "アップグレード済み: $upgraded 件"
+echo "スキップ（v9.0済み or state.json なし）: $skipped 件"
+echo "エラー: $errors 件"


### PR DESCRIPTION
## 📌 概要

v9.0 移行の残タスクを全対応する。

## 🔧 変更内容

### P4: New-CronSchedule.ps1 state.json v9.0 化
`Invoke-EnsureStateJson` の生成 JSON を v8 スキーマ → v9.0 スキーマへ更新。
新規プロジェクト登録時から `/goal`・`blocked_issues`・`learning` が使用可能になる。

- `project.start_date` を登録日で自動設定（週次フェーズ計算が即日有効）
- `execution.same_error_limit: 2`（Stop Conditions v9.0）
- `completed_issues` / `blocked_issues` / `learning` フィールド追加
- `quality_gates` 追加（lint warning_threshold / coverage）

### P5: Linux 既存プロジェクト state.json v9.0 アップグレードスクリプト
`scripts/setup/upgrade-state-json-v9.sh` 新規作成。

```bash
# Linux サーバーで実行
bash scripts/setup/upgrade-state-json-v9.sh
```

- 全プロジェクトを走査し v9.0 スキーマ確認
- 既存値を保持しつつ不足フィールドをマージ（Python3 json）
- 実行前バックアップ自動作成（`.bak.YYYYMMDDHHMMSS`）

### P6: examples/ CLAUDE.md v9.0 化
- `examples/CLAUDE.md`: v9.0 最小スタータープレートとして全面更新
- 言語別 5 ファイル: v9.0 適用注記を先頭に追加

## 📋 PR 整理（別途 Close 済み）

| PR | 理由 |
|---|---|
| #253 Close | v9.0 #274 で完全上書き済み |
| #250 Close | ANSI 修正は main 適用済み |
| #261 Close | 全有効変更が v8.2.6 マージ済み |
| #264/#265/#266 | Dependabot マージ済み ✅ |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * ClaudeOS v9.0メインテンプレートを拡張しました。セッション開始手順、言語ルール、運用ルール、STABLE承認基準、リファレンスリンクを充実させました
  * 5つの言語別テンプレート（Django API、Go マイクロサービス、Laravel API、Rust API、SaaS Nextjs）にClaudeOS v9.0適用情報とエージェント機能ガイダンスを追加しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kensan196948G/ClaudeCode-StartUpTools-New/pull/275)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->