### PR TITLE
feat(trust): Trust Ledger 完全運用化 — blocked_events自動更新 / START_PROMPT統合 / Labels

### DIFF
--- a/.github/workflows/blocked-events-update.yml
+++ b/.github/workflows/blocked-events-update.yml
@@ -1,0 +1,84 @@
+name: Blocked Events Update
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+
+jobs:
+  update-blocked-events:
+    if: github.event.label.name == 'blocked'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
+
+      - name: Increment blocked_events in trust-score.json
+        run: |
+          python3 - <<'EOF'
+          import json
+          from datetime import datetime, timezone
+
+          TRUST_FILE = ".claude/claudeos/data/trust-score.json"
+
+          try:
+              with open(TRUST_FILE) as f:
+                  trust = json.load(f)
+          except Exception:
+              print("trust-score.json not found, skipping")
+              exit(0)
+
+          h = trust.setdefault("history", {})
+          h["blocked_events"] = h.get("blocked_events", 0) + 1
+
+          now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+          h["last_updated"] = now
+
+          # Trust Score を再計算（penalty 反映）
+          total   = h.get("total_ci_runs", 0)
+          success = h.get("successful_ci_runs", 0)
+          streak  = h.get("ci_success_streak", 0)
+          blocked = h["blocked_events"]
+
+          base_score    = (success / total) * 0.5 if total > 0 else 0.0
+          streak_bonus  = min(streak / 10, 1.0) * 0.1
+          block_penalty = min(blocked * 0.05, 0.2)
+          score = max(0.0, min(1.0, base_score + streak_bonus - block_penalty))
+
+          old_level = trust.get("level", 1)
+          level = 3 if score >= 0.95 else 2 if score >= 0.85 else 1
+
+          trust["score"]              = round(score, 4)
+          trust["level"]              = level
+          trust["auto_merge_enabled"] = score >= 0.85
+          trust["updated_at"]         = now
+          trust["history"]            = h
+
+          with open(TRUST_FILE, "w", encoding="utf-8") as f:
+              json.dump(trust, f, indent=2, ensure_ascii=False)
+
+          downgrade = "DOWNGRADE" if level < old_level else "no change"
+          print(f"[Trust Score] blocked_events={blocked} score={score:.4f} level={level} ({downgrade})")
+          EOF
+
+      - name: Commit blocked_events update
+        run: |
+          git config user.name  "ClaudeOS Trust Bot"
+          git config user.email "claudeos@github-actions[bot]"
+          git add .claude/claudeos/data/trust-score.json
+
+          ISSUE_NUM="${{ github.event.issue.number }}"
+          SCORE=$(python3 -c "import json; d=json.load(open('.claude/claudeos/data/trust-score.json')); print(d['score'])")
+          LEVEL=$(python3 -c "import json; d=json.load(open('.claude/claudeos/data/trust-score.json')); print(d['level'])")
+          BLOCKED=$(python3 -c "import json; d=json.load(open('.claude/claudeos/data/trust-score.json')); print(d['history']['blocked_events'])")
+
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore(trust): Blocked #${ISSUE_NUM} → blocked=${BLOCKED} score=${SCORE} level=${LEVEL} [skip ci]"
+            git push
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -917,6 +917,7 @@ Agent Teams で並列に動き、Agent View で監視する。
 - セッション開始時に `trust.level` を確認し、許可操作範囲内で行動する
 - セッション終了時に `trust.history` を更新し `trust.score` を再計算する
 - Security Critical 検出時は即座に Level 1 へ降格する
+- **Blocked 発生時**: Issue に `blocked` ラベルを付与すること（GitHub Actions が `blocked_events` を自動インクリメントする）
 
 ## 23.1 Agent Communication Protocol（GitHub Issues メッセージバス）
 

--- a/Claude/templates/claude/START_PROMPT.md
+++ b/Claude/templates/claude/START_PROMPT.md
@@ -69,6 +69,33 @@ Read したファイルの `/goal "..."` の内容を、**そのまま Skill ツ
 > goal_type が未設定・不明の場合は、`gh issue list` と `gh run list` を確認し、
 > CTO 判断で最適な goal_type を選択してから実行すること。
 
+## 🛡️ Trust Level 確認（必須・スキップ禁止）
+
+以下を **必ず順番に実行**すること。
+
+### ステップ 1: trust-score.json を Read する
+
+```text
+.claude/claudeos/data/trust-score.json
+```
+
+### ステップ 2: trust.level に応じた許可操作範囲を確認する
+
+```text
+Level 1 (score 0.00-0.84): ファイル編集・テスト実行・Issue起票・Draft PR
+Level 2 (score 0.85-0.94): + PR作成・auto_merge（CI全通過時）
+Level 3 (score 0.95-1.00): + Staging デプロイ
+※ 本番デプロイは全 Level で人間サインオフ必須
+```
+
+### ステップ 3: エージェントメッセージを確認する
+
+```bash
+gh issue list --label "agent-msg,status:open" --limit 10
+```
+
+`priority:urgent` のメッセージは現在の作業を中断して最優先で処理すること。
+
 ## ⚡ 起動後必須実行
 
 ```bash

--- a/Claude/templates/claudeos/workflows/blocked-events-update.yml
+++ b/Claude/templates/claudeos/workflows/blocked-events-update.yml
@@ -1,0 +1,79 @@
+name: Blocked Events Update
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+
+jobs:
+  update-blocked-events:
+    if: github.event.label.name == 'blocked'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
+
+      - name: Increment blocked_events in trust-score.json
+        run: |
+          python3 - <<'EOF'
+          import json
+          from datetime import datetime, timezone
+
+          TRUST_FILE = ".claude/claudeos/data/trust-score.json"
+
+          try:
+              with open(TRUST_FILE) as f:
+                  trust = json.load(f)
+          except Exception:
+              print("trust-score.json not found, skipping")
+              exit(0)
+
+          h = trust.setdefault("history", {})
+          h["blocked_events"] = h.get("blocked_events", 0) + 1
+          now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+          h["last_updated"] = now
+
+          total   = h.get("total_ci_runs", 0)
+          success = h.get("successful_ci_runs", 0)
+          streak  = h.get("ci_success_streak", 0)
+          blocked = h["blocked_events"]
+
+          base_score    = (success / total) * 0.5 if total > 0 else 0.0
+          streak_bonus  = min(streak / 10, 1.0) * 0.1
+          block_penalty = min(blocked * 0.05, 0.2)
+          score = max(0.0, min(1.0, base_score + streak_bonus - block_penalty))
+
+          old_level = trust.get("level", 1)
+          level = 3 if score >= 0.95 else 2 if score >= 0.85 else 1
+
+          trust["score"]              = round(score, 4)
+          trust["level"]              = level
+          trust["auto_merge_enabled"] = score >= 0.85
+          trust["updated_at"]         = now
+          trust["history"]            = h
+
+          with open(TRUST_FILE, "w", encoding="utf-8") as f:
+              json.dump(trust, f, indent=2, ensure_ascii=False)
+
+          print(f"[Trust Score] blocked_events={blocked} score={score:.4f} level={level}")
+          EOF
+
+      - name: Commit blocked_events update
+        run: |
+          git config user.name  "ClaudeOS Trust Bot"
+          git config user.email "claudeos@github-actions[bot]"
+          git add .claude/claudeos/data/trust-score.json
+          ISSUE_NUM="${{ github.event.issue.number }}"
+          SCORE=$(python3 -c "import json; d=json.load(open('.claude/claudeos/data/trust-score.json')); print(d['score'])")
+          LEVEL=$(python3 -c "import json; d=json.load(open('.claude/claudeos/data/trust-score.json')); print(d['level'])")
+          BLOCKED=$(python3 -c "import json; d=json.load(open('.claude/claudeos/data/trust-score.json')); print(d['history']['blocked_events'])")
+          if git diff --staged --quiet; then
+            echo "No changes"
+          else
+            git commit -m "chore(trust): Blocked #${ISSUE_NUM} → blocked=${BLOCKED} score=${SCORE} level=${LEVEL} [skip ci]"
+            git push
+          fi


### PR DESCRIPTION
## 📌 概要

Trust Ledger の完全運用化。blocked_events 自動更新・START_PROMPT 統合・GitHub Labels 作成の3点を実装。

## 🔧 変更内容

### 1. START_PROMPT.md — Trust Level 確認ステップ追加
- セッション開始時に trust-score.json を Read して trust.level を確認（必須・スキップ禁止）
- Level 1/2/3 の許可操作範囲を明示
- Agent メッセージ確認（gh issue list --label agent-msg,status:open）を起動時必須に追加

### 2. blocked_events 自動更新 GitHub Actions
- .github/workflows/blocked-events-update.yml 新規作成
- Issue に `blocked` ラベルが付与されると自動トリガー
- Python で blocked_events インクリメント + Trust Score 再計算 + commit
- CLAUDE.md §23 に「Blocked 発生時は blocked ラベルを付与すること」を追記

### 3. GitHub Labels 11種類作成済み
- agent-msg / agent:cto / agent:developer / agent:qa / agent:security / agent:devops
- priority:urgent / status:open / status:in-progress / status:done / blocked

## 📊 Trust Score 完全動作フロー

```
CI 成功/失敗 → trust-score-update.yml → score/level 更新
Blocked 発生 → Issue に blocked ラベル → blocked-events-update.yml → penalty 反映
セッション開始 → START_PROMPT が trust-score.json を Read → Level 確認 → 許可範囲で行動
```

## 🔭 影響範囲
- 全登録プロジェクト（Start-ClaudeCode.ps1 実行時に自動配布）
- 後方互換: trust-score.json 未存在プロジェクトはワークフロー初回実行時に自動生成

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * ブロック発生時の GitHub Issues 運用ルール（ラベル付与）を追加
  * システム起動時の信頼レベル確認プロセスと、優先度メッセージの処理手順を明示

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kensan196948G/ClaudeCode-StartUpTools-New/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->