### PR TITLE
feat(phase7c): claude ultrareview CLI ラッパー + CLAUDE.md §11 Gate-2b 追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -698,6 +698,22 @@ skip_if 条件が真の項目のみスキップ可。スキップした場合は
 - 主要回帰（#1・#22・#31・#51・#71・#111・#131・#141・#231〜#241）を必ず含める
 - 未実行項目は「未実行理由」を終了報告に記載する（記載なしは merge 禁止）
 
+### Gate-2b: ultrareview (Phase 7C+ / Trust Level 2+ の PR 必須)
+
+PR 作成直後・merge 直前に `node scripts/tools/run-ultrareview.js --target <PR#>` を実行し、
+Claude Code 公式の multi-agent cloud review を行う。
+
+| 適用条件 | 内容 |
+|---|---|
+| Trust Level | 2 以上 |
+| 適用範囲 | open PR (本番 deploy 前必須) |
+| 月次上限 | `state.feature_flags.ultrareview.monthly_cap` で制御 (default 50/月) |
+| 結果保存 | `reports/ultrareview/YYYY-MM-DD.json` |
+| 重大度判定 | critical / high / blocker → `state.warnings[].kind="ultrareview_blocker"` 自動追記 |
+
+**重要**: ultrareview はクラウド処理 (課金対象、最大 30 分)。session-end hook での同期呼び出しは禁止
+(session 終了が大幅遅延する)。手動 / cron / 別 PR で非同期統合する設計とする。
+
 ### Verify フェーズ標準参加 Agent（全登録プロジェクト共通）
 
 `e2e-runner` と `security-reviewer` を全プロジェクトの Verify フェーズ必須参加 Agent とする。

--- a/scripts/tools/run-ultrareview.js
+++ b/scripts/tools/run-ultrareview.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Phase 7C: claude ultrareview CLI ラッパー
+//
+// 機能:
+// - `claude ultrareview --json [target]` を子プロセスで実行
+// - 結果を reports/ultrareview/YYYY-MM-DD.json に保存
+// - blocker/critical を検出した場合 state.warnings[] に kind=ultrareview_blocker を追記
+// - state.feature_flags.ultrareview.monthly_count を更新 (月次上限制御)
+//
+// 使い方:
+//   node scripts/tools/run-ultrareview.js                  # 現在ブランチをレビュー
+//   node scripts/tools/run-ultrareview.js --target 290     # PR #290 をレビュー
+//   node scripts/tools/run-ultrareview.js --target main    # base branch main 差分
+//   node scripts/tools/run-ultrareview.js --dry-run        # 実行せず予定動作のみ表示
+//   node scripts/tools/run-ultrareview.js --timeout 10     # timeout (分) 指定 (default 30)
+//
+// 注意: ultrareview はクラウド処理で課金対象。
+// 月次上限を state.feature_flags.ultrareview.monthly_cap で制御する (default 50)。
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const STATE_FILE = path.join(process.cwd(), "state.json");
+const REPORT_DIR = path.join(process.cwd(), "reports", "ultrareview");
+const DEFAULT_MONTHLY_CAP = 50;
+
+function parseArgs(argv) {
+  const args = { target: null, dryRun: false, timeoutMinutes: 30 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--target") args.target = argv[++i];
+    else if (a === "--timeout") args.timeoutMinutes = parseInt(argv[++i], 10) || 30;
+    else if (a === "-h" || a === "--help") {
+      console.log("Usage: node scripts/tools/run-ultrareview.js [--target <pr#|branch>] [--dry-run] [--timeout <min>]");
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function readState() {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function writeStateAtomic(state) {
+  const tmp = `${STATE_FILE}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2) + "\n", "utf8");
+  fs.renameSync(tmp, STATE_FILE);
+}
+
+function currentMonth() {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function checkMonthlyCap(state) {
+  state.feature_flags = state.feature_flags || {};
+  state.feature_flags.ultrareview = state.feature_flags.ultrareview || {
+    monthly_cap: DEFAULT_MONTHLY_CAP,
+    current_month: currentMonth(),
+    count: 0,
+  };
+  const ur = state.feature_flags.ultrareview;
+  if (ur.current_month !== currentMonth()) {
+    ur.current_month = currentMonth();
+    ur.count = 0;
+  }
+  const cap = ur.monthly_cap || DEFAULT_MONTHLY_CAP;
+  return { allowed: ur.count < cap, used: ur.count, cap, ur };
+}
+
+function appendWarning(state, payload) {
+  state.warnings = state.warnings || [];
+  state.warnings.push({
+    at: new Date().toISOString(),
+    kind: "ultrareview_blocker",
+    ...payload,
+  });
+}
+
+function todayStamp() {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const state = readState();
+  const cap = checkMonthlyCap(state);
+
+  console.log(`[ultrareview] monthly usage: ${cap.used}/${cap.cap}`);
+
+  if (!cap.allowed) {
+    console.log(`[ultrareview] SKIP: monthly cap reached (${cap.used}/${cap.cap}) for ${cap.ur.current_month}`);
+    process.exit(0);
+  }
+
+  const cmd = "claude";
+  const cmdArgs = ["ultrareview", "--json", "--timeout", String(args.timeoutMinutes)];
+  if (args.target) cmdArgs.push(args.target);
+
+  if (args.dryRun) {
+    console.log(`[ultrareview][DRY-RUN] would run: ${cmd} ${cmdArgs.join(" ")}`);
+    console.log(`[ultrareview][DRY-RUN] would save to: ${path.join(REPORT_DIR, `${todayStamp()}.json`)}`);
+    console.log(`[ultrareview][DRY-RUN] monthly count would become: ${cap.used + 1}/${cap.cap}`);
+    process.exit(0);
+  }
+
+  if (!fs.existsSync(REPORT_DIR)) {
+    fs.mkdirSync(REPORT_DIR, { recursive: true });
+  }
+
+  console.log(`[ultrareview] running: ${cmd} ${cmdArgs.join(" ")}`);
+  const startMs = Date.now();
+  const r = spawnSync(cmd, cmdArgs, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    timeout: (args.timeoutMinutes + 2) * 60 * 1000,
+    shell: process.platform === "win32",
+  });
+  const elapsedSec = Math.round((Date.now() - startMs) / 1000);
+
+  if (r.error) {
+    console.error(`[ultrareview] spawn error: ${r.error.message}`);
+    process.exit(2);
+  }
+
+  if (r.status !== 0) {
+    console.error(`[ultrareview] non-zero exit ${r.status} after ${elapsedSec}s`);
+    if (r.stderr) console.error(r.stderr);
+    process.exit(r.status || 3);
+  }
+
+  let bugs = null;
+  try {
+    bugs = JSON.parse(r.stdout);
+  } catch (e) {
+    console.error(`[ultrareview] failed to parse JSON output: ${e.message}`);
+    const rawPath = path.join(REPORT_DIR, `${todayStamp()}.raw.txt`);
+    fs.writeFileSync(rawPath, r.stdout, "utf8");
+    console.error(`[ultrareview] raw output saved to ${rawPath}`);
+    process.exit(4);
+  }
+
+  const reportPath = path.join(REPORT_DIR, `${todayStamp()}.json`);
+  fs.writeFileSync(reportPath, JSON.stringify(bugs, null, 2) + "\n", "utf8");
+  console.log(`[ultrareview] saved to ${reportPath} (${elapsedSec}s)`);
+
+  cap.ur.count += 1;
+
+  const findings = Array.isArray(bugs) ? bugs : Array.isArray(bugs && bugs.bugs) ? bugs.bugs : [];
+  const severeFindings = findings.filter((f) => {
+    const sev = String((f && (f.severity || f.priority)) || "").toLowerCase();
+    return sev === "critical" || sev === "high" || sev === "blocker";
+  });
+
+  if (severeFindings.length > 0) {
+    appendWarning(state, {
+      message: `ultrareview detected ${severeFindings.length} critical/high finding(s)`,
+      severeCount: severeFindings.length,
+      totalCount: findings.length,
+      reportPath: path.relative(process.cwd(), reportPath),
+    });
+    console.log(`[ultrareview][WARN] ${severeFindings.length} critical/high finding(s); recorded to state.warnings`);
+  } else {
+    console.log(`[ultrareview] no critical/high findings (${findings.length} total finding(s))`);
+  }
+
+  writeStateAtomic(state);
+  process.exit(severeFindings.length > 0 ? 1 : 0);
+}
+
+if (require.main === module) main();
+
+module.exports = { parseArgs, checkMonthlyCap, currentMonth };


### PR DESCRIPTION
## Summary

- `scripts/tools/run-ultrareview.js` 新規: `claude ultrareview --json` CLI を node ラッパーで叩く
- `CLAUDE.md §11` に Gate-2b ultrareview 追加 (Trust Level 2+ の PR 必須)

## Script の機能

| 機能 | 内容 |
|---|---|
| 実行 | `claude ultrareview --json [target]` を子プロセスで spawn |
| 結果保存 | `reports/ultrareview/YYYY-MM-DD.json` |
| 重大度判定 | critical / high / blocker → `state.warnings[].kind="ultrareview_blocker"` 追記 |
| 月次上限 | `state.feature_flags.ultrareview.monthly_cap` で制御 (default 50/月、月跨ぎで自動リセット) |
| CLI 引数 | `--target <PR#|branch>` / `--timeout <min>` / `--dry-run` / `--help` |

## 使用例

```bash
node scripts/tools/run-ultrareview.js                    # 現在ブランチ
node scripts/tools/run-ultrareview.js --target 290       # PR #290
node scripts/tools/run-ultrareview.js --dry-run          # 動作確認
node scripts/tools/run-ultrareview.js --timeout 10       # 10 分タイムアウト
```

## 計画書からのスコープ変更

実装着手時に判明: `claude ultrareview` は **デフォルト 30 分のクラウド処理 (課金対象)**。
session-end hook で同期呼び出しすると session 終了が大幅遅延しユーザ体験を損なう。

| 当初計画 | 修正後 (本 PR) |
|---|---|
| session-end.js から自動呼び出し | **script のみ提供。hook 統合は別 PR (PR-7C.1) に分離** |
| Trust Level >= 2 で hook 発火 | Gate-2b は手動 / cron / 別 PR で発火 |

## Test plan

- [x] `claude ultrareview --help` で CLI 仕様確認 (--json / --timeout 対応)
- [x] `node scripts/tools/run-ultrareview.js --dry-run` で動作確認
- [x] `node scripts/tools/run-ultrareview.js --dry-run --target 290 --timeout 10` で引数動作確認
- [ ] CI 全パス
- [ ] (本 PR では実行しない) 実際の `claude ultrareview` 実機呼び出し (課金対象のため要承認後)

## ロールバック

`scripts/tools/run-ultrareview.js` 削除 + `CLAUDE.md` §11 の Gate-2b セクション削除のみ。
hook 統合していないため副作用なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation（ドキュメント）**
  * クラウド審査プロセスに関するドキュメントを更新しました。適用条件、実行手順、結果の管理方法、および運用上の制約事項を明記しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kensan196948G/ClaudeCode-StartUpTools-New/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->