### PR TITLE
feat(autonomy): 二重起動防止ロック + supervisor schema (Phase 3, v3.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 # CHANGELOG
 
+## [v3.4.2] - 2026-06-02 — 二重起動防止ロック + supervisor schema（Autonomy Supervisor Phase 3 / 仕上げ）
+
+### 🎯 概要
+cron(OS) と Autonomy Supervisor の **二重起動を flock で確実に防止**（従来の start 時警告を「保証」に格上げ）。`state.schema.json` / `state.json.example` に supervisor ガードレールを正式定義し、上限値の上書き方法を明文化。
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `Claude/templates/linux/cron-launcher.sh`（+配布） | **flock 二重起動防止**: 同一プロジェクトの cron-launcher を直列化し後発は skip。`trap finalize` より前に exit するため skip 時は session.json/メールを生成せず、稼働中セッションも巻き込まない |
+| `state.schema.json` / `state.json.example` | `supervisor` ブロック（`daily_max_minutes` 等 6 キー）を正式定義 |
+| `tests/bats/unit/supervisor.bats` | 再起動ループ E2E（`deploy.ready` 動的反転 → goal-reached）追加 |
+
+### ✅ 検証
+
+- **flock 実機スモーク**: 後発が `lock held — skip`、先発は正常実行
+- **実機 tmux スモーク**: supervisor → deployed cron-launcher → 実 `claudeos-<proj>` セッション + keeper + lock 生成を確認（本番 tmux 無傷）
+- 再起動ループ E2E bats 追加。全 bats **194 件** / shellcheck error 0 / validate-state-example PASS
+- 注: メニュー専用項目（#1）は `MO` コントロールセンターで完結するため不要としスキップ
+
+---
+
 ## [v3.4.1] - 2026-06-02 — 統合コントロールセンター（Autonomy Supervisor Phase 2 / TUI）
 
 ### 🎯 概要

--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # ============================================================
 # cron-launcher.sh - Linux 側で ClaudeCode を cron から起動するラッパ
-# ClaudeOS v3.3.8
+# ClaudeOS v3.4.2
 #
 # Usage: cron-launcher.sh <project> <duration-minutes>
 #
@@ -53,6 +53,22 @@ fi
 
 DURATION_SEC=$((DURATION_MIN * 60))
 SAFE_PROJECT=$(printf '%s' "$PROJECT" | tr -c 'A-Za-z0-9_-' '_')
+
+# --- 二重起動防止 (v3.4.2): 同一プロジェクトの cron-launcher を flock で直列化 ---
+# cron(OS) 経路と Autonomy Supervisor 経路が同時発火しても後発は安全に skip する。
+# trap finalize より前に exit するため、skip 時は session.json/メールを生成しない。
+# 既存の "先に kill-session" より前に抜けるので、稼働中セッションも巻き込まない。
+LOCK_DIR="$CLAUDEOS_HOME/locks"
+mkdir -p "$LOCK_DIR" 2>/dev/null || true
+LOCK_FILE="$LOCK_DIR/${SAFE_PROJECT}.lock"
+if command -v flock >/dev/null 2>&1; then
+  exec {LOCK_FD}>"$LOCK_FILE" || true
+  if [[ -n "${LOCK_FD:-}" ]] && ! flock -n "$LOCK_FD"; then
+    echo "[cron-launcher] $PROJECT は既に実行中 (lock held) — 二重起動を防止し skip" >&2
+    exit 0
+  fi
+fi
+
 STAMP=$(date +'%Y%m%d-%H%M%S')
 SESSION_ID="${STAMP}-${SAFE_PROJECT}"
 SESSION_FILE="$SESSIONS_DIR/${SESSION_ID}.json"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.4.1** (統合コントロールセンター — TUI から監視+起動+supervisor+介入 / Phase 2) — 旧: v3.4.0 |
+| バージョン | **v3.4.2** (二重起動防止ロック + supervisor schema / Phase 3 仕上げ) — 旧: v3.4.1 |
 | テスト | **776件** — Pester (Unit 21 / Integration 11 / Smoke 1) |
 | CI | ✅ SUCCESS |
 | ClaudeOS (Claude Code 専用) | **v9.0** (`/goal` 駆動 / Agent Teams パターン A/B/C / Agent View / 動的判断 / 週次フェーズ制御 / learning パターン記録 / Stop Conditions 厳格化 / Opus 4.7 最適化 / 1H cache / PreCompact hook) |
@@ -432,8 +432,10 @@ bash bin/autonomy.sh status [project] | list                   # 状態（restar
 |---|---|
 | Goal 到達 | `deploy.ready=true` / `phase_mode∈{maintenance,released}` |
 | 異常 | `kpi.security_critical>0` / `blocked_issues` 非空 |
-| 日次上限 | 既定 **600 分 / 6 回**（`state.json` の `supervisor` ブロックで上書き可） |
+| 日次上限 | 既定 **600 分 / 6 回**（`state.json` の `supervisor` ブロックで上書き可、`state.json.example` 参照） |
 | crash-loop / 手動 | 短命セッション連続 / `stop` |
+
+> 🔒 **二重起動防止（v3.4.2）**: cron-launcher が `flock` で同一プロジェクトを直列化。cron(OS) と supervisor が同時発火しても後発は安全に skip するため、cron を外し忘れても稼働中セッションを巻き込みません（推奨は引き続き cron 削除）。
 
 > ⚠️ supervisor 管理プロジェクトは **cron 登録を外す**（二重起動回避）。残っている場合 `start` は警告し、`--force` で続行。
 

--- a/state.json.example
+++ b/state.json.example
@@ -212,5 +212,13 @@
     "environment": null,
     "post_deploy_verified": false,
     "notes": ""
+  },
+  "supervisor": {
+    "daily_max_minutes": 600,
+    "max_restarts_per_day": 6,
+    "session_minutes": 300,
+    "cooldown_seconds": 30,
+    "crash_loop_threshold": 3,
+    "crash_loop_min_seconds": 120
   }
 }

--- a/state.schema.json
+++ b/state.schema.json
@@ -356,6 +356,18 @@
         "post_deploy_verified": { "type": "boolean" },
         "notes": { "type": "string" }
       }
+    },
+    "supervisor": {
+      "type": "object",
+      "description": "Autonomy Supervisor (bin/autonomy.sh) のガードレール。全て任意で既定値を上書きする。",
+      "properties": {
+        "daily_max_minutes": { "type": "integer", "description": "1日の合計自律実行上限(分)。既定 600" },
+        "max_restarts_per_day": { "type": "integer", "description": "1日の再起動回数上限。既定 6" },
+        "session_minutes": { "type": "integer", "description": "1セッションの時間(分)。既定 300" },
+        "cooldown_seconds": { "type": "integer", "description": "再起動間のクールダウン(秒)。既定 30" },
+        "crash_loop_threshold": { "type": "integer", "description": "短命セッション連続で crash-loop 停止する回数。既定 3" },
+        "crash_loop_min_seconds": { "type": "integer", "description": "この秒数未満を短命セッションとみなす。既定 120" }
+      }
     }
   }
 }

--- a/tests/bats/unit/supervisor.bats
+++ b/tests/bats/unit/supervisor.bats
@@ -114,3 +114,19 @@ teardown() { _bats_common_teardown; }
   [ "$(sup__get Demo status '')" = "stopped" ]
   [ "$(sup__get Demo restarts_today 0)" = "0" ]
 }
+
+@test "sup__loop: 再起動ループ中に deploy.ready 反転で goal-reached (E2E)" {
+  # cron-launcher stub: 2回目の呼び出しで project state.json の deploy.ready を true に
+  cat > "$CCSU_SUP_CRON_LAUNCHER" <<EOF
+#!/usr/bin/env bash
+c="$TEST_TEMP/count"; n=\$(( \$(cat "\$c" 2>/dev/null || echo 0) + 1 )); echo "\$n" > "\$c"
+if (( n >= 2 )); then echo '{ "deploy": {"ready": true} }' > "$TEST_TEMP/projects/Demo/state.json"; fi
+exit 0
+EOF
+  chmod +x "$CCSU_SUP_CRON_LAUNCHER"
+  echo '{ "deploy": {"ready": false}, "supervisor": {"crash_loop_min_seconds": 0, "max_restarts_per_day": 100} }' > "$TEST_TEMP/projects/Demo/state.json"
+  run sup__loop Demo 5
+  # 2 セッション走って 2 回目後に goal 検出 → 停止
+  [ "$(sup__get Demo status '')" = "goal-reached" ]
+  [ "$(sup__get Demo restarts_today 0)" = "2" ]
+}


### PR DESCRIPTION
## 変更内容
Autonomy Supervisor Phase 3（仕上げ）。

- `cron-launcher.sh`: **flock 二重起動防止**（同一プロジェクトを直列化、後発は skip。`trap finalize` 前に exit するため skip 時は session.json/メール無し・稼働中セッションを巻き込まない）
- `state.schema.json` / `state.json.example`: `supervisor` ブロック（6 キー）を正式定義
- `tests/supervisor.bats`: 再起動ループ E2E（`deploy.ready` 動的反転 → goal-reached）追加

## テスト結果
- flock 実機スモーク（後発 skip）＋ 実機 tmux スモーク（supervisor→cron-launcher→実 `claudeos-<proj>` + keeper + lock 生成）
- 全 bats **194 件** / shellcheck 0 / validate-state-example PASS / check-doc-versions v3.4.2 同期

## 影響範囲
- cron-launcher にロック追加（既存挙動は維持、skip は二重発火時のみ）。schema/example は supervisor 追記のみ

## 残課題
- なし（#1 メニュー専用項目は MO コントロールセンターで完結のためスキップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)