### PR TITLE
feat(setup): ClaudeOS 未導入プロジェクト init スクリプト + SSH stdbuf デプロイ注意

### DIFF
--- a/Claude/templates/claude/ClaudeOS/core/04-agent-teams.md
+++ b/Claude/templates/claude/ClaudeOS/core/04-agent-teams.md
@@ -209,6 +209,11 @@ token をプラン上限に計上する。以下を厳守:
 project 配置分は TemplateSyncManager 経由で全登録プロジェクトへ配布可能。
 （ClaudeOS 専用 workflow の著作は live run 検証を伴うフォローアップで実施）
 
+> 💡 **SSH 越しで migrate / 配布スクリプトを実行する時は `stdbuf -oL -eL node …` を使う**:
+> 非 TTY だと Node の stdout がブロックバッファされ、**完走していても出力が出ず「固まった」ように見える**。
+> `stdbuf -oL` で行バッファ化すれば即時表示。`timeout N` 併用で安全に切り分けできる。
+> 例: `ssh host 'cd <repo> && timeout 120 stdbuf -oL -eL node scripts/setup/migrate-agent-teams.js --apply'`
+
 ### 🔌 無効化（必要時）
 
 `disableWorkflows: true`（settings）/ `CLAUDE_CODE_DISABLE_WORKFLOWS=1` / `/config` トグル。

--- a/scripts/setup/init-claudeos-project.js
+++ b/scripts/setup/init-claudeos-project.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// init-claudeos-project.js — ClaudeOS を未導入プロジェクトに新規導入する
+//
+// 背景:
+// - migrate-agent-teams.js は既存 ClaudeOS プロジェクトへの *差分配布* 専用で、
+//   .claude/claudeos が無いプロジェクトは skip する (例: CivilPDF-DX)。
+// - 本スクリプトは TemplateSyncManager.ps1 の Sync-LauncherClaudeGlobalConfig が行う
+//   テンプレートマッピングを cross-platform (Node) で忠実再現し、ClaudeOS 構造を *新規導入* する。
+//   (正規 init は PowerShell ランチャー結合のため、Linux 単体では使えない)
+//
+// セマンティクス:
+// - copy-if-missing: 既存ファイルは絶対に上書きしない (プロジェクト固有設定を保護)
+// - 冪等: 再実行で up-to-date
+// - --dry-run でプレビュー / --apply で実行
+// - state.json は "YOUR_PROJECT" をターゲット名に置換して seed
+// - skills 配置後に .skills-dirty sentinel を touch → 次セッションで reloadSkills 発火
+//
+// 使い方:
+//   node scripts/setup/init-claudeos-project.js --target /path/to/Project --dry-run
+//   node scripts/setup/init-claudeos-project.js --project CivilPDF-DX --apply
+//   (--project は config/linux-projects.json または config/config.json から解決。.claude 非依存)
+//
+// 導入後は migrate-agent-teams.js --apply で session-start.js 等を最新化することを推奨。
+//
+// SSH tip (Linux): 非 TTY では stdout がバッファされ固まって見えるため stdbuf 推奨:
+//   ssh host 'cd <repo> && stdbuf -oL -eL node scripts/setup/init-claudeos-project.js --project NAME --dry-run'
+
+const fs   = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.join(__dirname, "..", "..");
+
+// Sync-LauncherClaudeGlobalConfig (TemplateSyncManager.ps1:155-234) のマッピングを再現。
+// すべて copy-if-missing。type: "dir" = 再帰コピー / "file" = 単一ファイル。
+const MAPPINGS = [
+  { type: "dir",  src: "Claude/templates/claudeos",               dest: ".claude/claudeos",      label: ".claude/claudeos (本体ツリー)" },
+  { type: "dir",  src: "Claude/templates/claudeos/agents",        dest: ".claude/agents",        label: ".claude/agents (auto-discovery)" },
+  { type: "dir",  src: "Claude/templates/claudeos/commands",      dest: ".claude/commands",      label: ".claude/commands" },
+  { type: "dir",  src: "Claude/templates/claudeos/skills",        dest: ".claude/skills",        label: ".claude/skills" },
+  { type: "dir",  src: "Claude/templates/claudeos/hooks",         dest: ".claude/hooks",         label: ".claude/hooks" },
+  { type: "dir",  src: "Claude/templates/claudeos/scripts/tools", dest: "scripts/tools",         label: "scripts/tools" },
+  { type: "file", src: "Claude/templates/claude/CLAUDE.md",       dest: "CLAUDE.md",             label: "CLAUDE.md" },
+  { type: "file", src: "Claude/templates/claude/settings.json",   dest: ".claude/settings.json", label: ".claude/settings.json" },
+  { type: "file", src: "scripts/templates/claude-mcp.json",       dest: ".mcp.json",             label: ".mcp.json" },
+  { type: "file", src: "scripts/templates/claude-statusline.py",  dest: ".claude/statusline.py", label: ".claude/statusline.py" },
+];
+
+const STATE_TEMPLATE = "Claude/templates/claude/ClaudeOS/templates/state.json";
+const SKILLS_DIRTY    = ".claude/claudeos/.skills-dirty";
+
+// ──────────────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const args = { mode: null, target: null, projectFilter: null, configPath: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if      (a === "--dry-run")  args.mode = "dry-run";
+    else if (a === "--apply")    args.mode = "apply";
+    else if (a === "--target")   args.target = argv[++i];
+    else if (a === "--project")  args.projectFilter = argv[++i];
+    else if (a === "--config")   args.configPath = argv[++i];
+    else if (a === "-h" || a === "--help") { printHelp(); process.exit(0); }
+  }
+  if (!args.mode) {
+    console.error("ERROR: must specify --dry-run or --apply");
+    printHelp();
+    process.exit(2);
+  }
+  if (!args.target && !args.projectFilter) {
+    console.error("ERROR: must specify --target <path> or --project <name>");
+    printHelp();
+    process.exit(2);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`
+init-claudeos-project.js — install ClaudeOS into a project that does not have it yet.
+
+Usage:
+  node scripts/setup/init-claudeos-project.js --target <path> --dry-run
+  node scripts/setup/init-claudeos-project.js --project <name> --apply
+
+Options:
+  --target <path>   Absolute/relative path to the target project directory
+  --project <name>  Resolve target via config/linux-projects.json or config/config.json
+  --config <path>   Explicit config path (default: auto-detect)
+
+Semantics: copy-if-missing (never overwrites existing files), idempotent.
+After init, run migrate-agent-teams.js --apply to refresh session-start.js etc.
+
+SSH tip (Linux): prefix with 'stdbuf -oL -eL' so output streams instead of appearing to hang.
+`);
+}
+
+// .claude を要求しないターゲット解決 (init 対象はまさに .claude が無い)
+function resolveTargetPath(args) {
+  if (args.target) return path.resolve(args.target);
+
+  const candidates = args.configPath ? [args.configPath] : [
+    path.join(process.cwd(), "config", "config.json"),
+    path.join(process.cwd(), "config", "linux-projects.json"),
+  ];
+  let cfgPath = null;
+  for (const c of candidates) { if (fs.existsSync(c)) { cfgPath = c; break; } }
+  if (!cfgPath) { console.error(`ERROR: no config found. Tried: ${candidates.join(", ")}`); process.exit(3); }
+
+  let cfg;
+  try { cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8")); }
+  catch (e) { console.error(`ERROR: failed to parse ${cfgPath}: ${e.message}`); process.exit(3); }
+
+  const base = cfg.basePath || cfg.projectsDir;
+  if (!base) { console.error(`ERROR: ${cfgPath} has neither basePath nor projectsDir`); process.exit(3); }
+  console.log(`[resolve] config: ${cfgPath}`);
+  return path.join(base, args.projectFilter);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+function copyDirIfMissing(srcDir, destDir, plan, dryRun) {
+  if (!fs.existsSync(srcDir)) { plan.srcMissing.push(srcDir); return; }
+  for (const e of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    const s = path.join(srcDir, e.name);
+    const d = path.join(destDir, e.name);
+    if (e.isDirectory()) {
+      copyDirIfMissing(s, d, plan, dryRun);
+    } else if (e.isFile()) {
+      if (fs.existsSync(d)) { plan.skip++; continue; }
+      plan.create++;
+      if (!dryRun) {
+        fs.mkdirSync(path.dirname(d), { recursive: true });
+        fs.copyFileSync(s, d);
+      }
+    }
+  }
+}
+
+function copyFileIfMissing(src, dest, plan, dryRun, transform) {
+  if (!fs.existsSync(src)) { plan.srcMissing.push(src); return; }
+  if (fs.existsSync(dest)) { plan.skip++; return; }
+  plan.create++;
+  if (!dryRun) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    if (transform) {
+      fs.writeFileSync(dest, transform(fs.readFileSync(src, "utf8")), "utf8");
+    } else {
+      fs.copyFileSync(src, dest);
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+function main() {
+  const args       = parseArgs(process.argv.slice(2));
+  const targetPath = resolveTargetPath(args);
+  const projName   = path.basename(targetPath);
+  const dryRun     = args.mode === "dry-run";
+  const tag        = dryRun ? "[DRY-RUN]" : "[APPLY]";
+
+  if (!fs.existsSync(targetPath)) {
+    console.error(`ERROR: target project directory not found: ${targetPath}`);
+    process.exit(4);
+  }
+
+  console.log(`[init] target : ${targetPath}`);
+  console.log(`[init] project: ${projName}`);
+  console.log(`[init] mode   : ${args.mode}`);
+  console.log("");
+
+  const totals = { create: 0, skip: 0, srcMissing: [] };
+
+  for (const m of MAPPINGS) {
+    const src  = path.join(REPO_ROOT, m.src);
+    const dest = path.join(targetPath, m.dest);
+    const plan = { create: 0, skip: 0, srcMissing: [] };
+    if (m.type === "dir") copyDirIfMissing(src, dest, plan, dryRun);
+    else                  copyFileIfMissing(src, dest, plan, dryRun);
+    totals.create += plan.create;
+    totals.skip   += plan.skip;
+    totals.srcMissing.push(...plan.srcMissing);
+    const note = plan.srcMissing.length ? " (SOURCE MISSING!)" : "";
+    console.log(`  ${tag} ${m.label}: +${plan.create} new / ${plan.skip} kept${note}`);
+  }
+
+  // state.json を seed (YOUR_PROJECT → 実プロジェクト名に置換)
+  {
+    const src  = path.join(REPO_ROOT, STATE_TEMPLATE);
+    const dest = path.join(targetPath, "state.json");
+    const plan = { create: 0, skip: 0, srcMissing: [] };
+    copyFileIfMissing(src, dest, plan, dryRun, (txt) => txt.replace(/"YOUR_PROJECT"/g, JSON.stringify(projName)));
+    totals.create += plan.create; totals.skip += plan.skip; totals.srcMissing.push(...plan.srcMissing);
+    console.log(`  ${tag} state.json (name=${projName}): +${plan.create} new / ${plan.skip} kept${plan.srcMissing.length ? " (SOURCE MISSING!)" : ""}`);
+  }
+
+  // skills を配置したので .skills-dirty を touch → 次セッションで reloadSkills 発火
+  if (!dryRun && totals.create > 0) {
+    try {
+      const sentinel = path.join(targetPath, SKILLS_DIRTY);
+      fs.mkdirSync(path.dirname(sentinel), { recursive: true });
+      fs.writeFileSync(sentinel, new Date().toISOString() + "\n", "utf8");
+      console.log(`  [APPLY] touched ${SKILLS_DIRTY} (次セッションで skill 再スキャン)`);
+    } catch (e) { console.error(`  WARN: failed to touch sentinel: ${e.message}`); }
+  }
+
+  console.log("");
+  console.log("─".repeat(60));
+  console.log(`Summary: ${dryRun ? "would-create" : "created"}=${totals.create}  kept=${totals.skip}`);
+  if (totals.srcMissing.length) {
+    console.log(`⚠️  source missing (${totals.srcMissing.length}): ${totals.srcMissing.join(", ")}`);
+  }
+  if (totals.create === 0) {
+    console.log("ClaudeOS は既に導入済みのようです (新規作成ファイルなし)。");
+  } else if (!dryRun) {
+    console.log("");
+    console.log("次の推奨ステップ: session-start.js 等を最新化");
+    console.log("  node scripts/setup/migrate-agent-teams.js --project " + projName + " --apply");
+  }
+}
+
+main();

--- a/scripts/setup/migrate-agent-teams.js
+++ b/scripts/setup/migrate-agent-teams.js
@@ -24,6 +24,11 @@
 //   node scripts/setup/migrate-agent-teams.js --apply                  # 全プロジェクト適用
 //   node scripts/setup/migrate-agent-teams.js --apply --project ProjA  # 個別適用
 //   node scripts/setup/migrate-agent-teams.js --rollback               # 復元
+//
+// SSH 越し実行時の注意 (Linux):
+//   非 TTY では Node の stdout がブロックバッファされ、完走していても出力が出ず「固まった」
+//   ように見える。stdbuf で行バッファ化し timeout で保護すると安全:
+//     ssh host 'cd <repo> && timeout 120 stdbuf -oL -eL node scripts/setup/migrate-agent-teams.js --apply'
 
 const fs   = require("fs");
 const path = require("path");
@@ -84,6 +89,10 @@ Usage:
 Options:
   --config <path>   Path to config.json or linux-projects.json (default: auto-detect)
   --project <name>  Filter by project name
+
+SSH tip (Linux): run with line-buffered stdout so output streams instead of
+appearing to hang on non-TTY sessions:
+  ssh host 'cd <repo> && timeout 120 stdbuf -oL -eL node scripts/setup/migrate-agent-teams.js --apply'
 `);
 }
 


### PR DESCRIPTION
## 📌 Summary

2 つの運用改善。きっかけは PR #295 後の Linux 配布作業で判明した課題。

1. **`init-claudeos-project.js` 新規** — ClaudeOS 未導入プロジェクト (例: CivilPDF-DX) への新規導入スクリプト。`migrate-agent-teams.js` は既存 ClaudeOS プロジェクトへの *差分配布* 専用で `.claude/claudeos` が無い project を skip するため、新規導入の経路が無かった。正規 init (`TemplateSyncManager.ps1` の `Sync-LauncherClaudeGlobalConfig`) は PowerShell ランチャー結合で Linux 単体では使えないため、その 10 マッピングを **Node で cross-platform 再現**。
2. **SSH stdbuf 運用注意の追記** — 非 TTY な SSH で Node スクリプトを実行すると stdout がブロックバッファされ「固まった」ように見える罠 (今回 migrate 実行で遭遇) を doc/help に記録。

## 🛠 Changes

### `8181359` feat(setup): init-claudeos-project.js
- **copy-if-missing** セマンティクス (既存ファイル絶対保護・冪等)
- 10 マッピング: `.claude/claudeos` 本体ツリー + `agents`/`commands`/`skills`/`hooks` の標準パス複製 + `CLAUDE.md`/`settings.json`/`.mcp.json`/`statusline.py` の seed
- `state.json` は `YOUR_PROJECT` → 実プロジェクト名に置換して seed
- skills 配置後 `.skills-dirty` を touch → 次セッションで **reloadSkills 発火** (PR #295 で実装した機能をここで実活用)
- `--target <path>` / `--project <name>` (config 解決・**`.claude` 非依存** = 未導入 project を対象にできる) / `--dry-run` / `--apply`

### `ccee5ce` docs(deploy): SSH stdbuf 注意
- `core/04-agent-teams.md`「保存と全プロジェクト配布」§ + `migrate-agent-teams.js` ヘッダ/`--help` に `stdbuf -oL -eL` + `timeout` の SSH 実行注意を追記

## ✅ Test plan (Windows temp target で検証済)

- [x] `node --check` 構文 OK (両スクリプト)
- [x] `--dry-run` (空 target): would-create=421 / SOURCE MISSING ゼロ (全 source パス解決)
- [x] `--apply`: created=421 / 主要 11 ファイル実在 (session-start.js / reasoning-bank.js / cto.md / tdd.md / SKILL.md / settings.json / CLAUDE.md / .mcp.json / statusline.py / state.json / .skills-dirty)
- [x] `state.json` 名前置換 OK (project.name = target basename)
- [x] 導入された session-start.js が dynamic workflows 版 (workflow gate hint あり)
- [x] 冪等性: 再 `--dry-run` → would-create=0 / kept=421
- [x] テンプレ settings.json は完全配線 (SessionStart/Stop/PreToolUse/PreCompact/PostToolUse + TeamCreate/SendMessage matcher) → init 単独で完全状態に到達

## 🎯 CivilPDF-DX への適用 (merge 後 Linux で実行)

```bash
ssh kensan@kensan1969 'cd ~/Projects/ClaudeCode-StartUpTools-New && git checkout main && git pull && \
  stdbuf -oL -eL node scripts/setup/init-claudeos-project.js --project CivilPDF-DX --dry-run'
# 確認後 --apply、続けて整合確認:
#   node scripts/setup/init-claudeos-project.js --project CivilPDF-DX --apply
#   node scripts/setup/migrate-agent-teams.js --project CivilPDF-DX --dry-run   # up-to-date になるはず
```

## 影響範囲

| カテゴリ | 影響 |
|---|---|
| 新規スクリプト | `init-claudeos-project.js` のみ。既存スクリプト不変 |
| 既存プロジェクト | copy-if-missing で既存ファイルは絶対不変。冪等 |
| doc | core/04 + migrate help に注意書き追記のみ |

## 残課題

- CivilPDF-DX 実導入は merge 後 Linux で実行 (上記コマンド)
- 長期的には正規 init (PowerShell) と本 Node init の責務整理 (どちらを正本とするか)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * SSH経由でのスクリプト実行時の出力表示に関する対策方法を追記しました。非TTY環境での標準出力バッファリングの詳細な説明、推奨設定方法、およびタイムアウト機能を組み合わせた動作確認方法を新たに追加しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kensan196948G/ClaudeCode-StartUpTools-New/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->