### PR TITLE
feat(monitor): 統合コントロールセンター (Autonomy Supervisor Phase 2, v3.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 # CHANGELOG
 
+## [v3.4.1] - 2026-06-02 — 統合コントロールセンター（Autonomy Supervisor Phase 2 / TUI）
+
+### 🎯 概要
+ライブ監視タブ `claudeos-monitor` を **統合コントロールセンター** に拡張（Phase 2）。1 画面で「実行中セッション（タブ/FG 介入）＋ 登録プロジェクト一覧 ＋ supervisor 状態」を表示し、キー操作で 起動・supervisor 開始/停止・介入 をまとめて行える。当初ゴール「インタラクティブ TUI + 完全自律」の TUI 側を実現。
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `bin/monitor-sessions.sh` | 登録/supervisor セクション追加（cron ∪ supervisor 一覧 + session稼働/status/restarts/minutes）。キー `l`起動 `s`監督開始 `x`監督停止。`s` は cron 競合時に「外して切替」プロンプト |
+| `bin/menu.sh` | `MO` ラベルを「🎛️ コントロールセンター」に更新 |
+| `tests/bats/unit/monitor-sessions.bats` | 登録セクション 5 件追加（複数 supervisor の連結バグ回帰含む）|
+
+### ✅ 主な内容
+
+- 操作キー: `[1-9]` 介入FG / `[l]` 自律1セッション起動(BG) / `[s]` supervisor 開始 / `[x]` 停止 / `Ctrl-b 0` 監視へ
+- `s`（supervisor 開始）は cron 登録があれば「外して supervisor へ切替えますか?」を確認（承認方針: 競合回避）
+- **修正**: supervisor 状態ファイル複数時に project 名が改行なしで連結される不具合（`json_get` の改行欠落）→ 視覚スモークで検出、回帰テスト追加
+- 全 bats **193 件** / shellcheck error 0 / check-doc-versions PASS
+
+---
+
 ## [v3.4.0] - 2026-06-02 — Autonomy Supervisor（Goal到達まで自律再開・Phase 1/CLI）
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.4.0** (Autonomy Supervisor — Goal到達まで自律再開 / Phase 1 CLI) — 旧: v3.3.8 |
+| バージョン | **v3.4.1** (統合コントロールセンター — TUI から監視+起動+supervisor+介入 / Phase 2) — 旧: v3.4.0 |
 | テスト | **776件** — Pester (Unit 21 / Integration 11 / Smoke 1) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | **v9.0** (`/goal` 駆動 / Agent Teams パターン A/B/C / Agent View / 動的判断 / 週次フェーズ制御 / learning パターン記録 / Stop Conditions 厳格化 / Opus 4.7 最適化 / 1H cache / PreCompact hook) |
@@ -436,7 +436,15 @@ bash bin/autonomy.sh status [project] | list                   # 状態（restar
 | crash-loop / 手動 | 短命セッション連続 / `stop` |
 
 > ⚠️ supervisor 管理プロジェクトは **cron 登録を外す**（二重起動回避）。残っている場合 `start` は警告し、`--force` で続行。
-> 🔜 Phase 2 でライブ監視タブ（`claudeos-monitor`）から起動・監督・介入を統合予定。
+
+**🎛️ 統合コントロールセンター（v3.4.1 / Phase 2）**: メニュー `MO`（または `bash bin/monitor-sessions.sh open`）で、1 画面に「実行中セッション（タブ/FG 介入）＋ 登録プロジェクト ＋ supervisor 状態」を集約。キー操作:
+
+| キー | 動作 |
+|---|---|
+| `[1-9]` / `Ctrl-b <n>` | そのプロジェクトを前面(FG)へ＝介入 / `Ctrl-b 0` でダッシュボードへ |
+| `[l]` | 登録から選んで自律1セッション起動（BG） |
+| `[s]` | 登録から選んで supervisor 開始（cron 競合時は「外して切替」を確認） |
+| `[x]` | supervisor 停止 |
 
 Linux native メニューを使う場合は `./start.sh` を実行します。項目 `7` は `~/.claudeos/{logs,sessions,tmp}` と `~/.tmux.conf` の ClaudeOS 管理ブロックを作成・更新します。
 

--- a/bin/menu.sh
+++ b/bin/menu.sh
@@ -102,7 +102,7 @@ show_menu() {
   printf '  %s⏰ Linux Cron 管理%s\n' "$C_YELLOW" "$C_RESET"
   printf '   %s 14 %s  📅  Cron スケジュール 登録・編集・削除 / 選んで一括BG起動\n' "$C_BG_DKBLUE" "$C_RESET"
   printf '   %s 15 %s  📺  セッション状態監視 (一覧 / 接続・停止)\n' "$C_BG_DKBLUE" "$C_RESET"
-  printf '   %s MO %s  📺  ライブ監視タブを開く (経過/残り・タブ切替FG / claudeos-monitor)\n' "$C_BG_DKBLUE" "$C_RESET"
+  printf '   %s MO %s  🎛️  コントロールセンター (監視+起動+supervisor+介入 / claudeos-monitor)\n' "$C_BG_DKBLUE" "$C_RESET"
   printf '\n'
 
   local hr; hr="  $(printf '─%.0s' {1..52})"

--- a/bin/monitor-sessions.sh
+++ b/bin/monitor-sessions.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # ============================================================
-# monitor-sessions.sh — Cron/手動セッションのライブ監視タブ (ClaudeOS v3.3.8)
+# monitor-sessions.sh — ライブ監視タブ + 統合コントロールセンター (ClaudeOS v3.4.1)
+#   (Phase 2: 登録プロジェクト一覧 + supervisor 起動/停止/介入を 1 画面に統合)
 #
 # 役割:
 #   専用 tmux セッション "claudeos-monitor" を用意し、実行中の
@@ -29,6 +30,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/../lib/common.sh"
+# shellcheck source=lib/config-loader.sh
+source "$SCRIPT_DIR/../lib/config-loader.sh"
+# shellcheck source=lib/cron-manager.sh
+source "$SCRIPT_DIR/../lib/cron-manager.sh"
+# shellcheck source=lib/supervisor.sh
+source "$SCRIPT_DIR/../lib/supervisor.sh"
 
 TMUX_BIN="${CCSU_TMUX_BIN:-tmux}"
 MON_SESSION="${CCSU_MONITOR_SESSION:-claudeos-monitor}"
@@ -143,29 +150,138 @@ mon__collect() {
 }
 
 # ------------------------------------------------------------
+# 登録プロジェクト + supervisor (コントロールセンター)
+# ------------------------------------------------------------
+
+# mon__registered_projects — cron 登録 ∪ supervisor 管理下 のプロジェクト名 (一意)
+mon__registered_projects() {
+  {
+    cron__list 2>/dev/null | awk -F'|' '$2!="" {print $2}'
+    if [[ -d "$SUP_DIR" ]]; then
+      local f
+      for f in "$SUP_DIR"/*.json; do
+        [[ -f "$f" ]] || continue
+        # json_get は改行を付けないため明示的に改行する (複数ファイルの連結防止)
+        printf '%s\n' "$(json_get "$f" '.project' '')"
+      done
+    fi
+  } | awk 'NF' | sort -u
+}
+
+# mon__collect_registered — 「project|session_running|sup_status|restarts|minutes」
+mon__collect_registered() {
+  local p safe running sup_status restarts minutes
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    safe="$(ccsu_safe_name "$p")"
+    if "$TMUX_BIN" has-session -t "claudeos-$safe" 2>/dev/null; then running=1; else running=0; fi
+    sup_status="$(sup__get "$p" status '-')"
+    restarts="$(sup__get "$p" restarts_today '-')"
+    minutes="$(sup__get "$p" minutes_today '-')"
+    printf '%s|%s|%s|%s|%s\n' "$p" "$running" "$sup_status" "$restarts" "$minutes"
+  done < <(mon__registered_projects)
+}
+
+# mon__remove_cron_for <project> — 当該プロジェクトの CLAUDEOS cron を全削除。削除数を stdout
+mon__remove_cron_for() {
+  local project="$1" id p count=0 r
+  while IFS='|' read -r id p _; do
+    [[ "$p" == "$project" ]] || continue
+    r="$(cron__remove "$id")"; count=$(( count + r ))
+  done < <(cron__list 2>/dev/null)
+  printf '%s' "$count"
+}
+
+# mon__supervise_start <project> — cron 競合があれば外して supervisor 開始
+mon__supervise_start() {
+  local project="$1" force="" ans n
+  if cron__list 2>/dev/null | awk -F'|' -v p="$project" '$2==p{f=1} END{exit !f}'; then
+    read -rp "  cron 登録を外して supervisor に切替えますか? [Y/n]: " ans || true
+    if [[ "${ans,,}" != "n" && "${ans,,}" != "no" ]]; then
+      n="$(mon__remove_cron_for "$project")"; log_ok "cron 削除: $project ($n 件)"
+    else
+      force="--force"
+    fi
+  fi
+  bash "$SCRIPT_DIR/autonomy.sh" start "$project" ${force:+$force} || true
+}
+
+# mon__action <l|s|x> — 登録一覧から選んでアクション実行 (ダッシュボードのサブ操作)
+mon__action() {
+  local key="$1" label
+  local -a regs; mapfile -t regs < <(mon__registered_projects)
+  tput cnorm 2>/dev/null || true
+  clear 2>/dev/null || true
+  case "$key" in
+    l) label="起動 (自律1セッション / BG)" ;;
+    s) label="supervisor 開始 (Goal到達まで自律再開)" ;;
+    x) label="supervisor 停止" ;;
+  esac
+  printf '\n  %s== %s ==%s\n' "$C_CYAN" "$label" "$C_RESET"
+  if (( ${#regs[@]} == 0 )); then
+    printf '  登録プロジェクトがありません (項14で cron 登録 / autonomy.sh start)\n'
+    read -rp "  Enter で戻る " _ || true; tput civis 2>/dev/null || true; return 0
+  fi
+  local i; for i in "${!regs[@]}"; do printf '   [%d] %s\n' "$((i + 1))" "${regs[$i]}"; done
+  local sel p; read -rp "  番号 (0=キャンセル): " sel || true
+  if [[ "$sel" =~ ^[0-9]+$ ]] && (( sel >= 1 && sel <= ${#regs[@]} )); then
+    p="${regs[$((sel - 1))]}"
+    case "$key" in
+      l) bash "$SCRIPT_DIR/cron-schedule.sh" run-now --project "$p" || true ;;
+      s) mon__supervise_start "$p" ;;
+      x) bash "$SCRIPT_DIR/autonomy.sh" stop "$p" || true ;;
+    esac
+    read -rp "  Enter で戻る " _ || true
+  fi
+  tput civis 2>/dev/null || true
+}
+
+# ------------------------------------------------------------
 # 描画
 # ------------------------------------------------------------
 mon__hr() { printf '  %s%s%s\n' "$C_GRAY" "$(printf '─%.0s' {1..56})" "$C_RESET"; }
 
 mon__render_once() {
   local stamp; stamp="$(date '+%Y-%m-%d %H:%M:%S')"
-  printf '\n  %s📺 ClaudeOS ライブ監視%s  (%s秒更新)        %s%s%s\n' \
+  printf '\n  %s🎛️  ClaudeOS コントロールセンター%s  (%s秒更新)   %s%s%s\n' \
     "$C_CYAN" "$C_RESET" "$MON_REFRESH" "$C_GRAY" "$stamp" "$C_RESET"
   mon__hr
-  printf '   %s#  %-26s %-9s %-9s%s\n' "$C_GRAY" "プロジェクト" "経過" "残り" "$C_RESET"
+  # --- 実行中セッション (タブ) ---
+  printf '   %s● 実行中セッション%s  %s#  %-22s %-9s %-9s%s\n' \
+    "$C_GREEN" "$C_RESET" "$C_GRAY" "プロジェクト" "経過" "残り" "$C_RESET"
   local any=0 tab proj el rem has ic rem_s
   while IFS='|' read -r tab proj el rem has; do
     [[ -z "$tab" ]] && continue
     any=1
     ic="$(mon__status_icon "$rem" "$has")"
     if [[ "$has" == "1" ]]; then rem_s="$(mon__fmt_hms "$rem")"; else rem_s="—"; fi
-    printf '  %s%2s%s  %-26s %-9s %-9s %s\n' \
+    printf '   %s%2s%s  %-22s %-9s %-9s %s\n' \
       "$C_YELLOW" "$tab" "$C_RESET" "$proj" "$(mon__fmt_hms "$el")" "$rem_s" "$ic"
   done < <(mon__collect)
-  (( any == 0 )) && printf '   %s(実行中の ClaudeOS セッションなし)%s\n' "$C_GRAY" "$C_RESET"
+  (( any == 0 )) && printf '   %s(実行中なし)%s\n' "$C_GRAY" "$C_RESET"
   mon__hr
-  printf '   %s[1-9]%s そのタブへ(FG)   %sCtrl-b 0%s 監視へ戻る   %s[r]%s更新 %s[q]%s終了\n' \
-    "$C_GREEN" "$C_RESET" "$C_CYAN" "$C_RESET" "$C_YELLOW" "$C_RESET" "$C_YELLOW" "$C_RESET"
+  # --- 登録プロジェクト + supervisor ---
+  printf '   %s● 登録 / supervisor%s  %s#  %-22s %-7s %-13s rst/min%s\n' \
+    "$C_GREEN" "$C_RESET" "$C_GRAY" "プロジェクト" "session" "supervisor" "$C_RESET"
+  local rn=0 rp rrun rstat rrst rmin sicon supcol
+  while IFS='|' read -r rp rrun rstat rrst rmin; do
+    [[ -z "$rp" ]] && continue
+    rn=$(( rn + 1 ))
+    if [[ "$rrun" == "1" ]]; then sicon="●稼働"; else sicon="○停止"; fi
+    case "$rstat" in
+      running)            supcol="$C_GREEN" ;;
+      goal-reached)       supcol="$C_CYAN" ;;
+      blocked|crash-loop) supcol="$C_RED" ;;
+      *)                  supcol="$C_GRAY" ;;
+    esac
+    printf '   %s%2s%s  %-22s %-7s %s%-13s%s %s/%s\n' \
+      "$C_YELLOW" "$rn" "$C_RESET" "$rp" "$sicon" "$supcol" "$rstat" "$C_RESET" "$rrst" "$rmin"
+  done < <(mon__collect_registered)
+  (( rn == 0 )) && printf '   %s(登録なし — 項14 cron 登録 / autonomy.sh start)%s\n' "$C_GRAY" "$C_RESET"
+  mon__hr
+  printf '   %s[1-9]%s介入FG %sCtrl-b 0%s監視 %s[l]%s起動 %s[s]%s監督開始 %s[x]%s監督停止 %s[r]%s更新 %s[q]%s終了\n' \
+    "$C_GREEN" "$C_RESET" "$C_CYAN" "$C_RESET" "$C_YELLOW" "$C_RESET" "$C_YELLOW" "$C_RESET" \
+    "$C_YELLOW" "$C_RESET" "$C_YELLOW" "$C_RESET" "$C_YELLOW" "$C_RESET"
 }
 
 # mon__dashboard — window 0 で動くライブループ (open が内部起動)
@@ -182,6 +298,9 @@ mon__dashboard() {
     case "$key" in
       q|Q) break ;;
       [1-9]) "$TMUX_BIN" select-window -t "$MON_SESSION:$key" 2>/dev/null || true ;;
+      l|L) mon__action l ;;
+      s|S) mon__action s ;;
+      x|X) mon__action x ;;
       *) : ;;   # r / 空(タイムアウト) → 再描画
     esac
   done
@@ -218,11 +337,13 @@ Usage: monitor-sessions.sh [open|dashboard|sync|--once|--help]
   --once     ダッシュボードを1回描画して終了 (非対話 / テスト)
   --help     このヘルプ
 
-キー操作 (監視タブ表示中):
-  [1-9]     その番号のプロジェクトタブへ切替 (フォアグラウンド)
-  Ctrl-b 0  監視ダッシュボードへ戻る
-  Ctrl-b n  次のタブ / Ctrl-b p 前のタブ (tmux 標準)
-  [q]       監視ダッシュボードを終了 (各プロジェクトは BG で継続)
+キー操作 (コントロールセンター表示中):
+  [1-9]     その番号のプロジェクトタブへ切替 (フォアグラウンド/介入)
+  Ctrl-b 0  ダッシュボードへ戻る   Ctrl-b n/p  次/前のタブ (tmux 標準)
+  [l]       登録から選んで自律1セッション起動 (BG)
+  [s]       登録から選んで supervisor 開始 (Goal到達まで自律再開)
+  [x]       supervisor 停止
+  [q]       ダッシュボードを終了 (各セッション/supervisor は継続)
 EOF
 }
 

--- a/tests/bats/unit/monitor-sessions.bats
+++ b/tests/bats/unit/monitor-sessions.bats
@@ -35,8 +35,28 @@ case "${1:-}" in
   *) exit 0 ;;
 esac
 '
+  # cron-manager 用 crontab スタブ (CRON_STORE 不在 → 登録なし)
+  export CRON_STORE="$TEST_TEMP/crontab.store"
+  make_stub_bin crontab '
+store="${CRON_STORE:?}"
+case "${1:-}" in
+  -l) [[ -f "$store" ]] && cat "$store" || exit 1 ;;
+  -)  cat > "$store" ;;
+  *)  exit 2 ;;
+esac
+'
+  # supervisor 状態ディレクトリ (空 → supervisor なし)
+  export CCSU_SUP_DIR="$TEST_TEMP/sup"
 }
 teardown() { _bats_common_teardown; }
+
+# 登録 cron エントリを seed
+_mon_seed_cron() {
+  cat > "$CRON_STORE" <<EOF
+# CLAUDEOS:abc12345 project=$1 duration=300 created=2026-01-01T00:00:00
+0 21 * * 1,2,3,4,5,6 bash /x/cron-launcher.sh $1 300
+EOF
+}
 
 # ---- 純粋ヘルパ: mon__fmt_hms --------------------------------
 @test "mon__fmt_hms: 3661 → 01:01:01" {
@@ -101,7 +121,7 @@ teardown() { _bats_common_teardown; }
   export MON_TEST_SESSIONS=""
   run bash "$SCRIPT" --once
   [ "$status" -eq 0 ]
-  [[ "$output" == *"実行中の ClaudeOS セッションなし"* ]]
+  [[ "$output" == *"(実行中なし)"* ]]
 }
 
 @test "--once: duration ありで経過/残りと プロジェクト名を表示" {
@@ -114,8 +134,8 @@ teardown() { _bats_common_teardown; }
   [[ "$output" == *"MyProj"* ]]
   # HH:MM:SS 形式の経過/残りが描画される
   [[ "$output" =~ [0-9][0-9]:[0-9][0-9]:[0-9][0-9] ]]
-  # duration があるので残りは — ではない
-  [[ "$output" == *"ライブ監視"* ]]
+  # コントロールセンターのタイトル
+  [[ "$output" == *"コントロールセンター"* ]]
 }
 
 @test "--once: duration 無しは残り — 表示" {
@@ -140,4 +160,53 @@ teardown() { _bats_common_teardown; }
 @test "不明な引数でエラー" {
   run bash "$SCRIPT" frobnicate
   [ "$status" -ne 0 ]
+}
+
+# ---- 登録 / supervisor セクション (Phase 2 コントロールセンター) ----
+@test "mon__registered_projects: cron ∪ supervisor を一意列挙 (連結バグ回帰)" {
+  _mon_seed_cron ProjA
+  mkdir -p "$CCSU_SUP_DIR"
+  echo '{ "project": "ProjB" }' > "$CCSU_SUP_DIR/ProjB.json"
+  echo '{ "project": "ProjC" }' > "$CCSU_SUP_DIR/ProjC.json"
+  run bash -c "source '$SCRIPT'; mon__registered_projects"
+  [[ "$output" == *"ProjA"* ]]
+  [[ "$output" == *"ProjB"* ]]
+  [[ "$output" == *"ProjC"* ]]
+  # supervisor 複数ファイルが改行なしで連結された幻のエントリが無いこと
+  [[ "$output" != *"ProjBProjC"* ]]
+  [[ "$output" != *"ProjCProjB"* ]]
+  # ちょうど 3 行 (連結があれば 2 行や 4 行になる)
+  [ "$(printf '%s\n' "$output" | grep -c .)" -eq 3 ]
+}
+
+@test "mon__collect_registered: session稼働とsupervisor状態を出力" {
+  _mon_seed_cron ProjA
+  export MON_TEST_SESSIONS="claudeos-ProjA"
+  mkdir -p "$CCSU_SUP_DIR"
+  echo '{ "project": "ProjA", "status": "running", "restarts_today": 2, "minutes_today": 30 }' > "$CCSU_SUP_DIR/ProjA.json"
+  run bash -c "source '$SCRIPT'; mon__collect_registered"
+  [[ "$output" == *"ProjA|1|running|2|30"* ]]
+}
+
+@test "mon__remove_cron_for: 当該プロジェクトの cron を削除" {
+  _mon_seed_cron ProjA
+  run bash -c "source '$SCRIPT'; mon__remove_cron_for ProjA"
+  [ "$output" = "1" ]
+  run cat "$CRON_STORE"
+  [[ "$output" != *"project=ProjA"* ]]
+}
+
+@test "--once: 登録セクションに cron プロジェクトを表示" {
+  _mon_seed_cron ProjA
+  export MON_TEST_SESSIONS=""
+  run bash "$SCRIPT" --once
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"登録 / supervisor"* ]]
+  [[ "$output" == *"ProjA"* ]]
+}
+
+@test "--once: 登録なしの案内" {
+  export MON_TEST_SESSIONS=""
+  run bash "$SCRIPT" --once
+  [[ "$output" == *"登録なし"* ]]
 }


### PR DESCRIPTION
## 変更内容
ライブ監視タブ `claudeos-monitor` を **統合コントロールセンター** に拡張（Phase 2）。1 画面で「実行中セッション（タブ/FG 介入）＋ 登録プロジェクト ＋ supervisor 状態」を集約し、キーで 起動・supervisor 開始/停止・介入 を操作。

- `bin/monitor-sessions.sh`: 登録/supervisor セクション（cron ∪ supervisor、session稼働/status/restarts/minutes）。キー `l`起動 `s`監督開始 `x`監督停止。`s` は cron 競合時に「外して切替」プロンプト
- `bin/menu.sh`: `MO` を「🎛️ コントロールセンター」に
- **修正**: supervisor 複数ファイルで project 名が改行なし連結される不具合（`json_get` 改行欠落）→ 回帰テスト追加

## テスト結果
- monitor-sessions.bats 登録セクション5件追加（連結バグ回帰含む）
- 全 bats **193 件** / shellcheck 0 / check-doc-versions PASS（v3.4.1 同期）

## 影響範囲
- 既存のライブ監視タブを拡張。`--once`/`sync`/`open` の互換維持

## 残課題
- Phase 3（任意）: menu 追加配線・state.json.example に supervisor ブロック例・E2E 拡充

🤖 Generated with [Claude Code](https://claude.com/claude-code)