### PR TITLE
feat(autonomy): Autonomy Supervisor — Goal到達まで自律再開 (Phase 1/CLI, v3.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 # CHANGELOG
 
+## [v3.4.0] - 2026-06-02 — Autonomy Supervisor（Goal到達まで自律再開・Phase 1/CLI）
+
+### 🎯 概要
+登録プロジェクトを **Goal/Release 到達まで自律再開** させる Autonomy Supervisor を追加（Phase 1: CLI）。各セッションは `cron-launcher.sh` 経由（claude TUI + 自律 + メール + 監視タブメタ）を再利用し、終了を検知して再起動する。暴走/コスト対策のガードレールを必須化し、既定は OFF（opt-in）。
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `lib/supervisor.sh` | **新規**。ガードレール純粋関数（goal/abnormal/cap/crash）＋自律ループ＋状態I/O（`~/.claudeos/supervisor/<safe>.json`） |
+| `bin/autonomy.sh` | **新規**。CLI（`start`/`stop`/`status`/`list`）。`setsid` 常駐起動・cron 競合検知・グレースフル/即時停止 |
+| `tests/bats/unit/supervisor.bats` / `autonomy.bats` | **新規 37 件** |
+
+### ✅ ガードレール（暴走/コスト対策・state.json `supervisor` ブロックで上書き可）
+
+- **停止条件**: Goal到達(`deploy.ready` / `phase_mode∈{maintenance,released}`) / 異常(`kpi.security_critical>0` / `blocked_issues` 非空) / 日次上限(既定 **600分・6回**) / crash-loop(短命セッション連続) / 手動(stop フラグ・kill)
+- **既定 OFF**: 明示 `start` するまで何も自走しない
+- **cron 競合回避**: supervisor 管理プロジェクトに cron 登録が残っていれば `start` 時に警告（`--force` で続行）
+- テスト: 全 bats **188 件**パス / shellcheck error 0
+
+### 🔑 CLI
+
+```bash
+bash bin/autonomy.sh start  <project> [--duration N] [--force]
+bash bin/autonomy.sh stop   <project> [--now]
+bash bin/autonomy.sh status [project]
+bash bin/autonomy.sh list
+```
+
+### 🔜 次フェーズ
+Phase 2: `claudeos-monitor` を統合コントロールセンターに拡張（TUI から 起動 + ライブ監督 + 介入(FG) + supervisor 状態表示）。
+
+---
+
 ## [v3.3.8] - 2026-06-02 — Cron BG 既定化 + ライブ監視タブ（tmux）
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.3.8** (Cron BG既定化 + tmux ライブ監視タブ + 手動メール対応) — 旧: v3.3.7 |
+| バージョン | **v3.4.0** (Autonomy Supervisor — Goal到達まで自律再開 / Phase 1 CLI) — 旧: v3.3.8 |
 | テスト | **776件** — Pester (Unit 21 / Integration 11 / Smoke 1) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | **v9.0** (`/goal` 駆動 / Agent Teams パターン A/B/C / Agent View / 動的判断 / 週次フェーズ制御 / learning パターン記録 / Stop Conditions 厳格化 / Opus 4.7 最適化 / 1H cache / PreCompact hook) |
@@ -417,6 +417,26 @@ bash bin/monitor-sessions.sh open                          # ライブ監視タ�
 > **📧 終了レポートメール**: `~/.env-claudeos` に SMTP 設定 + `CLAUDEOS_EMAIL_ENABLED=1` があると、
 > セッション終了時に HTML レポートメール（`report-and-mail.py`）が送信されます。cron / BG 一括起動に加え、
 > **手動起動（L1/S1）も対応**（`setsid` 常駐 watcher が終了を検知）。手動分のみ止めたい場合は `CLAUDEOS_MANUAL_EMAIL=0`。
+
+#### 🤖 Autonomy Supervisor（Goal到達まで自律再開）— v3.4.0 / Phase 1
+
+登録プロジェクトを **Goal/Release 到達まで止めずに自律実行** させる supervisor（既定 OFF / opt-in）。セッション終了を検知し、未到達なら `cron-launcher.sh` を再起動して文脈継続（`state.json` resume）。暴走/コスト対策のガードレールで必ず停止します。
+
+```bash
+bash bin/autonomy.sh start  <project> [--duration N] [--force]  # 自律再開を開始（setsid 常駐）
+bash bin/autonomy.sh stop   <project> [--now]                   # 停止（--now で現セッションも即kill）
+bash bin/autonomy.sh status [project] | list                   # 状態（restarts/minutes/最終理由）
+```
+
+| 停止条件 | 内容 |
+|---|---|
+| Goal 到達 | `deploy.ready=true` / `phase_mode∈{maintenance,released}` |
+| 異常 | `kpi.security_critical>0` / `blocked_issues` 非空 |
+| 日次上限 | 既定 **600 分 / 6 回**（`state.json` の `supervisor` ブロックで上書き可） |
+| crash-loop / 手動 | 短命セッション連続 / `stop` |
+
+> ⚠️ supervisor 管理プロジェクトは **cron 登録を外す**（二重起動回避）。残っている場合 `start` は警告し、`--force` で続行。
+> 🔜 Phase 2 でライブ監視タブ（`claudeos-monitor`）から起動・監督・介入を統合予定。
 
 Linux native メニューを使う場合は `./start.sh` を実行します。項目 `7` は `~/.claudeos/{logs,sessions,tmp}` と `~/.tmux.conf` の ClaudeOS 管理ブロックを作成・更新します。
 

--- a/bin/autonomy.sh
+++ b/bin/autonomy.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ============================================================
+# autonomy.sh — Autonomy Supervisor CLI (ClaudeOS v3.4.0)
+#
+# 登録プロジェクトを Goal/Release 到達まで自律再開させる supervisor を管理する。
+# 各セッションは cron-launcher.sh 経由 (= claude TUI + 自律 + メール + 監視タブメタ)。
+#
+# 使い方:
+#   autonomy.sh start  <project> [--duration N] [--force]   # supervisor 起動 (setsid 常駐)
+#   autonomy.sh stop   <project> [--now]                    # グレースフル停止 (--now で即kill)
+#   autonomy.sh status [project]                            # 状態表示 (省略時は全件)
+#   autonomy.sh list                                        # 一覧
+#
+# 安全: 既定 OFF (明示 start するまで何も自走しない)。日次上限/Goal/Blocked で必ず停止。
+#       supervisor 管理プロジェクトに cron 登録があると競合するため start 時に警告
+#       (--force で続行可。推奨は項14 で当該 cron を削除)。
+# ============================================================
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+# shellcheck source=lib/config-loader.sh
+source "$SCRIPT_DIR/../lib/config-loader.sh"
+# shellcheck source=lib/launcher-common.sh
+source "$SCRIPT_DIR/../lib/launcher-common.sh"
+# shellcheck source=lib/cron-manager.sh
+source "$SCRIPT_DIR/../lib/cron-manager.sh"
+# shellcheck source=lib/supervisor.sh
+source "$SCRIPT_DIR/../lib/supervisor.sh"
+
+SELF="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
+
+# au__has_cron <project> — 当該プロジェクトの CLAUDEOS cron エントリがあれば 0
+au__has_cron() {
+  cron__list 2>/dev/null | awk -F'|' -v p="$1" '$2==p {f=1} END{exit !f}'
+}
+
+# au__start <project> [--duration N] [--force]
+au__start() {
+  local project="" duration="" force=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --duration) duration="$2"; shift 2 ;;
+      --force)    force=1; shift ;;
+      --*)        log_error "start: 不明な引数: $1"; return 1 ;;
+      *)          project="$1"; shift ;;
+    esac
+  done
+  [[ -n "$project" ]] || { log_error "start: <project> は必須"; return 1; }
+  launcher__project_exists "$project" || { log_error "プロジェクトが存在しません: $(launcher__project_dir "$project")"; return 1; }
+  [[ -f "$SUP_CRON_LAUNCHER" ]] || { log_error "cron-launcher.sh が見つかりません: $SUP_CRON_LAUNCHER"; return 1; }
+
+  if sup__is_running "$project"; then
+    log_warn "既に supervisor 稼働中: $project (pid=$(sup__get "$project" pid 0))"
+    return 0
+  fi
+
+  # cron 競合チェック (承認方針: supervisor 管理中は cron 登録を外す)
+  if au__has_cron "$project"; then
+    if (( force )); then
+      log_warn "cron 登録ありだが --force のため続行: $project (二重起動に注意)"
+    else
+      log_error "cron 登録が残っています: $project"
+      log_info  "  競合回避のため項14で当該 cron を削除してから start するか、--force を付けてください"
+      return 1
+    fi
+  fi
+
+  local runner logf
+  mkdir -p "$SUP_DIR"; chmod 700 "$SUP_DIR" 2>/dev/null || true
+  rm -f "$(sup__stop_file "$project")"   # 起動前に古い stop フラグをクリア (fresh start)
+  logf="$SUP_DIR/$(ccsu_safe_name "$project").log"
+  if has_cmd setsid; then runner=setsid; else runner=nohup; fi
+  "$runner" bash "$SELF" __run "$project" ${duration:+"$duration"} </dev/null >>"$logf" 2>&1 &
+  disown 2>/dev/null || true
+
+  # 起動確認 (state ファイルが書かれるまで軽く待つ)
+  local i
+  for ((i = 0; i < 10; i++)); do
+    [[ -f "$(sup__state_file "$project")" ]] && break
+    sleep 0.2
+  done
+  log_ok "supervisor 起動: $project"
+  log_info "  状態: bash bin/autonomy.sh status $project   ログ: $logf"
+  log_info "  停止: bash bin/autonomy.sh stop $project    (--now で即停止)"
+}
+
+# au__stop <project> [--now]
+au__stop() {
+  local project="" now=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --now) now=1; shift ;;
+      --*)   log_error "stop: 不明な引数: $1"; return 1 ;;
+      *)     project="$1"; shift ;;
+    esac
+  done
+  [[ -n "$project" ]] || { log_error "stop: <project> は必須"; return 1; }
+
+  if ! sup__is_running "$project" && [[ ! -f "$(sup__state_file "$project")" ]]; then
+    log_warn "supervisor は稼働していません: $project"
+    return 0
+  fi
+  sup__request_stop "$project"
+  log_ok "停止要求: $project (現セッション終了後に再起動を止めます)"
+
+  if (( now )); then
+    local pid safe; pid="$(sup__get "$project" pid 0)"; safe="$(ccsu_safe_name "$project")"
+    [[ "$pid" =~ ^[0-9]+$ ]] && (( pid > 0 )) && kill "$pid" 2>/dev/null || true
+    "$SUP_TMUX_BIN" kill-session -t "claudeos-$safe" 2>/dev/null || true
+    "$SUP_TMUX_BIN" kill-session -t "_keeper_$safe" 2>/dev/null || true
+    log_info "  --now: supervisor と現セッションを即停止しました"
+  fi
+}
+
+# au__render <project> — 1 プロジェクトの状態を 1 行で
+au__render() {
+  local project="$1" f status restarts minutes reason alive
+  f="$(sup__state_file "$project")"
+  [[ -f "$f" ]] || { printf '  %-26s %s(状態ファイルなし)%s\n' "$project" "$C_GRAY" "$C_RESET"; return 0; }
+  status="$(json_get "$f" '.status' '?')"
+  restarts="$(json_get "$f" '.restarts_today' '0')"
+  minutes="$(json_get "$f" '.minutes_today' '0')"
+  reason="$(json_get "$f" '.last_reason' '')"
+  if sup__is_running "$project"; then alive="● 稼働"; else alive="○ 停止"; fi
+  printf '  %-26s %-8s %-10s restarts=%-3s minutes=%-4s %s\n' \
+    "$project" "$alive" "$status" "$restarts" "$minutes" "$reason"
+}
+
+# au__status [project]
+au__status() {
+  if [[ -n "${1:-}" ]]; then au__render "$1"; return 0; fi
+  au__list
+}
+
+# au__list — 全 supervisor を列挙
+au__list() {
+  printf '  %s● Autonomy Supervisor 一覧:%s\n' "$C_GREEN" "$C_RESET"
+  local found=0 f project
+  if [[ -d "$SUP_DIR" ]]; then
+    for f in "$SUP_DIR"/*.json; do
+      [[ -f "$f" ]] || continue
+      found=1
+      project="$(json_get "$f" '.project' "$(basename "$f" .json)")"
+      au__render "$project"
+    done
+  fi
+  (( found == 0 )) && printf '  %s(supervisor なし)%s\n' "$C_GRAY" "$C_RESET"
+  return 0
+}
+
+main() {
+  require_cmd jq
+  case "${1:-}" in
+    start)   shift; au__start "$@" ;;
+    stop)    shift; au__stop "$@" ;;
+    status)  shift; au__status "$@" ;;
+    list)    au__list ;;
+    __run)   shift; sup__loop "$@" ;;   # setsid から呼ばれる本体
+    ""|--help|-h)
+      printf 'Usage: autonomy.sh start|stop|status|list <project> [opts]\n'
+      printf '  start  <project> [--duration N] [--force]\n'
+      printf '  stop   <project> [--now]\n'
+      printf '  status [project]\n'
+      printf '  list\n' ;;
+    *) log_error "不明なサブコマンド: $1 (start|stop|status|list)"; return 1 ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# ============================================================
+# supervisor.sh — Autonomy Supervisor (Goal 到達まで自律再開) — ClaudeOS v3.4.0
+#
+# 役割:
+#   登録プロジェクトの自律セッション (cron-launcher.sh) をセッション終了後に
+#   再起動し、Goal/Release 到達 または ガードレール抵触まで「止まらない」自律を実現する。
+#   各セッションは cron-launcher 経由なので TUI(claude) + resume header + メール + 監視タブ
+#   メタデータをそのまま再利用する (自律エンジンを新規実装しない)。
+#
+# 停止条件 (いずれかで停止):
+#   - Goal 到達 : project state.json の deploy.ready=true / phase_mode∈{maintenance,released}
+#   - 異常      : kpi.security_critical>0 / blocked_issues 非空
+#   - 上限      : 1日合計実行 >= daily_max_minutes / 再起動 >= max_restarts_per_day
+#   - crash-loop: 極端に短いセッションが crash_loop_threshold 連続
+#   - 手動      : stop フラグ / プロセス kill
+#
+# ガードレール既定値 (project state.json の "supervisor" ブロックで上書き可):
+#   daily_max_minutes=600 / max_restarts_per_day=6 / session_minutes=300
+#   cooldown_seconds=30 / crash_loop_threshold=3 / crash_loop_min_seconds=120
+#
+# テスト用 env 上書き:
+#   CCSU_SUP_DIR           : 状態ディレクトリ      (既定 $CCSU_HOME/supervisor)
+#   CCSU_SUP_CRON_LAUNCHER : cron-launcher.sh パス (既定 ~/.claudeos/cron-launcher.sh)
+#   CCSU_SUP_TODAY         : 当日 (YYYY-MM-DD)     (日次リセット検証用)
+#   CCSU_SUP_COOLDOWN      : クールダウン秒上書き  (テストは 0)
+#   CCSU_TMUX_BIN          : tmux コマンド         (--now 停止時のセッション kill)
+# ============================================================
+
+[[ -n "${_CCSU_SUPERVISOR_LOADED:-}" ]] && return 0
+_CCSU_SUPERVISOR_LOADED=1
+
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/json.sh"
+
+SUP_DIR="${CCSU_SUP_DIR:-$CCSU_HOME/supervisor}"
+SUP_CRON_LAUNCHER="${CCSU_SUP_CRON_LAUNCHER:-$HOME/.claudeos/cron-launcher.sh}"
+SUP_TMUX_BIN="${CCSU_TMUX_BIN:-tmux}"
+
+# ガードレール既定値
+SUP_DEF_DAILY_MAX_MIN=600
+SUP_DEF_MAX_RESTARTS=6
+SUP_DEF_SESSION_MIN=300
+SUP_DEF_COOLDOWN=30
+SUP_DEF_CRASH_THRESHOLD=3
+SUP_DEF_CRASH_MIN_SEC=120
+
+# ------------------------------------------------------------
+# パス/基本ヘルパ
+# ------------------------------------------------------------
+sup__state_file() { printf '%s/%s.json' "$SUP_DIR" "$(ccsu_safe_name "$1")"; }
+sup__stop_file()  { printf '%s/%s.stop' "$SUP_DIR" "$(ccsu_safe_name "$1")"; }
+sup__today()      { printf '%s' "${CCSU_SUP_TODAY:-$(date +%Y-%m-%d)}"; }
+sup__now_iso()    { date -Iseconds; }
+
+# sup__guard <project_state_json> <key> <default> — supervisor 設定値を取得
+sup__guard() {
+  local pstate="$1" key="$2" def="$3" v=""
+  [[ -f "$pstate" ]] && v="$(json_get "$pstate" ".supervisor.$key" "")"
+  [[ "$v" =~ ^[0-9]+$ ]] && printf '%s' "$v" || printf '%s' "$def"
+}
+
+# ------------------------------------------------------------
+# 純粋ガードレール判定 (引数 in / 理由文字列 out。空 = 継続)
+# ------------------------------------------------------------
+
+# sup__goal_reason <deploy_ready> <phase_mode>
+sup__goal_reason() {
+  local ready="$1" mode="$2"
+  [[ "$ready" == "true" ]] && { printf 'goal-reached:deploy.ready'; return 0; }
+  case "$mode" in
+    maintenance|released) printf 'goal-reached:phase_mode=%s' "$mode" ;;
+    *) : ;;
+  esac
+}
+
+# sup__abnormal_reason <security_critical> <blocked_count>
+sup__abnormal_reason() {
+  local sec="${1:-0}" blocked="${2:-0}"
+  [[ "$sec" =~ ^[0-9]+$ ]] || sec=0
+  [[ "$blocked" =~ ^[0-9]+$ ]] || blocked=0
+  if   (( sec > 0 ));     then printf 'blocked:security_critical=%s' "$sec"
+  elif (( blocked > 0 )); then printf 'blocked:blocked_issues=%s' "$blocked"
+  fi
+}
+
+# sup__cap_reason <minutes_today> <daily_max> <restarts_today> <max_restarts>
+sup__cap_reason() {
+  local min="${1:-0}" dmax="${2:-0}" rst="${3:-0}" rmax="${4:-0}"
+  if   (( dmax > 0 && min >= dmax )); then printf 'daily-cap:minutes=%s/%s' "$min" "$dmax"
+  elif (( rmax > 0 && rst >= rmax )); then printf 'daily-cap:restarts=%s/%s' "$rst" "$rmax"
+  fi
+}
+
+# sup__crash_reason <consecutive_short> <threshold>
+sup__crash_reason() {
+  local cs="${1:-0}" th="${2:-3}"
+  (( th > 0 && cs >= th )) && printf 'crash-loop:short_sessions=%s' "$cs"
+}
+
+# sup__project_stop_reason <project_state_json> — 到達/異常を集約 (空=継続)
+sup__project_stop_reason() {
+  local pstate="$1" ready mode sec blocked reason
+  [[ -f "$pstate" ]] || return 0
+  ready="$(json_get "$pstate" '.deploy.ready' 'false')"
+  mode="$(json_get "$pstate" '.project.phase_mode' '')"
+  [[ -z "$mode" ]] && mode="$(json_get "$pstate" '.maintenance.phase_mode' '')"
+  sec="$(json_get "$pstate" '.kpi.security_critical' '0')"
+  blocked="$(json_get "$pstate" '.blocked_issues | length' '0')"
+  reason="$(sup__goal_reason "$ready" "$mode")"; [[ -n "$reason" ]] && { printf '%s' "$reason"; return 0; }
+  reason="$(sup__abnormal_reason "$sec" "$blocked")"; [[ -n "$reason" ]] && { printf '%s' "$reason"; return 0; }
+}
+
+# ------------------------------------------------------------
+# supervisor 状態ファイル I/O (フラット JSON。SUP_* 作業変数を書き出す)
+# ------------------------------------------------------------
+sup__persist() {
+  local project="$1" f tmp ended_json="null"
+  f="$(sup__state_file "$project")"
+  mkdir -p "$SUP_DIR"; chmod 700 "$SUP_DIR" 2>/dev/null || true
+  [[ -n "${SUP_ENDED_AT:-}" ]] && ended_json="\"$SUP_ENDED_AT\""
+  tmp="$f.tmp.$$"
+  cat > "$tmp" <<JSON
+{
+  "project": "$project",
+  "status": "${SUP_STATUS:-running}",
+  "pid": ${SUP_PID:-0},
+  "started_at": "${SUP_STARTED_AT:-}",
+  "ended_at": ${ended_json},
+  "day": "${SUP_DAY:-}",
+  "restarts_today": ${SUP_RESTARTS:-0},
+  "minutes_today": ${SUP_MINUTES:-0},
+  "consecutive_short": ${SUP_CONSEC_SHORT:-0},
+  "last_session_secs": ${SUP_LAST_SECS:-0},
+  "last_reason": "${SUP_LAST_REASON:-}",
+  "updated_at": "$(sup__now_iso)"
+}
+JSON
+  mv "$tmp" "$f"
+}
+
+# sup__get <project> <field> <default> — 状態フィールド読取
+sup__get() {
+  local f; f="$(sup__state_file "$1")"
+  [[ -f "$f" ]] || { printf '%s' "$3"; return 0; }
+  json_get "$f" ".$2" "$3"
+}
+
+# sup__is_running <project> — pid 生存かつ status=running なら 0
+sup__is_running() {
+  local f pid status; f="$(sup__state_file "$1")"
+  [[ -f "$f" ]] || return 1
+  status="$(json_get "$f" '.status' '')"
+  pid="$(json_get "$f" '.pid' '0')"
+  [[ "$status" == "running" ]] || return 1
+  [[ "$pid" =~ ^[0-9]+$ ]] && (( pid > 0 )) || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+# sup__request_stop <project> — グレースフル停止フラグ
+sup__request_stop() {
+  mkdir -p "$SUP_DIR"
+  : > "$(sup__stop_file "$1")"
+}
+
+# ------------------------------------------------------------
+# sup__sleep <seconds> — stop フラグを見ながら中断可能スリープ (テストは即時)
+# ------------------------------------------------------------
+sup__sleep() {
+  local project="$1" secs="$2" i
+  (( secs <= 0 )) && return 0
+  for ((i = 0; i < secs; i++)); do
+    [[ -f "$(sup__stop_file "$project")" ]] && return 0
+    sleep 1
+  done
+}
+
+# ------------------------------------------------------------
+# sup__loop <project> [duration_min] — supervisor 本体 (setsid から実行)
+# ------------------------------------------------------------
+sup__loop() {
+  local project="$1" duration="${2:-}"
+  local safe base project_dir pstate
+  safe="$(ccsu_safe_name "$project")"
+  base="$(json_get "$CCSU_CONFIG_PATH" '.linuxBase' "$HOME/Projects")"
+  project_dir="$base/$project"
+  pstate="$project_dir/state.json"
+
+  # ガードレール値 (project state.json で上書き可)
+  local daily_max max_restarts session_min cooldown crash_th crash_min
+  daily_max="$(sup__guard "$pstate" daily_max_minutes "$SUP_DEF_DAILY_MAX_MIN")"
+  max_restarts="$(sup__guard "$pstate" max_restarts_per_day "$SUP_DEF_MAX_RESTARTS")"
+  session_min="${duration:-$(sup__guard "$pstate" session_minutes "$SUP_DEF_SESSION_MIN")}"
+  cooldown="${CCSU_SUP_COOLDOWN:-$(sup__guard "$pstate" cooldown_seconds "$SUP_DEF_COOLDOWN")}"
+  crash_th="$(sup__guard "$pstate" crash_loop_threshold "$SUP_DEF_CRASH_THRESHOLD")"
+  crash_min="$(sup__guard "$pstate" crash_loop_min_seconds "$SUP_DEF_CRASH_MIN_SEC")"
+
+  # 作業変数 (SUP_* グローバル: sup__persist が書き出す)
+  SUP_PID=$$; SUP_STATUS=running; SUP_STARTED_AT="$(sup__now_iso)"; SUP_ENDED_AT=""
+  SUP_DAY="$(sup__today)"; SUP_RESTARTS=0; SUP_MINUTES=0; SUP_CONSEC_SHORT=0
+  SUP_LAST_SECS=0; SUP_LAST_REASON=""
+  # 注: stop フラグのクリアは呼び出し側 (au__start) が起動前に行う。
+  #     ここでクリアしないことで、起動前/実行中に立てたフラグを確実に拾える。
+  sup__persist "$project"
+  log_info "[supervisor] start: $project (daily_max=${daily_max}m restarts=${max_restarts} session=${session_min}m)"
+
+  local stop_reason="" sess_start sess_end sess_secs
+  while true; do
+    # 1) 手動停止
+    if [[ -f "$(sup__stop_file "$project")" ]]; then stop_reason="stopped:manual"; break; fi
+    # 2) 日次リセット
+    if [[ "$SUP_DAY" != "$(sup__today)" ]]; then
+      SUP_DAY="$(sup__today)"; SUP_RESTARTS=0; SUP_MINUTES=0; SUP_CONSEC_SHORT=0
+    fi
+    # 3) Goal/異常 (セッション前)
+    stop_reason="$(sup__project_stop_reason "$pstate")"; [[ -n "$stop_reason" ]] && break
+    # 4) 日次上限
+    stop_reason="$(sup__cap_reason "$SUP_MINUTES" "$daily_max" "$SUP_RESTARTS" "$max_restarts")"; [[ -n "$stop_reason" ]] && break
+    # 5) crash-loop
+    stop_reason="$(sup__crash_reason "$SUP_CONSEC_SHORT" "$crash_th")"; [[ -n "$stop_reason" ]] && break
+
+    # 6) 1 セッション実行 (cron-launcher がセッション終了までブロック)
+    if [[ ! -f "$SUP_CRON_LAUNCHER" ]]; then stop_reason="stopped:launcher-missing"; break; fi
+    SUP_STATUS=running; SUP_LAST_REASON="launching session"; sup__persist "$project"
+    sess_start="$(date +%s)"
+    bash "$SUP_CRON_LAUNCHER" "$project" "$session_min" || true
+    sess_end="$(date +%s)"; sess_secs=$(( sess_end - sess_start )); (( sess_secs < 0 )) && sess_secs=0
+
+    # 7) カウンタ更新
+    SUP_RESTARTS=$(( SUP_RESTARTS + 1 ))
+    SUP_MINUTES=$(( SUP_MINUTES + sess_secs / 60 ))
+    SUP_LAST_SECS="$sess_secs"
+    if (( sess_secs < crash_min )); then SUP_CONSEC_SHORT=$(( SUP_CONSEC_SHORT + 1 )); else SUP_CONSEC_SHORT=0; fi
+    SUP_LAST_REASON="session ended (${sess_secs}s)"; sup__persist "$project"
+
+    # 8) Goal/異常 (セッション後)
+    stop_reason="$(sup__project_stop_reason "$pstate")"; [[ -n "$stop_reason" ]] && break
+
+    # 9) クールダウン
+    sup__sleep "$project" "$cooldown"
+  done
+
+  # 終了処理
+  case "$stop_reason" in
+    goal-reached:*) SUP_STATUS="goal-reached" ;;
+    blocked:*)      SUP_STATUS="blocked" ;;
+    crash-loop:*)   SUP_STATUS="crash-loop" ;;
+    daily-cap:*)    SUP_STATUS="daily-cap" ;;
+    *)              SUP_STATUS="stopped" ;;
+  esac
+  SUP_LAST_REASON="$stop_reason"; SUP_ENDED_AT="$(sup__now_iso)"
+  sup__persist "$project"
+  rm -f "$(sup__stop_file "$project")"
+  log_info "[supervisor] stop: $project → status=$SUP_STATUS reason=$stop_reason restarts=$SUP_RESTARTS minutes=$SUP_MINUTES"
+}

--- a/tests/bats/unit/autonomy.bats
+++ b/tests/bats/unit/autonomy.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+# ============================================================
+# autonomy.bats — bin/autonomy.sh (Autonomy Supervisor CLI) のテスト
+#   setsid/tmux/crontab を stub 化。__run は実行せず spawn 経路のみ検証。
+# ============================================================
+
+load '../helpers/common-setup'
+
+setup() {
+  _bats_common_setup
+  export AI_STARTUP_CONFIG_PATH="$TEST_TEMP/config.json"
+  printf '{ "linuxBase": "%s/projects" }\n' "$TEST_TEMP" > "$AI_STARTUP_CONFIG_PATH"
+  mkdir -p "$TEST_TEMP/projects/Demo"
+  export CCSU_SUP_DIR="$TEST_TEMP/sup"
+  export CCSU_SUP_CRON_LAUNCHER="$TEST_TEMP/cron-launcher.sh"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$CCSU_SUP_CRON_LAUNCHER"; chmod +x "$CCSU_SUP_CRON_LAUNCHER"
+
+  export CRON_STORE="$TEST_TEMP/crontab.store"
+  make_stub_bin crontab '
+store="${CRON_STORE:?}"
+case "${1:-}" in
+  -l) [[ -f "$store" ]] && cat "$store" || exit 1 ;;
+  -)  cat > "$store" ;;
+  *)  exit 2 ;;
+esac
+'
+  # setsid: spawn 引数を記録し、起動確認用に state ファイルも生成 (poll 高速化)
+  make_stub_bin setsid '
+echo "$@" >> "$TEST_TEMP/setsid.log"
+p="${4:-}"
+[[ -n "$p" ]] && { mkdir -p "$CCSU_SUP_DIR"; printf "{\"project\":\"%s\",\"status\":\"running\",\"pid\":%s}\n" "$p" "$$" > "$CCSU_SUP_DIR/$p.json"; }
+exit 0
+'
+  make_stub_bin tmux 'echo "$@" >> "$TEST_TEMP/tmux.log"; exit 0'
+  export CCSU_TMUX_BIN=tmux
+  SCRIPT="$REPO_ROOT/bin/autonomy.sh"
+}
+teardown() { _bats_common_teardown; }
+
+_seed_cron() {
+  cat > "$CRON_STORE" <<EOF
+# CLAUDEOS:abc12345 project=$1 duration=300 created=2026-01-01T00:00:00
+0 21 * * 1,2,3,4,5,6 bash /x/cron-launcher.sh $1 300
+EOF
+}
+
+@test "start: cron 登録ありは --force 無しで拒否 (spawn しない)" {
+  _seed_cron Demo
+  run bash "$SCRIPT" start Demo
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cron 登録が残っています"* ]]
+  [ ! -f "$TEST_TEMP/setsid.log" ]
+}
+
+@test "start: cron 無し → setsid で __run 起動" {
+  run bash "$SCRIPT" start Demo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"supervisor 起動: Demo"* ]]
+  [ -f "$TEST_TEMP/setsid.log" ]
+  grep -q "__run Demo" "$TEST_TEMP/setsid.log"
+}
+
+@test "start: --force で cron ありでも続行" {
+  _seed_cron Demo
+  run bash "$SCRIPT" start Demo --force
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--force"* ]]
+  grep -q "__run Demo" "$TEST_TEMP/setsid.log"
+}
+
+@test "start: 存在しないプロジェクトでエラー" {
+  run bash "$SCRIPT" start NoSuch
+  [ "$status" -ne 0 ]
+}
+
+@test "start: 既に稼働中なら再起動しない" {
+  mkdir -p "$CCSU_SUP_DIR"
+  printf '{ "project":"Demo","status":"running","pid": %s }\n' "$$" > "$CCSU_SUP_DIR/Demo.json"
+  run bash "$SCRIPT" start Demo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"既に supervisor 稼働中"* ]]
+  [ ! -f "$TEST_TEMP/setsid.log" ]
+}
+
+@test "stop: graceful で stop フラグ作成 (kill しない)" {
+  mkdir -p "$CCSU_SUP_DIR"
+  printf '{ "project":"Demo","status":"running","pid": %s }\n' "$$" > "$CCSU_SUP_DIR/Demo.json"
+  run bash "$SCRIPT" stop Demo
+  [ "$status" -eq 0 ]
+  [ -f "$CCSU_SUP_DIR/Demo.stop" ]
+}
+
+@test "stop: 未稼働は警告" {
+  run bash "$SCRIPT" stop Demo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"稼働していません"* ]]
+}
+
+@test "stop --now: 死pidでも安全に tmux kill-session を試行" {
+  mkdir -p "$CCSU_SUP_DIR"
+  printf '{ "project":"Demo","status":"running","pid": 999999 }\n' > "$CCSU_SUP_DIR/Demo.json"
+  run bash "$SCRIPT" stop Demo --now
+  [ "$status" -eq 0 ]
+  [ -f "$CCSU_SUP_DIR/Demo.stop" ]
+  grep -q "kill-session" "$TEST_TEMP/tmux.log"
+}
+
+@test "list: supervisor なしのメッセージ" {
+  run bash "$SCRIPT" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"supervisor なし"* ]]
+}
+
+@test "status <project>: 状態を表示" {
+  mkdir -p "$CCSU_SUP_DIR"
+  printf '{ "project":"Demo","status":"goal-reached","pid":0,"restarts_today":3,"minutes_today":120,"last_reason":"goal-reached:deploy.ready" }\n' > "$CCSU_SUP_DIR/Demo.json"
+  run bash "$SCRIPT" status Demo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Demo"* ]]
+  [[ "$output" == *"goal-reached"* ]]
+}
+
+@test "不明サブコマンドでエラー" {
+  run bash "$SCRIPT" frobnicate
+  [ "$status" -ne 0 ]
+}

--- a/tests/bats/unit/supervisor.bats
+++ b/tests/bats/unit/supervisor.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+# ============================================================
+# supervisor.bats — lib/supervisor.sh のユニットテスト
+#   ガードレール純粋関数 / 状態I/O / ループ各停止シナリオを検証。
+#   cron-launcher は stub、停止は state.json/上限/フラグで誘発。
+# ============================================================
+
+load '../helpers/common-setup'
+
+setup() {
+  _bats_common_setup
+  export AI_STARTUP_CONFIG_PATH="$TEST_TEMP/config.json"
+  printf '{ "linuxBase": "%s/projects" }\n' "$TEST_TEMP" > "$AI_STARTUP_CONFIG_PATH"
+  export CCSU_SUP_DIR="$TEST_TEMP/sup"
+  export CCSU_SUP_COOLDOWN=0
+  export CCSU_SUP_CRON_LAUNCHER="$TEST_TEMP/launcher.sh"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$CCSU_SUP_CRON_LAUNCHER"; chmod +x "$CCSU_SUP_CRON_LAUNCHER"
+  mkdir -p "$TEST_TEMP/projects/Demo"
+  source "$REPO_ROOT/lib/supervisor.sh"
+}
+teardown() { _bats_common_teardown; }
+
+# ---- 純粋ガードレール関数 ----------------------------------
+@test "sup__goal_reason: deploy.ready=true" { run sup__goal_reason true development; [ "$output" = "goal-reached:deploy.ready" ]; }
+@test "sup__goal_reason: phase_mode=maintenance" { run sup__goal_reason false maintenance; [ "$output" = "goal-reached:phase_mode=maintenance" ]; }
+@test "sup__goal_reason: released" { run sup__goal_reason false released; [ "$output" = "goal-reached:phase_mode=released" ]; }
+@test "sup__goal_reason: development は継続(空)" { run sup__goal_reason false development; [ -z "$output" ]; }
+@test "sup__abnormal_reason: security>0" { run sup__abnormal_reason 2 0; [ "$output" = "blocked:security_critical=2" ]; }
+@test "sup__abnormal_reason: blocked>0" { run sup__abnormal_reason 0 3; [ "$output" = "blocked:blocked_issues=3" ]; }
+@test "sup__abnormal_reason: 正常は空" { run sup__abnormal_reason 0 0; [ -z "$output" ]; }
+@test "sup__cap_reason: minutes 到達" { run sup__cap_reason 600 600 0 6; [[ "$output" == daily-cap:minutes* ]]; }
+@test "sup__cap_reason: restarts 到達" { run sup__cap_reason 0 600 6 6; [[ "$output" == daily-cap:restarts* ]]; }
+@test "sup__cap_reason: 上限内は空" { run sup__cap_reason 10 600 1 6; [ -z "$output" ]; }
+@test "sup__crash_reason: 閾値到達" { run sup__crash_reason 3 3; [[ "$output" == crash-loop* ]]; }
+@test "sup__crash_reason: 閾値未満は空" { run sup__crash_reason 1 3; [ -z "$output" ]; }
+
+# ---- project state.json 読取判定 ---------------------------
+@test "sup__project_stop_reason: deploy.ready=true → goal-reached" {
+  echo '{ "deploy": {"ready": true} }' > "$TEST_TEMP/p.json"
+  run sup__project_stop_reason "$TEST_TEMP/p.json"
+  [ "$output" = "goal-reached:deploy.ready" ]
+}
+@test "sup__project_stop_reason: phase_mode=maintenance → goal-reached" {
+  echo '{ "project": {"phase_mode":"maintenance"} }' > "$TEST_TEMP/p.json"
+  run sup__project_stop_reason "$TEST_TEMP/p.json"
+  [ "$output" = "goal-reached:phase_mode=maintenance" ]
+}
+@test "sup__project_stop_reason: development は空(継続)" {
+  echo '{ "project": {"phase_mode":"development"}, "deploy": {"ready": false} }' > "$TEST_TEMP/p.json"
+  run sup__project_stop_reason "$TEST_TEMP/p.json"
+  [ -z "$output" ]
+}
+@test "sup__project_stop_reason: blocked_issues 非空 → blocked" {
+  echo '{ "deploy": {"ready": false}, "blocked_issues": [101,102] }' > "$TEST_TEMP/p.json"
+  run sup__project_stop_reason "$TEST_TEMP/p.json"
+  [ "$output" = "blocked:blocked_issues=2" ]
+}
+
+# ---- 状態 I/O ----------------------------------------------
+@test "sup__persist + sup__get: 往復し妥当な JSON" {
+  SUP_STATUS=running SUP_PID=$$ SUP_RESTARTS=2 SUP_MINUTES=42 sup__persist Demo
+  [ "$(sup__get Demo status '')" = "running" ]
+  [ "$(sup__get Demo restarts_today 0)" = "2" ]
+  [ "$(sup__get Demo minutes_today 0)" = "42" ]
+  jq -e . "$CCSU_SUP_DIR/Demo.json" >/dev/null
+}
+@test "sup__is_running: 生存pid+running なら 0" {
+  SUP_STATUS=running SUP_PID=$$ sup__persist Demo
+  run sup__is_running Demo; [ "$status" -eq 0 ]
+}
+@test "sup__is_running: 死pid なら非0" {
+  SUP_STATUS=running SUP_PID=999999 sup__persist Demo
+  run sup__is_running Demo; [ "$status" -ne 0 ]
+}
+@test "sup__is_running: status!=running なら非0" {
+  SUP_STATUS=stopped SUP_PID=$$ sup__persist Demo
+  run sup__is_running Demo; [ "$status" -ne 0 ]
+}
+@test "sup__request_stop: stop フラグを作成" {
+  sup__request_stop Demo
+  [ -f "$CCSU_SUP_DIR/Demo.stop" ]
+}
+
+# ---- ループ各停止シナリオ ----------------------------------
+@test "sup__loop: deploy.ready=true で goal-reached 即停止 (restarts=0)" {
+  echo '{ "deploy": {"ready": true} }' > "$TEST_TEMP/projects/Demo/state.json"
+  run sup__loop Demo 5
+  [ "$status" -eq 0 ]
+  [ "$(sup__get Demo status '')" = "goal-reached" ]
+  [ "$(sup__get Demo restarts_today 0)" = "0" ]
+}
+@test "sup__loop: max_restarts=1 で 1セッション後 daily-cap" {
+  echo '{ "deploy": {"ready": false}, "supervisor": {"max_restarts_per_day": 1, "crash_loop_min_seconds": 0} }' > "$TEST_TEMP/projects/Demo/state.json"
+  run sup__loop Demo 5
+  [ "$(sup__get Demo status '')" = "daily-cap" ]
+  [ "$(sup__get Demo restarts_today 0)" = "1" ]
+}
+@test "sup__loop: 短命連続で crash-loop 停止" {
+  echo '{ "deploy": {"ready": false}, "supervisor": {"crash_loop_threshold": 2, "crash_loop_min_seconds": 999999, "max_restarts_per_day": 100} }' > "$TEST_TEMP/projects/Demo/state.json"
+  run sup__loop Demo 5
+  [ "$(sup__get Demo status '')" = "crash-loop" ]
+}
+@test "sup__loop: 起動前 stop フラグで manual 停止 (restarts=0)" {
+  echo '{ "deploy": {"ready": false} }' > "$TEST_TEMP/projects/Demo/state.json"
+  mkdir -p "$CCSU_SUP_DIR"; : > "$CCSU_SUP_DIR/Demo.stop"
+  run sup__loop Demo 5
+  [ "$(sup__get Demo status '')" = "stopped" ]
+  [ "$(sup__get Demo restarts_today 0)" = "0" ]
+}
+@test "sup__loop: launcher 不在で停止 (暴走しない)" {
+  echo '{ "deploy": {"ready": false} }' > "$TEST_TEMP/projects/Demo/state.json"
+  SUP_CRON_LAUNCHER="$TEST_TEMP/does-not-exist.sh"
+  run sup__loop Demo 5
+  [ "$(sup__get Demo status '')" = "stopped" ]
+  [ "$(sup__get Demo restarts_today 0)" = "0" ]
+}


### PR DESCRIPTION
## 変更内容
登録プロジェクトを **Goal/Release 到達まで自律再開** させる Autonomy Supervisor（Phase 1: CLI）。各セッションは `cron-launcher.sh` 経由（claude TUI + 自律 + メール + 監視タブメタ）を再利用し、終了検知→再起動する。

- `lib/supervisor.sh`（新規）: ガードレール純粋関数（goal/abnormal/cap/crash）＋自律ループ＋状態I/O
- `bin/autonomy.sh`（新規）: CLI（start/stop/status/list）。setsid 常駐・cron 競合検知・グレースフル/即時停止
- 停止条件: Goal(`deploy.ready`/`phase_mode`) / 異常(`security`/`blocked`) / 日次上限(既定600分・6回) / crash-loop / 手動
- 既定 **OFF**（opt-in）

## テスト結果
- 新規 `supervisor.bats` + `autonomy.bats` **37 件**（純粋関数・状態I/O・ループ5シナリオ・CLI・cron競合）
- 全 bats **188 件**パス / shellcheck error 0 / check-doc-versions PASS（README=CHANGELOG=v3.4.0）

## 影響範囲
- 新規 2 ファイル + テスト2 + docs。既存挙動への影響なし（supervisor は明示 start するまで起動しない）

## 残課題
- Phase 2: `claudeos-monitor` を統合コントロールセンター化（TUI から 起動+監督+介入+supervisor状態）
- cron と supervisor の二重起動はロックでなく start 時警告で回避（Phase 2 で連携強化検討）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * v3.4.0でAutonomy Supervisor（自動実行管理機能）を追加。デフォルトOFF、オプトインで有効化可能。Goal到達時の自動再開に対応し、異常検知やコスト上限などのガードレール機構を搭載。

* **Documentation**
  * Autonomy Supervisorの操作方法、制御コマンド、停止条件についてドキュメントを更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->