### PR TITLE
fix(phase7d): migrate-phase7.js に Linux config/linux-projects.json サポート追加

### DIFF
--- a/scripts/setup/migrate-phase7.js
+++ b/scripts/setup/migrate-phase7.js
@@ -75,44 +75,11 @@ function expandUserPath(p) {
   return p.replace(/^%USERPROFILE%/i, process.env.USERPROFILE || process.env.HOME || "");
 }
 
-function loadRegisteredProjects(configPath) {
-  // Discovery 戦略:
-  // 1. config/config.json から projectsDir と recentProjects.historyFile を読む
-  // 2. recent-projects.json から project name のリストを取得
-  // 3. projectsDir + name でパスを構築
-  // 4. .mcp.json を持つプロジェクトのみ対象とする
-  const cfgPath = configPath || path.join(process.cwd(), "config", "config.json");
-  if (!fs.existsSync(cfgPath)) {
-    console.error(`WARN: ${cfgPath} not found. No projects to migrate.`);
-    return [];
-  }
-  let cfg;
-  try {
-    cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
-  } catch (e) {
-    console.error(`ERROR: failed to parse ${cfgPath}: ${e.message}`);
-    process.exit(3);
-  }
-
+function discoverProjectsFromWindowsConfig(cfg) {
+  // Windows: config/config.json + recent-projects.json + projectsDir scan
   const projectsDir = cfg.projectsDir;
   if (!projectsDir) {
     console.error("ERROR: config.json has no projectsDir");
-    return [];
-  }
-
-  const historyFile = expandUserPath(
-    (cfg.recentProjects && cfg.recentProjects.historyFile) || ""
-  );
-  if (!historyFile || !fs.existsSync(historyFile)) {
-    console.error(`WARN: recent-projects.json not found at ${historyFile}`);
-    return [];
-  }
-
-  let history;
-  try {
-    history = JSON.parse(fs.readFileSync(historyFile, "utf8"));
-  } catch (e) {
-    console.error(`ERROR: failed to parse ${historyFile}: ${e.message}`);
     return [];
   }
 
@@ -120,17 +87,26 @@ function loadRegisteredProjects(configPath) {
   const projects = [];
 
   // Strategy A: recent-projects.json から名前を取り projectsDir 配下を確認
-  for (const entry of history.projects || []) {
-    if (!entry.project || seen.has(entry.project)) continue;
-    seen.add(entry.project);
-    const projectPath = path.join(projectsDir, entry.project);
-    if (!fs.existsSync(projectPath)) continue;
-    if (!fs.existsSync(path.join(projectPath, ".mcp.json"))) continue;
-    projects.push({ name: entry.project, path: projectPath });
+  const historyFile = expandUserPath(
+    (cfg.recentProjects && cfg.recentProjects.historyFile) || ""
+  );
+  if (historyFile && fs.existsSync(historyFile)) {
+    try {
+      const history = JSON.parse(fs.readFileSync(historyFile, "utf8"));
+      for (const entry of history.projects || []) {
+        if (!entry.project || seen.has(entry.project)) continue;
+        seen.add(entry.project);
+        const projectPath = path.join(projectsDir, entry.project);
+        if (!fs.existsSync(projectPath)) continue;
+        if (!fs.existsSync(path.join(projectPath, ".mcp.json"))) continue;
+        projects.push({ name: entry.project, path: projectPath, _source: "recent" });
+      }
+    } catch (e) {
+      console.error(`WARN: failed to parse ${historyFile}: ${e.message}`);
+    }
   }
 
-  // Strategy B (fallback): projectsDir 直下を scan し、.mcp.json を持つ
-  // ディレクトリを追加する (Strategy A で見つからなかったローカルプロジェクト用)
+  // Strategy B (fallback): projectsDir 直下を scan
   try {
     const entries = fs.readdirSync(projectsDir, { withFileTypes: true });
     for (const e of entries) {
@@ -148,6 +124,89 @@ function loadRegisteredProjects(configPath) {
   }
 
   return projects;
+}
+
+function discoverProjectsFromLinuxConfig(cfg) {
+  // Linux: config/linux-projects.json with basePath + projects array
+  const basePath = cfg.basePath;
+  if (!basePath) {
+    console.error("ERROR: linux-projects.json has no basePath");
+    return [];
+  }
+
+  const seen = new Set();
+  const projects = [];
+
+  // Strategy A: linux-projects.json の projects 配列から名前を取得
+  for (const name of cfg.projects || []) {
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    const projectPath = path.join(basePath, name);
+    if (!fs.existsSync(projectPath)) continue;
+    if (!fs.existsSync(path.join(projectPath, ".mcp.json"))) continue;
+    projects.push({ name, path: projectPath, _source: "linux-registry" });
+  }
+
+  // Strategy B (fallback): basePath 直下も scan
+  try {
+    const entries = fs.readdirSync(basePath, { withFileTypes: true });
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      if (seen.has(e.name)) continue;
+      const projectPath = path.join(basePath, e.name);
+      if (!fs.existsSync(path.join(projectPath, ".mcp.json"))) continue;
+      seen.add(e.name);
+      projects.push({ name: e.name, path: projectPath, _source: "scan" });
+    }
+  } catch (e) {
+    if (process.env.MIGRATE_PHASE7_DEBUG) {
+      console.error(`[debug] scan ${basePath} failed: ${e.message}`);
+    }
+  }
+
+  return projects;
+}
+
+function loadRegisteredProjects(configPath) {
+  // Auto-detect: try explicit --config, then Windows config.json, then Linux linux-projects.json
+  const candidates = configPath
+    ? [configPath]
+    : [
+        path.join(process.cwd(), "config", "config.json"),
+        path.join(process.cwd(), "config", "linux-projects.json"),
+      ];
+
+  let cfgPath = null;
+  for (const c of candidates) {
+    if (fs.existsSync(c)) { cfgPath = c; break; }
+  }
+
+  if (!cfgPath) {
+    console.error(`WARN: no config file found. Tried: ${candidates.join(", ")}`);
+    return [];
+  }
+
+  let cfg;
+  try {
+    cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+  } catch (e) {
+    console.error(`ERROR: failed to parse ${cfgPath}: ${e.message}`);
+    process.exit(3);
+  }
+
+  console.log(`[discovery] using config: ${cfgPath}`);
+
+  // Format detection: linux-projects.json has "basePath" + "projects" array
+  // Windows config.json has "projectsDir" + "recentProjects"
+  if (cfg.basePath && Array.isArray(cfg.projects)) {
+    return discoverProjectsFromLinuxConfig(cfg);
+  }
+  if (cfg.projectsDir) {
+    return discoverProjectsFromWindowsConfig(cfg);
+  }
+
+  console.error(`ERROR: ${cfgPath} has neither basePath+projects (Linux) nor projectsDir (Windows)`);
+  return [];
 }
 
 function loadMcp(projectPath) {


### PR DESCRIPTION
## Summary

Phase 7D の migration script を Linux 環境でも動作するよう修正。

## 問題 (実機判明)

Linux 側 (`/home/kensan/Projects/ClaudeCode-StartUpTools-New`) で実行すると:

\`\`\`
WARN: /home/kensan/Projects/ClaudeCode-StartUpTools-New/config/config.json not found.
No registered projects found. Exiting.
\`\`\`

`config/config.json` は **Windows 専用** (machine-specific でリポジトリ管理外)。
Linux 環境は代わりに `config/linux-projects.json` (basePath + projects 配列形式) を使う。

## 修正内容

`loadRegisteredProjects()` を auto-detect 形式に書き換え:

1. **候補探索**: `--config` 明示 → `config/config.json` → `config/linux-projects.json`
2. **形式判別** (内容ベース):
   - `basePath` + `projects` 配列 → Linux 形式
   - `projectsDir` + `recentProjects` → Windows 形式
3. **共通ロジック**: 名前リスト → `.mcp.json` 持つプロジェクト抽出 + basePath 直下 scan fallback
4. 使用中の config path を `[discovery]` ログで明示

## Linux 側 linux-projects.json 例

\`\`\`json
{
  "host": "192.168.0.185",
  "basePath": "/home/kensan/Projects",
  "projects": [
    "AEGIS-SIGHT",
    "Civil-Draw",
    "ClaudeCode-StartUpTools-New",
    "...19 projects total..."
  ]
}
\`\`\`

## Test plan

- [x] Windows 回帰: 従来通り 4 プロジェクト検出 (AEGIS-SIGHT 等)
  - ClaudeCode-StartUpTools-New 自身は PR-7A merge 後 "already migrated" 報告 ✅ 冪等性確認
- [x] Linux config の形式検出: `--config config/linux-projects.json` で `[discovery] using config: config/linux-projects.json` 表示
- [ ] (merge 後) Linux 実機で 19 プロジェクト検出予定
- [ ] CI 全パス

## ロールバック

`scripts/setup/migrate-phase7.js` のみ revert で戻る。

## 関連

- Phase 7D 元 PR: #293 (merged in 74f938a)
- 検出された不具合: Linux 側で `git pull && node scripts/setup/migrate-phase7.js --apply` を実行した際 0 件返却

🤖 Generated with [Claude Code](https://claude.com/claude-code)