### PR TITLE
fix(setup): init --all --apply に未導入 dir skip ガード

### DIFF
--- a/scripts/setup/init-claudeos-project.js
+++ b/scripts/setup/init-claudeos-project.js
@@ -302,11 +302,20 @@ function main() {
     const dirs     = listAllProjectDirs(args.configPath);
     const selfName = path.basename(process.cwd());
     console.log(`[init --all] mode: ${args.mode}  dirs: ${dirs.length} (self "${selfName}" excluded)`);
+    if (!dryRun) console.log(`[init --all] --apply は既存 ClaudeOS プロジェクト (.claude/claudeos あり) のみ対象。未導入 dir は skip。`);
     console.log("");
     const agg = {};
     for (const d of dirs) {
       const n = path.basename(d);
       if (n === selfName) continue;
+      const onboarded = fs.existsSync(path.join(d, ".claude", "claudeos"));
+      // --apply ガード: .claude/claudeos が無い dir (.pytest_cache / アーカイブ等) は
+      // onboard せず skip し litter を防ぐ。新規 onboard は --project <name> --apply を明示使用。
+      if (!dryRun && !onboarded) {
+        agg["SKIP-NEW"] = (agg["SKIP-NEW"] || 0) + 1;
+        console.log(`  ${n.padEnd(48)} SKIP-NEW (no .claude/claudeos — onboard: --project ${n} --apply)`);
+        continue;
+      }
       const t   = processProject(d, dryRun, true);   // quiet
       const cls = classify(t);
       const key = cls.split(" ")[0];
@@ -316,7 +325,7 @@ function main() {
     console.log("");
     console.log("─".repeat(72));
     console.log(`Summary (${dryRun ? "audit" : "applied"}): ${Object.entries(agg).map(([k, v]) => `${k}=${v}`).join("  ")}`);
-    if (dryRun) console.log("適用: --all --apply (copy-if-missing + settings deep-merge / 既存保護 / backup / 冪等)。");
+    if (dryRun) console.log("適用: --all --apply は既存 ClaudeOS projects のみ完成 (未導入 dir は skip / 既存保護 / backup / 冪等)。");
     return;
   }
 


### PR DESCRIPTION
## 📌 背景

Linux 全プロジェクト監査 (`--all --dry-run`) の結果、`/home/kensan/Projects` 直下に `.pytest_cache` / `Project-Archieve` / `Project-Deployed` / `Project-Documents` 等の**非プロジェクト dir** が存在。`--all --apply` がこれらまで onboard すると litter になる。

## 🛠 修正

`--all --apply` に**ガード**: `.claude/claudeos` が無い dir は `SKIP-NEW` として skip（onboard しない）。新規 onboard は `--project <name> --apply` の明示使用に限定。

- `--all --apply` → 既存 ClaudeOS プロジェクト（PARTIAL/OK）のみ完成、未導入 dir は skip
- `--all --dry-run`（監査）→ 従来どおり全 dir を分類表示（UN-ONBOARDED 含む）。全体像は維持

## ✅ 検証 (Windows mock: claudeos 有/無の 2 dir)

| dir | --all --apply | 結果 |
|---|---|---|
| HasClaudeOS (.claude/claudeos あり) | 処理 | settings.json 作成=適用 ✓ |
| NoClaudeOS (.claude/claudeos なし) | **SKIP-NEW** | `.claude` 未作成=litter なし ✓ |

`--all --dry-run` は両方表示（監査の網羅性維持）。

## 🎯 用途 (merge 後 Linux で PARTIAL 12 件を一括完成)

```
node scripts/setup/init-claudeos-project.js --all --apply
```
→ PARTIAL 12 (Civil-Draw 等) + OK 2 のみ完成（base hooks 補完含む）。`.pytest_cache`/アーカイブ 5 件は SKIP-NEW。

## 影響範囲
- `init-claudeos-project.js` の --all --apply 分岐のみ。dry-run / 単一 --project は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)