### PR TITLE
feat(phase3b): Trust Dashboard / auto_merge / 並列cron設計 / negative_patterns

### DIFF
--- a/.claude/claudeos/scripts/hooks/session-end.js
+++ b/.claude/claudeos/scripts/hooks/session-end.js
@@ -150,6 +150,35 @@ try {
         state.learning.failure_patterns.unshift(entry);
         if (state.learning.failure_patterns.length > 20) state.learning.failure_patterns.length = 20;
         console.log(`[SessionEnd][Learning] failure_pattern recorded (reasons: ${reasons.join(", ")})`);
+
+        // ④ negative_patterns: Blocked が 2 回以上発生したパターンを reasoning-bank に書き込む
+        try {
+          const rbMod    = require("./reasoning-bank.js");
+          const dataDir  = path.join(__dirname, "..", "..", "data");
+          const bank     = rbMod.loadBank(dataDir);
+          const projectName = path.basename(process.cwd());
+          const negText  = reasons.join(" / ");
+          const existing = (bank.negative_patterns || []).find(
+            n => n.project === projectName && rbMod.detectProblemPattern(n.pattern) === rbMod.detectProblemPattern(negText)
+          );
+          if (existing) {
+            existing.failure_count = (existing.failure_count || 1) + 1;
+            existing.last_seen = new Date().toISOString();
+            // 2 回以上の場合は採用禁止フラグを立てる
+            if (existing.failure_count >= 2) existing.prohibited = true;
+          } else {
+            bank.negative_patterns = bank.negative_patterns || [];
+            bank.negative_patterns.push({
+              project: projectName, pattern: negText.slice(0, 150),
+              failure_count: 1, prohibited: false, last_seen: new Date().toISOString(),
+            });
+          }
+          if (bank.negative_patterns.length > 50) bank.negative_patterns = bank.negative_patterns.slice(-50);
+          rbMod.saveBank(dataDir, bank);
+          console.log(`[ReasoningBank] negative_pattern recorded: ${negText.slice(0, 60)}`);
+        } catch (negErr) {
+          if (process.env.CLAUDEOS_DEBUG) console.error(`[ReasoningBank] negative_pattern write failed: ${negErr.message}`);
+        }
       }
     } catch (learnErr) {
       if (process.env.CLAUDEOS_DEBUG) console.error(`[SessionEnd] learning-record skipped: ${learnErr.message}`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -918,6 +918,8 @@ Agent Teams で並列に動き、Agent View で監視する。
 - セッション終了時に `trust.history` を更新し `trust.score` を再計算する
 - Security Critical 検出時は即座に Level 1 へ降格する
 - **Blocked 発生時**: Issue に `blocked` ラベルを付与すること（GitHub Actions が `blocked_events` を自動インクリメントする）
+- **Level 2 以上での PR 作成時**: CI 全通過を確認してから `gh pr merge <番号> --auto --squash` を実行すること（詳細: `.claude/claudeos/docs/auto-merge-protocol.md`）
+- **Level 2 禁止（手動必須）**: 認証・認可変更 / DB スキーマ変更 / 本番デプロイ / Security Critical 残存 PR
 
 ## 23.1 Agent Communication Protocol（GitHub Issues メッセージバス）
 

--- a/Claude/templates/claudeos/docs/auto-merge-protocol.md
+++ b/Claude/templates/claudeos/docs/auto-merge-protocol.md
@@ -1,0 +1,64 @@
+# Auto Merge Protocol — Trust Level 2 以上での自律マージ
+
+## 概要
+
+`trust.level >= 2` かつ CI 全通過の PR を、CTO が人間の介入なしに自動マージする。
+
+---
+
+## 発動条件
+
+| 条件 | 内容 |
+|---|---|
+| trust.level | **2 以上**（trust.score >= 0.85） |
+| CI | 全チェック通過（`gh pr checks` 全て pass） |
+| PR 種別 | 通常の機能追加・バグ修正・ドキュメント更新 |
+
+## 禁止条件（Level 2 でも手動必須）
+
+- 認証・認可の変更
+- DB スキーマ変更
+- 本番デプロイ
+- Security Critical 指摘が残っている PR
+
+---
+
+## CTO の実行手順
+
+```bash
+# 1. Trust Level を確認
+LEVEL=$(python3 -c "import json; print(json.load(open('.claude/claudeos/data/trust-score.json'))['level'])")
+echo "Trust Level: $LEVEL"
+
+# 2. CI 全通過を確認
+gh pr checks <PR番号>
+
+# 3. Level 2 以上 + 全通過なら auto-merge を設定
+if [ "$LEVEL" -ge 2 ]; then
+  gh pr merge <PR番号> --auto --squash
+  echo "[AutoMerge] PR #<番号> に auto-merge を設定しました"
+fi
+```
+
+---
+
+## PowerShell 版（Windows cron 環境）
+
+```powershell
+$ts = Get-Content ".claude/claudeos/data/trust-score.json" | ConvertFrom-Json
+if ($ts.level -ge 2) {
+  gh pr merge $prNumber --auto --squash
+  Write-Host "[AutoMerge] Level $($ts.level) → PR #$prNumber auto-merge 設定"
+}
+```
+
+---
+
+## 注意事項
+
+- `--auto` フラグは「CI 通過後に自動マージ」を設定するもので、即時マージではない
+- Trust Level が降格した場合（Security Critical 等）は即座に auto-merge を取り消す:
+  ```bash
+  gh pr merge <PR番号> --disable-auto
+  ```
+- 週次で auto-merge の実績を確認し、問題があれば Level 閾値を上げること

--- a/Claude/templates/claudeos/docs/parallel-cron-experiment.md
+++ b/Claude/templates/claudeos/docs/parallel-cron-experiment.md
@@ -1,0 +1,129 @@
+# 並列 Cron 実験ガイド — 2セッション同時実行
+
+## 概要
+
+1つのプロジェクトで CTO（実装担当）と QA（監視担当）を
+別プロセスとして同時起動し、GitHub Issues 経由で協調する実験。
+
+---
+
+## アーキテクチャ
+
+```
+Linux cron
+  ├─ Session A: CTO ロール（実装・PR作成・マージ判断）
+  │    claude -p "$(cat ~/.claudeos/roles/cto-build.md)" --project <ProjectName>
+  │
+  └─ Session B: QA ロール（テスト監視・品質チェック・報告）
+       claude -p "$(cat ~/.claudeos/roles/qa-monitor.md)" --project <ProjectName>
+
+通信チャネル: GitHub Issues（[AGENT-MSG] ラベル付き）
+共有状態:    state.json（排他制御は atomic write で担保）
+```
+
+---
+
+## ロールファイル
+
+### CTO ロール: `~/.claudeos/roles/cto-build.md`
+
+```markdown
+あなたは CTO ロールで動作します。
+
+責務: 実装・PR作成・マージ判断
+制約:
+- QA からの [AGENT-MSG] を30分ごとに確認する
+- QA が fail を報告した場合は実装を一時停止する
+- state.json への書き込みは session-end hook に任せる（直接書き込み禁止）
+
+セッション開始時:
+1. gh issue list --label "agent-msg,agent:qa,status:open" を確認
+2. gh issue list --state open --limit 10 を確認
+3. 優先度の高いタスクから実装開始
+
+/goal "Issue #XX 実装完了・CI成功・PR作成済み、または stop after 15 turns"
+```
+
+### QA ロール: `~/.claudeos/roles/qa-monitor.md`
+
+```markdown
+あなたは QA ロール（監視担当）で動作します。
+
+責務: テスト実行・CI 監視・品質報告
+制約:
+- 実装は行わない（読み取りとテスト実行のみ）
+- 問題を発見したら GitHub Issue に [AGENT-MSG] として報告する
+- CTO の実装を妨害しない（Issues コメントのみ）
+
+セッション開始時:
+1. gh run list --limit 5 で CI 状態を確認
+2. 失敗があれば CTO に報告: gh issue create --label "agent-msg,agent:qa,priority:urgent" ...
+3. テストを実行して結果を記録する
+
+/goal "CI 全通過確認・品質レポート作成済み、または stop after 10 turns"
+```
+
+---
+
+## cron 設定例（Linux）
+
+```bash
+# ~/.claudeos/cron-parallel-launcher.sh
+#!/bin/bash
+PROJECT=$1
+
+# CTO セッション（バックグラウンド）
+claude -p "$(cat ~/.claudeos/roles/cto-build.md)" \
+  --project "$PROJECT" \
+  --output-format stream-json \
+  > ~/.claudeos/logs/${PROJECT}-cto.log 2>&1 &
+CTO_PID=$!
+
+# 5分遅延して QA セッション起動（CTO が先に起動するため）
+sleep 300
+
+# QA セッション（バックグラウンド）
+claude -p "$(cat ~/.claudeos/roles/qa-monitor.md)" \
+  --project "$PROJECT" \
+  --output-format stream-json \
+  > ~/.claudeos/logs/${PROJECT}-qa.log 2>&1 &
+QA_PID=$!
+
+echo "CTO PID=$CTO_PID QA PID=$QA_PID" > ~/.claudeos/${PROJECT}-parallel.pid
+
+# 両セッションの完了を待つ（最大5時間）
+wait $CTO_PID $QA_PID
+echo "Parallel session completed for $PROJECT"
+```
+
+---
+
+## デッドロック防止ルール
+
+1. **state.json の読み書き**: CTO のみが session-end hook で更新。QA は読み取り専用
+2. **同一ファイルの同時編集**: 禁止。QA が編集が必要な場合は CTO に Issue で依頼
+3. **PR の同時作成**: 禁止。CTO のみが PR を作成する
+4. **GitHub Issue**: 両セッションが書き込み可能（ラベルで区別）
+
+---
+
+## 実験開始前チェックリスト
+
+- [ ] GitHub Labels が作成済み（agent-msg, agent:cto, agent:qa 等）
+- [ ] ~/.claudeos/roles/ に両ロールファイルが存在する
+- [ ] ~/.claudeos/logs/ ディレクトリが存在する
+- [ ] プロジェクトの state.json に trust.level >= 1 が設定済み
+- [ ] Agent Communication Protocol を理解している
+
+---
+
+## 実装ステータス
+
+| コンポーネント | 状態 |
+|---|---|
+| GitHub Issues メッセージバス | ✅ 実装済み |
+| ラベル定義（agent-msg 等） | ✅ 作成済み |
+| Issue テンプレート | ✅ 作成済み |
+| ロールファイル | ⚠️ 手動作成が必要 |
+| 並列 cron ランチャー | ⚠️ 上記スクリプトを手動配置 |
+| 実際の並列実行テスト | ❌ 未実施（次回セッションで実験） |

--- a/scripts/dashboards/mission-control.html
+++ b/scripts/dashboards/mission-control.html
@@ -186,7 +186,8 @@ const MOCK_STATE = {
   automation: { auto_issue_generation: true, self_evolution: true },
   learning: { usage_history: { agents: { "security-reviewer": { call_count: 12 }, "e2e-runner": { call_count: 8 }, "tester": { call_count: 15 } } } },
   debug: { last_failure_category: null, same_error_retry_count: 0, rescue_retry_count: 0, flaky_suspected: false },
-  compact: { trigger_at_pct: 70, last_pre_compact_at: new Date(Date.now() - 7200000).toISOString() }
+  compact: { trigger_at_pct: 70, last_pre_compact_at: new Date(Date.now() - 7200000).toISOString() },
+  trust: { score: 0.72, level: 1, auto_merge_enabled: false, history: { total_ci_runs: 12, successful_ci_runs: 10, ci_success_streak: 4, blocked_events: 1 } }
 };
 
 const AGENTS_DATA = [
@@ -851,6 +852,21 @@ const DashboardPanel = ({ state, sessionElapsed }) => {
           <SysRow label="最終Compact" value={formatTime(state.compact.last_pre_compact_at)} color={MC.textDim} />
           <SysRow label="最終検証" value={formatTime(state.stable.last_verified_at)} color={MC.textDim} />
           <SysRow label="Flaky疑い" value={state.debug.flaky_suspected ? "あり" : "なし"} color={state.debug.flaky_suspected ? MC.amber : MC.green} />
+          {state.trust && (<>
+            <div style={{ borderTop:`1px solid ${MC.border}`, margin:"4px 0" }} />
+            <SysRow label="Trust Score"
+              value={`${Math.round((state.trust.score||0)*100)}%`}
+              color={state.trust.score>=0.95 ? MC.green : state.trust.score>=0.85 ? MC.amber : MC.red} />
+            <SysRow label="Trust Level"
+              value={`Level ${state.trust.level||1}${state.trust.level>=2 ? (state.trust.level>=3?" 🟢":" 🟡") : " 🔴"}`}
+              color={state.trust.level>=2 ? (state.trust.level>=3 ? MC.green : MC.amber) : MC.red} />
+            <SysRow label="Auto Merge"
+              value={state.trust.auto_merge_enabled ? "✅ 有効" : "⏸ 無効"}
+              color={state.trust.auto_merge_enabled ? MC.green : MC.textMuted} />
+            <SysRow label="CI Streak"
+              value={`${(state.trust.history||{}).ci_success_streak||0} 連続`}
+              color={((state.trust.history||{}).ci_success_streak||0)>=5 ? MC.green : MC.textDim} />
+          </>)}
         </div>
       </Panel>
     </div>

--- a/scripts/dashboards/serve-dashboard.js
+++ b/scripts/dashboards/serve-dashboard.js
@@ -239,6 +239,23 @@ function buildProjectData(entry) {
   const kpi    = state.kpi     || {};
   const stable = state.stable  || {};
 
+  // Trust Ledger: state.json の trust フィールドを優先し、なければ trust-score.json を参照
+  let trustData = state.trust || {};
+  if (entry.hasCron && !trustData.score) {
+    try {
+      const tsFile = path.join(PROJECTS_DIR, entry.project, '.claude', 'claudeos', 'data', 'trust-score.json');
+      if (fs.existsSync(tsFile)) {
+        const ts = JSON.parse(fs.readFileSync(tsFile, 'utf8'));
+        trustData = {
+          score:             ts.score             ?? 0.0,
+          level:             ts.level             ?? 1,
+          auto_merge_enabled: ts.auto_merge_enabled ?? false,
+          history:           ts.history           || {},
+        };
+      }
+    } catch { /* graceful degradation */ }
+  }
+
   // registration_date が未設定なら Cron created を初期値に使う
   if (!proj.registration_date && !proj.start_date && entry.created) {
     proj.registration_date = entry.created.split('T')[0];
@@ -270,6 +287,19 @@ function buildProjectData(entry) {
       achieved:    stable.stable_achieved    || false,
       consecutive: stable.consecutive_success || 0,
       targetN:     stable.target_n            || 3,
+    } : null,
+    trust: entry.hasCron ? {
+      score:           trustData.score              ?? 0.0,
+      level:           trustData.level              ?? 1,
+      autoMergeEnabled: trustData.auto_merge_enabled ?? false,
+      history: {
+        totalCiRuns:       (trustData.history || {}).total_ci_runs        ?? 0,
+        successfulCiRuns:  (trustData.history || {}).successful_ci_runs   ?? 0,
+        ciSuccessStreak:   (trustData.history || {}).ci_success_streak    ?? 0,
+        blockedEvents:     (trustData.history || {}).blocked_events       ?? 0,
+        lastCiOutcome:     (trustData.history || {}).last_ci_outcome      ?? '',
+        lastUpdated:       (trustData.history || {}).last_updated         ?? '',
+      },
     } : null,
     session: entry.hasCron ? getLatestSession(entry.project) : null,
   };


### PR DESCRIPTION
## 📌 概要

Phase 3B — AI組織の自律判断範囲拡大と並列性の基盤実装。4テーマを一括対応。

## 🔧 変更内容

### ① Trust Score ダッシュボード表示
- serve-dashboard.js: buildProjectData() に trust フィールド追加
  - state.trust 優先 → なければ .claude/claudeos/data/trust-score.json を fallback 参照
- mission-control.html: System Status パネルに Trust セクション追加
  - Trust Score（%）/ Trust Level 🔴🟡🟢 / Auto Merge 有効状態 / CI Streak を表示
  - モックデータに trust フィールドを追加（score=0.72, level=1）

### ② auto_merge の実際の有効化
- auto-merge-protocol.md 新規作成（手順・禁止条件・PowerShell版コマンド）
- CLAUDE.md §23: Level 2+ で gh pr merge --auto --squash を実行するルールを追記
- Level 2 でも手動必須の条件を明示（認証変更・DB変更・本番 deploy）

### ③ 2セッション並列 cron 実験設計
- parallel-cron-experiment.md 新規作成
  - CTO / QA ロールファイルのテンプレート
  - cron-parallel-launcher.sh スクリプト（5分遅延起動・PID管理）
  - デッドロック防止ルール（state.json は CTO のみ書き込み）

### ④ negative_patterns 自動検出・書き込き
- session-end.js: Blocked 発生時に reasoning-bank.negative_patterns へ自動追記
  - 同パターンが 2 回以上失敗 → prohibited=true（採用禁止フラグ）
  - 上限 50 件で古いものから削除

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Trust Level に基づく PR 自動マージプロトコルを文書化
  * 並列 Cron 実験運用ガイドを追加
  * CTO 行動ルールを明確化し、セキュリティ要件と自動化条件を定義

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kensan196948G/ClaudeCode-StartUpTools-New/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->