### PR TITLE
feat(phase7b): autoMode.hard_deny で §18 禁止事項を classifier 層強制化

### DIFF
--- a/docs/phases/phase7b-automode-setup.md
+++ b/docs/phases/phase7b-automode-setup.md
@@ -1,0 +1,71 @@
+# Phase 7B — autoMode.hard_deny セットアップ手順
+
+**実装日**: 2026-05-20
+**Claude Code バージョン**: 2.1.136+ (`autoMode.hard_deny` 機能)
+**配布範囲**: **全プロジェクトに自動適用** (user 設定経由)
+
+## 📌 概要
+
+CLAUDE.md §18 の禁止事項を、Claude Code 公式の `autoMode.hard_deny` 機能で classifier レベル (層 1) で強制する。
+現状の hooks (層 3) と組み合わせて、三層防御の **層 1 + 層 3 の二重防御**を実現する。
+
+## ⚠️ 設計上の重要事項 (公式 docs より)
+
+| 項目 | 仕様 |
+|---|---|
+| 配置場所 | **`~/.claude/settings.json` (user)** または `.claude/settings.local.json` (local) のみ |
+| **読まれない場所** | `.claude/settings.json` (shared project settings) ← **重要** |
+| フォーマット | **自然言語 (prose) の文字列配列** (regex / オブジェクトではない) |
+| `$defaults` | **配列内の文字列**として記述 (`"hard_deny": ["$defaults", ...]`) |
+| 出典 | https://code.claude.com/docs/en/settings |
+
+## 🛠 セットアップ手順 (各ユーザー 1 回)
+
+`~/.claude/settings.json` の末尾に以下を追加する:
+
+```json
+{
+  "autoMode": {
+    "hard_deny": [
+      "$defaults",
+      "main または master ブランチへの直接 git push を実行しない (常に PR 経由でマージする)",
+      "main または master ブランチへの force push を実行しない",
+      "git commit に --no-verify を付与して pre-commit hook をスキップしない",
+      "main ブランチを origin/main に対して git reset --hard で書き換えない",
+      "ユーザーの明示的指示なく ~/.claude/CLAUDE.md または .claude/settings.json または .claude/hooks/ を編集しない",
+      "CI checks が failing 状態の pull request を merge しない",
+      ".claude/ ディレクトリまたは .claude/settings.json を削除しない"
+    ]
+  }
+}
+```
+
+## ✅ 検証
+
+```bash
+# JSON 構文確認
+node -e "JSON.parse(require('fs').readFileSync(process.env.HOME + '/.claude/settings.json','utf8')); console.log('OK')"
+# Windows
+node -e "JSON.parse(require('fs').readFileSync(process.env.USERPROFILE + '/.claude/settings.json','utf8')); console.log('OK')"
+```
+
+設定が効いているかは、Claude Code セッションで「`git push origin main` を実行して」と依頼し、auto-mode 下で block されることを確認する。
+
+## 🌐 全プロジェクト適用の保証
+
+- `~/.claude/settings.json` は **ユーザレベル設定**のため、対象ユーザーの **すべての Claude セッション (全プロジェクト)** に自動適用される
+- migration script 不要 (Phase 7 計画書の PR-7D スコープが軽減される)
+- Linux cron 環境では、cron を実行する OS user の `~/.claude/settings.json` を同様に更新する必要がある
+
+## 🔄 ロールバック
+
+```bash
+# autoMode ブロックを削除して再保存
+# (バックアップが無い場合は手動で削除)
+```
+
+## 🔗 関連
+
+- Phase 7 全体計画: `docs/phases/phase7-cc-features-integration.md` (PR-7A 経由でマージ予定)
+- CLAUDE.md §18 — 禁止事項の正本
+- Claude Code 公式 docs — https://code.claude.com/docs/en/settings


### PR DESCRIPTION
## Summary

- `~/.claude/settings.json` (user-level) に `autoMode.hard_deny` ブロックを追加し、CLAUDE.md §18 の禁止事項を classifier 層 (層 1) で強制
- `docs/phases/phase7b-automode-setup.md` にセットアップ手順書を追加 (他ユーザ・Linux cron 環境向け)

## 重要な設計修正

実装着手時に公式 docs (https://code.claude.com/docs/en/settings) で判明した仕様:

| 項目 | 当初計画 | 修正後 (実装済み) |
|---|---|---|
| 配置場所 | `.claude/settings.json` (project) | **`~/.claude/settings.json` (user)** |
| フォーマット | regex pattern オブジェクト | **自然言語 prose 配列** |
| `$defaults` | `"$defaults": true` (key) | **`"$defaults"` (配列内の string)** |

**結果**: user-level 設定のため migration script 不要で全プロジェクトに自動適用される (PR-7D スコープ縮小)。

## 適用される 7 ルール

1. main / master への直接 push 禁止
2. main / master への force push 禁止
3. `--no-verify` 付き git commit 禁止
4. main を origin/main に対して `git reset --hard` で書き換え禁止
5. 明示的指示なく CLAUDE.md / settings.json / hooks 編集禁止
6. CI failing 状態の PR merge 禁止
7. `.claude/` ディレクトリ / settings.json 削除禁止

## 注意事項

- `~/.claude/settings.json` は **リポジトリ管理外**のため本 PR には含まれない
- 他ユーザ・Linux cron 環境は `docs/phases/phase7b-automode-setup.md` の手順に従って手動セットアップが必要
- ~/.claude/settings.json は既に編集済み (この PR 提出者の環境のみ)

## Test plan

- [ ] `node -e "JSON.parse(...)"` で ~/.claude/settings.json の構文確認 (済: OK)
- [ ] 次セッションで `git push origin main` 等を試行 (実行はせず確認のみ) し、auto-mode 下で block されるか確認
- [ ] CI 全パス

## ロールバック

~/.claude/settings.json の autoMode ブロックを削除するだけ。リポジトリ側は doc を revert。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Claude Code のセキュリティ設定に関するセットアップドキュメントを追加しました。禁止事項の自動強制方法、設定手順、検証方法、ロールバック手順などの詳細な指南を含みます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kensan196948G/ClaudeCode-StartUpTools-New/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->