### PR TITLE
fix(setup): init-claudeos-project が settings.json の hooks/env を deep-merge

### DIFF
--- a/scripts/setup/init-claudeos-project.js
+++ b/scripts/setup/init-claudeos-project.js
@@ -40,13 +40,16 @@ const MAPPINGS = [
   { type: "dir",  src: "Claude/templates/claudeos/hooks",         dest: ".claude/hooks",         label: ".claude/hooks" },
   { type: "dir",  src: "Claude/templates/claudeos/scripts/tools", dest: "scripts/tools",         label: "scripts/tools" },
   { type: "file", src: "Claude/templates/claude/CLAUDE.md",       dest: "CLAUDE.md",             label: "CLAUDE.md" },
-  { type: "file", src: "Claude/templates/claude/settings.json",   dest: ".claude/settings.json", label: ".claude/settings.json" },
   { type: "file", src: "scripts/templates/claude-mcp.json",       dest: ".mcp.json",             label: ".mcp.json" },
   { type: "file", src: "scripts/templates/claude-statusline.py",  dest: ".claude/statusline.py", label: ".claude/statusline.py" },
 ];
 
-const STATE_TEMPLATE = "Claude/templates/claude/ClaudeOS/templates/state.json";
-const SKILLS_DIRTY    = ".claude/claudeos/.skills-dirty";
+// settings.json は copy-if-missing ではなく deep-merge で処理する (MAPPINGS とは別)。
+// 既存プロジェクトの settings.json は permissions/env をカスタムしている場合があり、
+// それらを保護しつつ ClaudeOS の hooks 登録 + 必要 env を *不足分だけ* 補完する。
+const SETTINGS_TEMPLATE = "Claude/templates/claude/settings.json";
+const STATE_TEMPLATE    = "Claude/templates/claude/ClaudeOS/templates/state.json";
+const SKILLS_DIRTY       = ".claude/claudeos/.skills-dirty";
 
 // ──────────────────────────────────────────────────────────────────────
 function parseArgs(argv) {
@@ -148,6 +151,59 @@ function copyFileIfMissing(src, dest, plan, dryRun, transform) {
   }
 }
 
+// settings.json を deep-merge: hooks (per-event, matcher+command で重複排除) と env を
+// 不足分だけ追加。permissions と既存スカラー値は保護 (上書きしない)。
+function mergeSettings(srcPath, destPath, plan, dryRun) {
+  if (!fs.existsSync(srcPath)) { plan.srcMissing.push(srcPath); return; }
+  if (!fs.existsSync(destPath)) {            // 新規: テンプレをそのままコピー
+    plan.create++;
+    if (!dryRun) { fs.mkdirSync(path.dirname(destPath), { recursive: true }); fs.copyFileSync(srcPath, destPath); }
+    return;
+  }
+  let tmpl, cur;
+  try { tmpl = JSON.parse(fs.readFileSync(srcPath, "utf8")); cur = JSON.parse(fs.readFileSync(destPath, "utf8")); }
+  catch (e) { console.error(`  WARN: settings.json parse 失敗、merge skip: ${e.message}`); plan.skip++; return; }
+
+  let added = 0;
+  // top-level キー (hooks/env/permissions 以外): 欠けていれば追加、既存は保護
+  for (const k of Object.keys(tmpl)) {
+    if (k === "hooks" || k === "env" || k === "permissions") continue;
+    if (!(k in cur)) { cur[k] = tmpl[k]; added++; }
+  }
+  // env: 欠けている key を追加、既存値は保護
+  if (tmpl.env && typeof tmpl.env === "object") {
+    cur.env = (cur.env && typeof cur.env === "object") ? cur.env : {};
+    for (const [k, v] of Object.entries(tmpl.env)) {
+      if (!(k in cur.env)) { cur.env[k] = v; added++; }
+    }
+  }
+  // hooks: event ごとに (matcher + command 群) シグネチャで重複排除して不足分を追加
+  const sig = (e) => JSON.stringify({ m: e.matcher, c: (e.hooks || []).map(h => h.command) });
+  if (tmpl.hooks && typeof tmpl.hooks === "object") {
+    cur.hooks = (cur.hooks && typeof cur.hooks === "object") ? cur.hooks : {};
+    for (const [event, entries] of Object.entries(tmpl.hooks)) {
+      cur.hooks[event] = Array.isArray(cur.hooks[event]) ? cur.hooks[event] : [];
+      const have = new Set(cur.hooks[event].map(sig));
+      for (const entry of entries) {
+        if (!have.has(sig(entry))) { cur.hooks[event].push(entry); have.add(sig(entry)); added++; }
+      }
+    }
+  }
+  // permissions は各プロジェクトのセキュリティ方針なので一切触らない。
+
+  if (added > 0) {
+    plan.merge += added;
+    if (!dryRun) {
+      fs.copyFileSync(destPath, destPath + ".bak-init");
+      const tmp = destPath + ".tmp." + process.pid;
+      fs.writeFileSync(tmp, JSON.stringify(cur, null, 2) + "\n", "utf8");
+      fs.renameSync(tmp, destPath);
+    }
+  } else {
+    plan.skip++;
+  }
+}
+
 // ──────────────────────────────────────────────────────────────────────
 function main() {
   const args       = parseArgs(process.argv.slice(2));
@@ -166,7 +222,7 @@ function main() {
   console.log(`[init] mode   : ${args.mode}`);
   console.log("");
 
-  const totals = { create: 0, skip: 0, srcMissing: [] };
+  const totals = { create: 0, skip: 0, merge: 0, srcMissing: [] };
 
   for (const m of MAPPINGS) {
     const src  = path.join(REPO_ROOT, m.src);
@@ -179,6 +235,17 @@ function main() {
     totals.srcMissing.push(...plan.srcMissing);
     const note = plan.srcMissing.length ? " (SOURCE MISSING!)" : "";
     console.log(`  ${tag} ${m.label}: +${plan.create} new / ${plan.skip} kept${note}`);
+  }
+
+  // settings.json を deep-merge (既存の permissions/env を保護しつつ ClaudeOS の hooks 登録 + env を補完)
+  {
+    const src  = path.join(REPO_ROOT, SETTINGS_TEMPLATE);
+    const dest = path.join(targetPath, ".claude/settings.json");
+    const plan = { create: 0, skip: 0, merge: 0, srcMissing: [] };
+    mergeSettings(src, dest, plan, dryRun);
+    totals.create += plan.create; totals.skip += plan.skip; totals.merge += plan.merge; totals.srcMissing.push(...plan.srcMissing);
+    const detail = plan.create ? "+1 new" : (plan.merge ? `+${plan.merge} merged (hooks/env)` : "up-to-date (kept)");
+    console.log(`  ${tag} .claude/settings.json: ${detail}${plan.srcMissing.length ? " (SOURCE MISSING!)" : ""}`);
   }
 
   // state.json を seed (YOUR_PROJECT → 実プロジェクト名に置換)
@@ -203,12 +270,12 @@ function main() {
 
   console.log("");
   console.log("─".repeat(60));
-  console.log(`Summary: ${dryRun ? "would-create" : "created"}=${totals.create}  kept=${totals.skip}`);
+  console.log(`Summary: ${dryRun ? "would-create" : "created"}=${totals.create}  ${dryRun ? "would-merge" : "merged"}=${totals.merge}  kept=${totals.skip}`);
   if (totals.srcMissing.length) {
     console.log(`⚠️  source missing (${totals.srcMissing.length}): ${totals.srcMissing.join(", ")}`);
   }
-  if (totals.create === 0) {
-    console.log("ClaudeOS は既に導入済みのようです (新規作成ファイルなし)。");
+  if (totals.create === 0 && totals.merge === 0) {
+    console.log("ClaudeOS は既に導入済みのようです (変更なし)。");
   } else if (!dryRun) {
     console.log("");
     console.log("次の推奨ステップ: session-start.js 等を最新化");


### PR DESCRIPTION
## 📌 背景

PR #296 で追加した `init-claudeos-project.js` を CivilPDF-DX に適用した際、ファイル一式 (418) は導入されたが **CivilPDF-DX の既存 settings.json が独自最小構成 (permissions/env のみ・base hooks 未登録)** だったため、`copy-if-missing` で settings.json が skip され、**SessionStart→session-start.js 等の hooks が登録されない**ことが判明 (`session-start.js` 単体実行は成功するが自動発火しない)。

## 🛠 修正

settings.json の処理を `copy-if-missing` → **deep-merge** に変更:

| 対象 | 挙動 |
|---|---|
| `hooks` | event ごとに matcher+command シグネチャで重複排除し、不足エントリを追加 |
| `env` | 欠けている key のみ追加 (既存値は保護) |
| top-level キー | 欠けていれば追加 (outputStyle/language 等) |
| `permissions` | **一切触らない** (プロジェクトのセキュリティ方針を保護) |
| 既存値 | 上書きしない / backup `*.bak-init` 作成 / 冪等 |

## ✅ 検証 (Windows, CivilPDF-DX 類似の最小 settings.json)

- [x] `merged=22`
- [x] `permissions` (allow/deny) 原状保護
- [x] `env`: `NODE_ENV`/`PYTHONDONTWRITEBYTECODE` 保護 + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` 等 ClaudeOS env 追加
- [x] `PostToolUse`: 既存 TeamCreate/SendMessage **重複なし** + usage-tracker/agent-transcript/auto-format 追加
- [x] `SessionStart`/`Stop`/`PreToolUse`/`PreCompact` 追加
- [x] backup `.bak-init` 作成 / 冪等 (再 dry-run `merged=0`)

## 🎯 CivilPDF-DX 仕上げ (merge 後 Linux で再実行)

```bash
ssh kensan@kensan1969 "cd ~/Projects/ClaudeCode-StartUpTools-New && git checkout main && git pull && stdbuf -oL -eL node scripts/setup/init-claudeos-project.js --project CivilPDF-DX --apply"
```
→ 既存 418 ファイルは kept、settings.json に hooks/env が merge され、CivilPDF-DX が完全な ClaudeOS プロジェクトになる。

## 影響範囲
- `init-claudeos-project.js` のみ。permissions・既存値を保護する安全設計。冪等。

🤖 Generated with [Claude Code](https://claude.com/claude-code)