### PR TITLE
feat(phase7d): テンプレ配布 + migration script で全登録プロジェクトに伝播

### DIFF
--- a/Claude/templates/claude/CLAUDE.md
+++ b/Claude/templates/claude/CLAUDE.md
@@ -512,6 +512,22 @@ STABLE 未達は merge / deploy 禁止。
 
 CI が未整備なら、未整備であることを先に記録する。
 
+### Gate-2b: ultrareview (Phase 7C+ / Trust Level 2+ の PR 必須)
+
+PR 作成直後・merge 直前に `node scripts/tools/run-ultrareview.js --target <PR#>` を実行し、
+Claude Code 公式の multi-agent cloud review を行う。
+
+| 適用条件 | 内容 |
+|---|---|
+| Trust Level | 2 以上 |
+| 適用範囲 | open PR (本番 deploy 前必須) |
+| 月次上限 | `state.feature_flags.ultrareview.monthly_cap` で制御 (default 50/月) |
+| 結果保存 | `reports/ultrareview/YYYY-MM-DD.json` |
+| 重大度判定 | critical / high / blocker → `state.warnings[].kind="ultrareview_blocker"` 自動追記 |
+
+**重要**: ultrareview はクラウド処理 (課金対象、最大 30 分)。session-end hook での同期呼び出しは禁止
+(session 終了が大幅遅延する)。手動 / cron / 別 PR で非同期統合する設計とする。
+
 ## 12. Auto Repair 制御 / Stop Conditions（CI Manager）
 
 **Stop Conditions（強制停止）:**

--- a/Claude/templates/claudeos/scripts/tools/run-ultrareview.js
+++ b/Claude/templates/claudeos/scripts/tools/run-ultrareview.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Phase 7C: claude ultrareview CLI ラッパー
+//
+// 機能:
+// - `claude ultrareview --json [target]` を子プロセスで実行
+// - 結果を reports/ultrareview/YYYY-MM-DD.json に保存
+// - blocker/critical を検出した場合 state.warnings[] に kind=ultrareview_blocker を追記
+// - state.feature_flags.ultrareview.monthly_count を更新 (月次上限制御)
+//
+// 使い方:
+//   node scripts/tools/run-ultrareview.js                  # 現在ブランチをレビュー
+//   node scripts/tools/run-ultrareview.js --target 290     # PR #290 をレビュー
+//   node scripts/tools/run-ultrareview.js --target main    # base branch main 差分
+//   node scripts/tools/run-ultrareview.js --dry-run        # 実行せず予定動作のみ表示
+//   node scripts/tools/run-ultrareview.js --timeout 10     # timeout (分) 指定 (default 30)
+//
+// 注意: ultrareview はクラウド処理で課金対象。
+// 月次上限を state.feature_flags.ultrareview.monthly_cap で制御する (default 50)。
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const STATE_FILE = path.join(process.cwd(), "state.json");
+const REPORT_DIR = path.join(process.cwd(), "reports", "ultrareview");
+const DEFAULT_MONTHLY_CAP = 50;
+
+function parseArgs(argv) {
+  const args = { target: null, dryRun: false, timeoutMinutes: 30 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--target") args.target = argv[++i];
+    else if (a === "--timeout") args.timeoutMinutes = parseInt(argv[++i], 10) || 30;
+    else if (a === "-h" || a === "--help") {
+      console.log("Usage: node scripts/tools/run-ultrareview.js [--target <pr#|branch>] [--dry-run] [--timeout <min>]");
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function readState() {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function writeStateAtomic(state) {
+  const tmp = `${STATE_FILE}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2) + "\n", "utf8");
+  fs.renameSync(tmp, STATE_FILE);
+}
+
+function currentMonth() {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function checkMonthlyCap(state) {
+  state.feature_flags = state.feature_flags || {};
+  state.feature_flags.ultrareview = state.feature_flags.ultrareview || {
+    monthly_cap: DEFAULT_MONTHLY_CAP,
+    current_month: currentMonth(),
+    count: 0,
+  };
+  const ur = state.feature_flags.ultrareview;
+  if (ur.current_month !== currentMonth()) {
+    ur.current_month = currentMonth();
+    ur.count = 0;
+  }
+  const cap = ur.monthly_cap || DEFAULT_MONTHLY_CAP;
+  return { allowed: ur.count < cap, used: ur.count, cap, ur };
+}
+
+function appendWarning(state, payload) {
+  state.warnings = state.warnings || [];
+  state.warnings.push({
+    at: new Date().toISOString(),
+    kind: "ultrareview_blocker",
+    ...payload,
+  });
+}
+
+function todayStamp() {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const state = readState();
+  const cap = checkMonthlyCap(state);
+
+  console.log(`[ultrareview] monthly usage: ${cap.used}/${cap.cap}`);
+
+  if (!cap.allowed) {
+    console.log(`[ultrareview] SKIP: monthly cap reached (${cap.used}/${cap.cap}) for ${cap.ur.current_month}`);
+    process.exit(0);
+  }
+
+  const cmd = "claude";
+  const cmdArgs = ["ultrareview", "--json", "--timeout", String(args.timeoutMinutes)];
+  if (args.target) cmdArgs.push(args.target);
+
+  if (args.dryRun) {
+    console.log(`[ultrareview][DRY-RUN] would run: ${cmd} ${cmdArgs.join(" ")}`);
+    console.log(`[ultrareview][DRY-RUN] would save to: ${path.join(REPORT_DIR, `${todayStamp()}.json`)}`);
+    console.log(`[ultrareview][DRY-RUN] monthly count would become: ${cap.used + 1}/${cap.cap}`);
+    process.exit(0);
+  }
+
+  if (!fs.existsSync(REPORT_DIR)) {
+    fs.mkdirSync(REPORT_DIR, { recursive: true });
+  }
+
+  console.log(`[ultrareview] running: ${cmd} ${cmdArgs.join(" ")}`);
+  const startMs = Date.now();
+  const r = spawnSync(cmd, cmdArgs, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    timeout: (args.timeoutMinutes + 2) * 60 * 1000,
+    shell: process.platform === "win32",
+  });
+  const elapsedSec = Math.round((Date.now() - startMs) / 1000);
+
+  if (r.error) {
+    console.error(`[ultrareview] spawn error: ${r.error.message}`);
+    process.exit(2);
+  }
+
+  if (r.status !== 0) {
+    console.error(`[ultrareview] non-zero exit ${r.status} after ${elapsedSec}s`);
+    if (r.stderr) console.error(r.stderr);
+    process.exit(r.status || 3);
+  }
+
+  let bugs = null;
+  try {
+    bugs = JSON.parse(r.stdout);
+  } catch (e) {
+    console.error(`[ultrareview] failed to parse JSON output: ${e.message}`);
+    const rawPath = path.join(REPORT_DIR, `${todayStamp()}.raw.txt`);
+    fs.writeFileSync(rawPath, r.stdout, "utf8");
+    console.error(`[ultrareview] raw output saved to ${rawPath}`);
+    process.exit(4);
+  }
+
+  const reportPath = path.join(REPORT_DIR, `${todayStamp()}.json`);
+  fs.writeFileSync(reportPath, JSON.stringify(bugs, null, 2) + "\n", "utf8");
+  console.log(`[ultrareview] saved to ${reportPath} (${elapsedSec}s)`);
+
+  cap.ur.count += 1;
+
+  const findings = Array.isArray(bugs) ? bugs : Array.isArray(bugs && bugs.bugs) ? bugs.bugs : [];
+  const severeFindings = findings.filter((f) => {
+    const sev = String((f && (f.severity || f.priority)) || "").toLowerCase();
+    return sev === "critical" || sev === "high" || sev === "blocker";
+  });
+
+  if (severeFindings.length > 0) {
+    appendWarning(state, {
+      message: `ultrareview detected ${severeFindings.length} critical/high finding(s)`,
+      severeCount: severeFindings.length,
+      totalCount: findings.length,
+      reportPath: path.relative(process.cwd(), reportPath),
+    });
+    console.log(`[ultrareview][WARN] ${severeFindings.length} critical/high finding(s); recorded to state.warnings`);
+  } else {
+    console.log(`[ultrareview] no critical/high findings (${findings.length} total finding(s))`);
+  }
+
+  writeStateAtomic(state);
+  process.exit(severeFindings.length > 0 ? 1 : 0);
+}
+
+if (require.main === module) main();
+
+module.exports = { parseArgs, checkMonthlyCap, currentMonth };

--- a/docs/phases/phase7d-template-distribution.md
+++ b/docs/phases/phase7d-template-distribution.md
@@ -1,0 +1,114 @@
+# Phase 7D — テンプレート配布 + migration script
+
+**実装日**: 2026-05-20
+**配布範囲**: 全登録プロジェクト
+**先行 PR**: PR-7A (#290) / PR-7B (#291) / PR-7C (#292)
+
+## 📌 概要
+
+PR-7A〜7C の Phase 7 機能を全登録プロジェクトに伝播させる。
+
+| 項目 | 配布方式 | 既存プロジェクト |
+|---|---|---|
+| 項目 A (MCP alwaysLoad) | テンプレ更新 + migration script | **migration script で適用** |
+| 項目 B (autoMode.hard_deny) | user settings | **既に全プロジェクト自動適用** (PR-7B 完了時点) |
+| 項目 C (run-ultrareview.js) | テンプレ Sync (overwrite-on-diff) | **launcher 起動時に自動配布** |
+| 項目 C (CLAUDE.md §11 Gate-2b) | テンプレ Sync | **launcher 起動時に自動配布** |
+
+## 🛠 変更内容
+
+### サブ D-1: テンプレート 3 ファイル更新
+
+- `scripts/templates/claude-mcp.json` — 各 server に `alwaysLoad: true` 追加 (項目 A)
+- `Claude/templates/claude/CLAUDE.md` — §11 に Gate-2b ultrareview 追記 (項目 C)
+- `Claude/templates/claudeos/scripts/tools/run-ultrareview.js` — 新規 (項目 C を配布)
+
+> **項目 B は user settings 専用のためテンプレ対象外** (PR-7B で完了)
+
+### サブ D-2: TemplateSyncManager.ps1 更新
+
+新規 `Sync-ProjectTemplateDirectory` 呼び出しを `Sync-LauncherClaudeGlobalConfig` に追加:
+
+```powershell
+Sync-ProjectTemplateDirectory `
+    -TemplateDir (Join-Path $StartupRoot 'Claude\templates\claudeos\scripts\tools') `
+    -TargetDir (Join-Path $ProjectDir 'scripts\tools') `
+    -Label 'scripts/tools'
+```
+
+これにより `scripts/tools/run-ultrareview.js` が次回 launcher 起動時に各プロジェクトへ配布される。
+
+### サブ D-3: migration script (`scripts/setup/migrate-phase7.js`)
+
+**機能**:
+- 各登録プロジェクトの `.mcp.json` を読み取り、`github` / `memory` / `context7` に `alwaysLoad: true` を差分マージ
+- 冪等 (何度実行しても結果同じ)、既存カスタマイズ保持、バックアップ作成 (`*.bak-phase7`)
+
+**プロジェクト discovery 戦略**:
+1. `config/config.json` の `projectsDir` を取得
+2. `recent-projects.json` から登録プロジェクト名を取り、`projectsDir + name` を確認
+3. (fallback) `projectsDir` 直下を scan して `.mcp.json` を持つディレクトリを追加
+
+**使い方**:
+```bash
+node scripts/setup/migrate-phase7.js --dry-run                # 全プロジェクト差分プレビュー
+node scripts/setup/migrate-phase7.js --apply                  # 全プロジェクトへ適用
+node scripts/setup/migrate-phase7.js --apply --project NAME   # 個別適用
+node scripts/setup/migrate-phase7.js --rollback               # *.bak-phase7 から復元
+```
+
+## ⚠️ 制約 (Linux 側プロジェクト)
+
+本 script は **ローカルファイルアクセスのみ**。SSH モードで `/home/kensan/Projects/` に存在する
+Linux 側プロジェクトには直接適用できない。
+
+### Linux 側プロジェクトへの適用方法
+
+```bash
+# Linux 側で本リポジトリを clone してから:
+ssh kensan@linux-host
+cd /home/kensan/Projects/ClaudeCode-StartUpTools-New
+git pull
+node scripts/setup/migrate-phase7.js --dry-run
+node scripts/setup/migrate-phase7.js --apply
+```
+
+または個別プロジェクトに対して:
+```bash
+# 単一プロジェクトに limited apply
+node scripts/setup/migrate-phase7.js --apply --project Civil-Draw
+```
+
+## ✅ 検証
+
+### 本セッションで実施済み
+- [x] `migrate-phase7.js --dry-run` で Windows ローカル 4 プロジェクト検出 (AEGIS-SIGHT 等)
+- [x] 各プロジェクト 3 server の変更 (`github` / `memory` / `context7`) 予定確認
+- [x] テンプレ JSON / CLAUDE.md / ps1 構文確認
+
+### 本 PR merge 後にユーザが実施
+- [ ] `node scripts/setup/migrate-phase7.js --apply` (Windows 側)
+- [ ] Linux 側に git pull → 同様に apply
+- [ ] 翌セッション以降、各プロジェクトで MCP が即時利用可能か確認
+- [ ] (任意) ローカル統合テスト: 1 プロジェクトで実 migration → rollback → 再 migration の冪等確認
+
+## 🔄 ロールバック
+
+- テンプレ更新: revert で戻る
+- TemplateSyncManager.ps1: revert で戻る
+- 各プロジェクトの .mcp.json: `node scripts/setup/migrate-phase7.js --rollback` で `*.bak-phase7` から復元
+
+## 🌐 全プロジェクト適用の最終状態
+
+| Phase 7 項目 | 既存プロジェクトへの適用方法 |
+|---|---|
+| 項目 A (MCP alwaysLoad) | `node scripts/setup/migrate-phase7.js --apply` (Windows + Linux 各々) |
+| 項目 B (autoMode.hard_deny) | `~/.claude/settings.json` に手動追記 (`docs/phases/phase7b-automode-setup.md` 参照) |
+| 項目 C (run-ultrareview.js) | 次回 launcher 起動時に自動配布 |
+| 項目 C (CLAUDE.md §11 Gate-2b) | 次回 launcher 起動時に自動配布 |
+
+## 🔗 関連
+
+- Phase 7 全体計画: `docs/phases/phase7-cc-features-integration.md` (PR-7A 経由)
+- PR-7B 手順書: `docs/phases/phase7b-automode-setup.md` (PR-7B 経由)
+- PR-7C script: `scripts/tools/run-ultrareview.js` (PR-7C 経由)

--- a/scripts/lib/TemplateSyncManager.ps1
+++ b/scripts/lib/TemplateSyncManager.ps1
@@ -224,6 +224,13 @@ function Sync-LauncherClaudeGlobalConfig {
         -TargetPath (Join-Path $ProjectDir '.claude\statusline.py') `
         -Label '.claude/statusline.py' `
         -EnsureParentDirectory
+
+    # Phase 7D: scripts/tools/ 配下のテンプレを各プロジェクトへ配布。
+    # 現状は run-ultrareview.js のみ。他の tools 配布は別 PR で都度追加する。
+    Sync-ProjectTemplateDirectory `
+        -TemplateDir (Join-Path $StartupRoot 'Claude\templates\claudeos\scripts\tools') `
+        -TargetDir (Join-Path $ProjectDir 'scripts\tools') `
+        -Label 'scripts/tools'
 }
 
 <#

--- a/scripts/setup/migrate-phase7.js
+++ b/scripts/setup/migrate-phase7.js
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+// Phase 7D: 既存登録プロジェクトの .mcp.json に Phase 7A (MCP alwaysLoad) を migration する
+//
+// 背景:
+// - TemplateSyncManager の Initialize-ProjectTemplate は init-only (既存ファイルがあると上書きしない)
+// - そのため .mcp.json への Phase 7A 変更は新規プロジェクトには配布されるが、
+//   既存登録プロジェクトには永遠に届かない
+// - 本 script で各登録プロジェクトの .mcp.json を読み取り、alwaysLoad 設定を差分マージする
+//
+// 対象 MCP server: github / memory / context7 (sequential-thinking は除外)
+//
+// 安全性:
+// - 冪等 (何回実行しても結果が同じ)
+// - 差分マージ (既存のユーザカスタマイズを保持)
+// - バックアップ作成 (*.bak-phase7)
+// - --dry-run で実行前プレビュー
+// - --rollback でバックアップから復元
+//
+// 使い方:
+//   node scripts/setup/migrate-phase7.js --dry-run                # 全登録プロジェクトの差分プレビュー
+//   node scripts/setup/migrate-phase7.js --apply                  # 全登録プロジェクトへ適用
+//   node scripts/setup/migrate-phase7.js --apply --project ProjA  # 個別プロジェクトのみ適用
+//   node scripts/setup/migrate-phase7.js --rollback               # 全プロジェクトを *.bak-phase7 から復元
+
+const fs = require("fs");
+const path = require("path");
+
+const ALWAYS_LOAD_SERVERS = ["github", "memory", "context7"];
+const BACKUP_SUFFIX = ".bak-phase7";
+
+function parseArgs(argv) {
+  const args = {
+    mode: null, // 'dry-run' | 'apply' | 'rollback'
+    projectFilter: null,
+    configPath: null,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") args.mode = "dry-run";
+    else if (a === "--apply") args.mode = "apply";
+    else if (a === "--rollback") args.mode = "rollback";
+    else if (a === "--project") args.projectFilter = argv[++i];
+    else if (a === "--config") args.configPath = argv[++i];
+    else if (a === "-h" || a === "--help") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  if (!args.mode) {
+    console.error("ERROR: must specify one of --dry-run / --apply / --rollback");
+    printHelp();
+    process.exit(2);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`
+Phase 7 migration script — distributes Phase 7A (MCP alwaysLoad) to existing registered projects.
+
+Usage:
+  node scripts/setup/migrate-phase7.js --dry-run                # preview diffs
+  node scripts/setup/migrate-phase7.js --apply                  # apply to all projects
+  node scripts/setup/migrate-phase7.js --apply --project NAME   # apply to specific project
+  node scripts/setup/migrate-phase7.js --rollback               # restore from *.bak-phase7
+
+Options:
+  --config <path>   Path to config.json (default: ./config.json)
+  --project <name>  Filter by project name
+`);
+}
+
+function expandUserPath(p) {
+  if (!p) return p;
+  return p.replace(/^%USERPROFILE%/i, process.env.USERPROFILE || process.env.HOME || "");
+}
+
+function loadRegisteredProjects(configPath) {
+  // Discovery 戦略:
+  // 1. config/config.json から projectsDir と recentProjects.historyFile を読む
+  // 2. recent-projects.json から project name のリストを取得
+  // 3. projectsDir + name でパスを構築
+  // 4. .mcp.json を持つプロジェクトのみ対象とする
+  const cfgPath = configPath || path.join(process.cwd(), "config", "config.json");
+  if (!fs.existsSync(cfgPath)) {
+    console.error(`WARN: ${cfgPath} not found. No projects to migrate.`);
+    return [];
+  }
+  let cfg;
+  try {
+    cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+  } catch (e) {
+    console.error(`ERROR: failed to parse ${cfgPath}: ${e.message}`);
+    process.exit(3);
+  }
+
+  const projectsDir = cfg.projectsDir;
+  if (!projectsDir) {
+    console.error("ERROR: config.json has no projectsDir");
+    return [];
+  }
+
+  const historyFile = expandUserPath(
+    (cfg.recentProjects && cfg.recentProjects.historyFile) || ""
+  );
+  if (!historyFile || !fs.existsSync(historyFile)) {
+    console.error(`WARN: recent-projects.json not found at ${historyFile}`);
+    return [];
+  }
+
+  let history;
+  try {
+    history = JSON.parse(fs.readFileSync(historyFile, "utf8"));
+  } catch (e) {
+    console.error(`ERROR: failed to parse ${historyFile}: ${e.message}`);
+    return [];
+  }
+
+  const seen = new Set();
+  const projects = [];
+
+  // Strategy A: recent-projects.json から名前を取り projectsDir 配下を確認
+  for (const entry of history.projects || []) {
+    if (!entry.project || seen.has(entry.project)) continue;
+    seen.add(entry.project);
+    const projectPath = path.join(projectsDir, entry.project);
+    if (!fs.existsSync(projectPath)) continue;
+    if (!fs.existsSync(path.join(projectPath, ".mcp.json"))) continue;
+    projects.push({ name: entry.project, path: projectPath });
+  }
+
+  // Strategy B (fallback): projectsDir 直下を scan し、.mcp.json を持つ
+  // ディレクトリを追加する (Strategy A で見つからなかったローカルプロジェクト用)
+  try {
+    const entries = fs.readdirSync(projectsDir, { withFileTypes: true });
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      if (seen.has(e.name)) continue;
+      const projectPath = path.join(projectsDir, e.name);
+      if (!fs.existsSync(path.join(projectPath, ".mcp.json"))) continue;
+      seen.add(e.name);
+      projects.push({ name: e.name, path: projectPath, _source: "scan" });
+    }
+  } catch (e) {
+    if (process.env.MIGRATE_PHASE7_DEBUG) {
+      console.error(`[debug] scan ${projectsDir} failed: ${e.message}`);
+    }
+  }
+
+  return projects;
+}
+
+function loadMcp(projectPath) {
+  const mcpPath = path.join(projectPath, ".mcp.json");
+  if (!fs.existsSync(mcpPath)) return { mcpPath, content: null, missing: true };
+  try {
+    const content = JSON.parse(fs.readFileSync(mcpPath, "utf8"));
+    return { mcpPath, content, missing: false };
+  } catch (e) {
+    return { mcpPath, content: null, error: e.message };
+  }
+}
+
+function computeMigration(content) {
+  // alwaysLoad: true をセットすべき server を列挙し、必要な変更を返す
+  if (!content || typeof content !== "object" || !content.mcpServers) {
+    return { changes: [], skipped: true, reason: "no mcpServers section" };
+  }
+  const changes = [];
+  for (const name of ALWAYS_LOAD_SERVERS) {
+    const server = content.mcpServers[name];
+    if (!server) continue;
+    if (server.alwaysLoad === true) continue;
+    changes.push({ server: name, action: "set alwaysLoad: true" });
+  }
+  return { changes, skipped: false };
+}
+
+function applyMigration(content) {
+  for (const name of ALWAYS_LOAD_SERVERS) {
+    const server = content.mcpServers[name];
+    if (!server) continue;
+    if (server.alwaysLoad === true) continue;
+    // alwaysLoad を先頭に挿入したいため、新しい object を作る
+    const reordered = { alwaysLoad: true };
+    for (const k of Object.keys(server)) {
+      if (k !== "alwaysLoad") reordered[k] = server[k];
+    }
+    content.mcpServers[name] = reordered;
+  }
+  return content;
+}
+
+function backupFile(filePath) {
+  const backupPath = filePath + BACKUP_SUFFIX;
+  fs.copyFileSync(filePath, backupPath);
+  return backupPath;
+}
+
+function writeJsonPreserveStyle(filePath, content) {
+  // 2-space indent + trailing newline (project convention)
+  fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + "\n", "utf8");
+}
+
+function processProject(project, mode) {
+  const { mcpPath, content, missing, error } = loadMcp(project.path);
+  const log = (msg) => console.log(`  [${project.name}] ${msg}`);
+
+  if (missing) {
+    log(`SKIP: ${mcpPath} does not exist`);
+    return { project: project.name, status: "skipped", reason: "no .mcp.json" };
+  }
+  if (error) {
+    log(`ERROR: failed to parse .mcp.json: ${error}`);
+    return { project: project.name, status: "error", reason: error };
+  }
+
+  if (mode === "rollback") {
+    const backupPath = mcpPath + BACKUP_SUFFIX;
+    if (!fs.existsSync(backupPath)) {
+      log(`SKIP: no backup at ${backupPath}`);
+      return { project: project.name, status: "skipped", reason: "no backup" };
+    }
+    fs.copyFileSync(backupPath, mcpPath);
+    log(`RESTORED from ${backupPath}`);
+    return { project: project.name, status: "rolled-back" };
+  }
+
+  const migration = computeMigration(content);
+  if (migration.skipped) {
+    log(`SKIP: ${migration.reason}`);
+    return { project: project.name, status: "skipped", reason: migration.reason };
+  }
+  if (migration.changes.length === 0) {
+    log(`OK: already migrated (alwaysLoad set on all eligible servers)`);
+    return { project: project.name, status: "unchanged" };
+  }
+
+  log(`changes (${migration.changes.length}):`);
+  migration.changes.forEach((c) => log(`  - ${c.server}: ${c.action}`));
+
+  if (mode === "dry-run") {
+    return { project: project.name, status: "would-change", changes: migration.changes };
+  }
+
+  // apply
+  const backupPath = backupFile(mcpPath);
+  log(`backup → ${backupPath}`);
+  const updated = applyMigration(content);
+  writeJsonPreserveStyle(mcpPath, updated);
+  log(`APPLIED`);
+  return { project: project.name, status: "applied", changes: migration.changes };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const projects = loadRegisteredProjects(args.configPath);
+  if (projects.length === 0) {
+    console.log("No registered projects found. Exiting.");
+    process.exit(0);
+  }
+
+  const targets = args.projectFilter
+    ? projects.filter((p) => p.name === args.projectFilter)
+    : projects;
+
+  if (targets.length === 0) {
+    console.error(`ERROR: no project matched filter "${args.projectFilter}"`);
+    console.error(`Available projects: ${projects.map((p) => p.name).join(", ")}`);
+    process.exit(4);
+  }
+
+  console.log(`Phase 7 migration mode: ${args.mode}`);
+  console.log(`Target projects (${targets.length}):`);
+  targets.forEach((p) => console.log(`  - ${p.name} @ ${p.path}`));
+  console.log();
+
+  const results = targets.map((p) => processProject(p, args.mode));
+
+  console.log();
+  console.log(`=== Summary (${args.mode}) ===`);
+  const byStatus = results.reduce((acc, r) => {
+    acc[r.status] = (acc[r.status] || 0) + 1;
+    return acc;
+  }, {});
+  Object.entries(byStatus).forEach(([s, n]) => console.log(`  ${s}: ${n}`));
+
+  const errorCount = byStatus.error || 0;
+  process.exit(errorCount > 0 ? 1 : 0);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  parseArgs,
+  computeMigration,
+  applyMigration,
+  ALWAYS_LOAD_SERVERS,
+  BACKUP_SUFFIX,
+};

--- a/scripts/templates/claude-mcp.json
+++ b/scripts/templates/claude-mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "github": {
+      "alwaysLoad": true,
       "command": "npx",
       "args": ["-y", "@anthropic/mcp-server-github"],
       "env": {
@@ -8,6 +9,7 @@
       }
     },
     "memory": {
+      "alwaysLoad": true,
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-memory"],
       "env": {
@@ -19,6 +21,7 @@
       "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
     },
     "context7": {
+      "alwaysLoad": true,
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"],
       "env": {


### PR DESCRIPTION
## Summary

Phase 7 シリーズの最終 PR。PR-7A〜7C の機能を全登録プロジェクトに伝播させる。

| 変更 | 配布対象 | 適用方法 |
|---|---|---|
| `scripts/templates/claude-mcp.json` に alwaysLoad 追加 | 新規プロジェクト | launcher 初回起動時に自動 |
| `Claude/templates/claude/CLAUDE.md §11` に Gate-2b 追記 | 全プロジェクト | launcher 起動時 Sync で自動 |
| `Claude/templates/claudeos/scripts/tools/run-ultrareview.js` 新規 | 全プロジェクト | launcher 起動時 Sync で自動 (TemplateSyncManager.ps1 更新) |
| `scripts/setup/migrate-phase7.js` | 既存プロジェクト | **手動 `--apply` 1 回実行** |

## なぜ migration script が必要か

`TemplateSyncManager.ps1` の `Initialize-ProjectTemplate` は **init-only** (既存ファイルがあると上書きしない)。
そのため `.mcp.json` への Phase 7A 変更は新規プロジェクトには配布されるが、**既存登録プロジェクトには永遠に届かない**。

migration script で各プロジェクトの `.mcp.json` を差分マージする (冪等 / 既存カスタマイズ保持 / バックアップ作成)。

## スコープ変更 (実装中の発見を反映)

| 観点 | 当初計画 | 修正後 |
|---|---|---|
| 項目 B (autoMode) のテンプレ化 | テンプレ settings.json に追加 | **user settings 専用と判明 → テンプレ対象外** |
| migration 対象 | .mcp.json + settings.json | **.mcp.json のみ** (項目 A) |
| テンプレ更新ファイル数 | 4 | **3** |

## 使い方

```bash
# 全プロジェクト差分プレビュー
node scripts/setup/migrate-phase7.js --dry-run

# 全プロジェクトに適用
node scripts/setup/migrate-phase7.js --apply

# 個別プロジェクト
node scripts/setup/migrate-phase7.js --apply --project AEGIS-SIGHT

# ロールバック (*.bak-phase7 から復元)
node scripts/setup/migrate-phase7.js --rollback
```

## Linux 側プロジェクトへの適用

本 script はローカルファイルアクセスのみ。SSH モードで `/home/kensan/Projects/` にあるプロジェクトには:

```bash
ssh kensan@linux-host
cd /home/kensan/Projects/ClaudeCode-StartUpTools-New
git pull
node scripts/setup/migrate-phase7.js --apply
```

## Test plan

- [x] `migrate-phase7.js --dry-run` で Windows ローカル 4 プロジェクト検出
  - AEGIS-SIGHT / ClaudeCode-StartUpTools-New / Codex-StartUpTools-New-BackUp / PC_Optimizer-BackUp20260420
- [x] 各プロジェクト 3 server (github/memory/context7) の変更予定確認
- [x] テンプレ JSON / CLAUDE.md / PowerShell module 構文確認
- [ ] CI 全パス
- [ ] (merge 後) 実 `--apply` 実行 + rollback 動作確認
- [ ] (merge 後) launcher 再起動で run-ultrareview.js が各プロジェクトに配布されるか確認

## ロールバック

- テンプレ更新: revert で戻る
- TemplateSyncManager.ps1: revert で戻る
- 各プロジェクトの .mcp.json: `node scripts/setup/migrate-phase7.js --rollback`

## Phase 7 全体完了状況

| PR | 内容 | 状態 |
|---|---|---|
| #290 | PR-7A: MCP alwaysLoad (本プロジェクト) + Phase 7 計画書 | Open |
| #291 | PR-7B: autoMode.hard_deny (user settings) | Open |
| #292 | PR-7C: run-ultrareview.js + CLAUDE.md §11 Gate-2b | Open |
| **本 PR** | **PR-7D: 全プロジェクト伝播** | **本 PR** |

Phase 7 シリーズ完了後、Linux cron 環境含む全プロジェクトに Phase 7 機能が適用される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * CI品質ゲート「ultrareview」の運用ルールを定義しました
  * Phase 7D テンプレート配布とマイグレーションの実装ドキュメントを追加しました（実装手順、検証項目、ロールバック方法を含む）

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kensan196948G/ClaudeCode-StartUpTools-New/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->