### PR TITLE
feat(monitor,cron): GitHubバッジ+未管理フィルタ+一括cron登録 (v3.4.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 # CHANGELOG
 
+## [v3.4.5] - 2026-06-02 — 多数プロジェクト管理の効率化（GitHub バッジ / 未管理フィルタ / 一括 cron 登録）
+
+### 🎯 概要
+多数のプロジェクト（GitHub レポジトリ 21 件等）を効率よく管理できるよう 3 点を追加。①コントロールセンターの `n` ピッカーに **GitHub バッジ（🐙）と未管理フィルタ（`u`/`a`）**、②未管理プロジェクトを**曜日・時刻に分散して一括 cron 登録**するヘルパ（`bulk-register`）、③存在しない dir を指す stale cron の掃除（運用）。
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `bin/monitor-sessions.sh` | `n` ピッカーに `mon__is_github`（🐙 バッジ）+ 未管理フィルタ（`u`=未管理のみ / `a`=全表示） |
+| `bin/cron-schedule.sh` | **`bulk-register`** サブコマンド追加（`--github-only` / `--unmanaged-only` / `--start` / `--spacing` / `--duration` / `--dow` / `--apply`）。既定 **dry-run**、既定間隔 = duration 時間で**重複ゼロ**、重複設定時は警告 |
+| `tests/bats/unit/*` | `bulk-register` 3 件 + `mon__is_github` 2 件追加 |
+
+### ✅ 内容
+
+- 32 プロジェクトから**未管理の GitHub プロジェクトを一目で選べる**（🐙 + ⚪/📅/🔁/🟢 バッジ、`u` で未管理のみ）
+- 一括登録は**曜日 round-robin + 時刻スロットで負荷分散**（全件同時起動を回避）。既定間隔は duration と同じ時間にして**同日のセッション重複を防止**（例: 300m → 09:00/14:00/19:00）
+- 既定 **dry-run（計画プレビュー）** → `--apply` で実登録。**コスト/負荷を確認してから適用**できる
+- 全 bats **204 件** / shellcheck error 0
+
+### 🔑 使い方
+
+```bash
+# 未管理の GitHub プロジェクトを曜日分散で一括登録（まず計画を確認）
+bash bin/cron-schedule.sh bulk-register --github-only --unmanaged-only
+# 計画に納得したら適用
+bash bin/cron-schedule.sh bulk-register --github-only --unmanaged-only --apply
+```
+
+---
+
 ## [v3.4.4] - 2026-06-02 — コントロールセンターの UX 修正（キー誤入力 / 重複タブ）
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -205,6 +205,25 @@ bash bin/autonomy.sh list                      # すべての Supervisor 一覧
 > 🧠 **裏側のしくみ（安心ポイント）**: 「追加」とは “supervisor を開始する／cron に登録する” こと **そのもの**です。
 > 別の管理リストを作らないので、画面の表示と実際の動きが**ズレません**。
 
+**🐙 GitHub バッジ & フィルタ**: 一覧では GitHub レポジトリを持つプロジェクトに `🐙` が付きます。
+プロジェクトが多いときは `u`（未管理のみ）/ `a`（全表示）で絞り込めます。
+
+### 📅 たくさんのプロジェクトをまとめて登録（曜日分散）
+
+> プロジェクトが多くて 1 つずつ登録するのが大変なときは、**未管理の GitHub プロジェクトを曜日・時刻に自動で振り分けて一括登録**できます（全部いっぺんに動かすとマシンが重くなるので、自動で分散します）。
+
+```bash
+# ① まず計画を確認（DRY-RUN：登録はされません）
+bash bin/cron-schedule.sh bulk-register --github-only --unmanaged-only
+#   例: 18 件を 月〜土 × 09:00 / 14:00 / 19:00 に分散（セッションが重ならない間隔）
+
+# ② 計画に納得したら適用
+bash bin/cron-schedule.sh bulk-register --github-only --unmanaged-only --apply
+```
+
+> 💡 既定の時間間隔は 1 セッションの長さ（5 時間）に合わせてあり、**同じ日のセッションが重なりません**。
+> もっと詰めたい/空けたい場合は `--start 9`（開始時刻）`--spacing 5`（間隔h）`--dow 1,2,3,4,5,6`（曜日）で調整できます。
+
 ---
 
 ## 📧 メール通知 & 🌐 Web ダッシュボード
@@ -290,7 +309,7 @@ bash bin/cron-schedule.sh add --project A --time 21:00 --dow 1,2,3,4,5,6
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.4.4** — コントロールセンターの UX 修正（キー誤入力 / 重複タブ）/ 旧: v3.4.3 |
+| バージョン | **v3.4.5** — 多数プロジェクト管理の効率化（GitHubバッジ / 未管理フィルタ / 一括cron登録）/ 旧: v3.4.4 |
 | 実行基盤 | 🐧 **Linux ネイティブ**（`start.sh` / `bin/*.sh` / tmux / cron） |
 | テスト | ✅ **bats 194 件**（Linux）+ **Pester**（pwsh / Windows CI）/ shellcheck 0 |
 | CI | ✅ SUCCESS（ShellCheck+bats / test-and-validate / Secrets / PSScriptAnalyzer / CodeRabbit） |

--- a/bin/cron-schedule.sh
+++ b/bin/cron-schedule.sh
@@ -13,6 +13,7 @@
 #   cron-schedule.sh remove-all
 #   cron-schedule.sh run-now --project P [--duration 300] [--foreground]  # 既定 BG
 #   cron-schedule.sh launch [--project P[,P2]] [--duration N] [--all]     # 登録から一括 BG
+#   cron-schedule.sh bulk-register [--github-only] [--unmanaged-only] [--apply]  # 曜日分散一括登録
 # ============================================================
 
 set -euo pipefail
@@ -192,6 +193,85 @@ cs__run_now() {
   fi
 }
 
+# --- GitHub レポジトリ判定 (.git + remote origin) ---
+cs__is_github() {
+  local d; d="$(config_projects_dir)/$1"
+  [[ -d "$d/.git" ]] || return 1
+  git -C "$d" remote get-url origin >/dev/null 2>&1
+}
+
+# --- cron 登録済み / supervisor 管理下 判定 ---
+cs__is_cron_registered() { cron__list 2>/dev/null | awk -F'|' -v p="$1" '$2==p{f=1} END{exit !f}'; }
+cs__is_supervised() { [[ -f "${CCSU_SUP_DIR:-$HOME/.claudeos/supervisor}/$(ccsu_safe_name "$1").json" ]]; }
+
+# --- 一括 cron 登録 (曜日・時刻に分散。既定 dry-run、--apply で実登録) ---
+#   bulk-register [--github-only] [--unmanaged-only] [--start HH] [--spacing H]
+#                 [--duration M] [--dow CSV] [--apply]
+#   負荷分散: 各プロジェクトを 曜日 round-robin + 時刻スロットで割り当て、全件同時起動を避ける。
+cs__bulk_register() {
+  local github_only=0 unmanaged_only=0 start_hour=9 spacing="" duration="$DEFAULT_DURATION" dow="1,2,3,4,5,6" apply=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --github-only)    github_only=1; shift ;;
+      --unmanaged-only) unmanaged_only=1; shift ;;
+      --start)          start_hour="$2"; shift 2 ;;
+      --spacing)        spacing="$2"; shift 2 ;;
+      --duration)       duration="$2"; shift 2 ;;
+      --dow)            dow="$2"; shift 2 ;;
+      --apply)          apply=1; shift ;;
+      *) log_error "bulk-register: 不明な引数: $1"; return 1 ;;
+    esac
+  done
+  [[ "$start_hour" =~ ^[0-9]+$ && "$duration" =~ ^[0-9]+$ ]] || { log_error "--start / --duration は数値"; return 1; }
+  # 既定 spacing: duration を時間換算 (= 重複しない最小間隔)。例 300m → 5h
+  [[ -z "$spacing" ]] && spacing=$(( (duration + 59) / 60 ))
+  [[ "$spacing" =~ ^[0-9]+$ ]] || { log_error "--spacing は数値"; return 1; }
+  (( spacing < 1 )) && spacing=1
+
+  local -a dows; IFS=',' read -ra dows <<< "$dow"
+  local ndow=${#dows[@]}
+  (( ndow == 0 )) && { log_error "--dow が空"; return 1; }
+  # 重複警告: 間隔 < duration なら同日のセッションが重なる
+  if (( spacing * 60 < duration )); then
+    printf '  %s⚠️ 間隔 %dh < duration %dm: 同日のセッションが重複します(同時実行が増えます)%s\n' \
+      "$C_YELLOW" "$spacing" "$duration" "$C_RESET"
+  fi
+
+  # 候補収集
+  local -a cands=(); local p
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    (( github_only ))    && { cs__is_github "$p" || continue; }
+    if (( unmanaged_only )); then
+      cs__is_cron_registered "$p" && continue
+      cs__is_supervised "$p" && continue
+    fi
+    cands+=("$p")
+  done < <(cs__project_list)
+  (( ${#cands[@]} == 0 )) && { log_warn "対象プロジェクトがありません (条件: github_only=$github_only unmanaged_only=$unmanaged_only)"; return 0; }
+
+  log_info "一括 cron 登録 計画: ${#cands[@]} 件 / 曜日=$dow / 開始 ${start_hour}時 / 間隔 ${spacing}h / duration ${duration}m"
+  (( apply == 0 )) && printf '  %s※ DRY-RUN (実登録は --apply を付与)%s\n' "$C_YELLOW" "$C_RESET"
+
+  local i day_idx slot hour d t ok=0 skip=0
+  for i in "${!cands[@]}"; do
+    day_idx=$(( i % ndow )); slot=$(( i / ndow ))
+    d="${dows[$day_idx]}"; hour=$(( start_hour + slot * spacing ))
+    if (( hour > 23 )); then printf '  ⚠️  %-30s スロット超過(%d時) → skip\n' "${cands[$i]}" "$hour"; skip=$((skip+1)); continue; fi
+    t="$(printf '%02d:00' "$hour")"
+    printf '  %-30s %s曜 %s  %sm\n' "${cands[$i]}" "$(cron__dow_label "$d")" "$t" "$duration"
+    if (( apply )); then
+      if cs__is_cron_registered "${cands[$i]}"; then printf '     (登録済み → skip)\n'; skip=$((skip+1)); continue; fi
+      if cron__add "${cands[$i]}" "$duration" "$t" "$d" >/dev/null; then ok=$((ok+1)); else log_warn "登録失敗: ${cands[$i]}"; fi
+    fi
+  done
+  if (( apply )); then
+    log_ok "一括登録: 登録 $ok 件 / skip $skip 件"
+  else
+    printf '  %s適用: 同じ引数に --apply を付けて再実行%s\n' "$C_CYAN" "$C_RESET"
+  fi
+}
+
 # --- 対話: 曜日選択 (0=日〜6=土、カンマ区切り) ---
 cs__prompt_dow() {
   printf '  0=日 1=月 2=火 3=水 4=木 5=金 6=土 (月〜土なら 1,2,3,4,5,6)\n' >&2
@@ -263,8 +343,9 @@ main() {
     remove-all) cron__remove_all; printf '\n' ;;
     run-now)    shift; cs__run_now "$@" ;;
     launch)     shift; cs__launch "$@" ;;
+    bulk-register) shift; cs__bulk_register "$@" ;;
     menu|"")    cs__menu ;;
-    *) log_error "不明なサブコマンド: $1 (list|add|remove|remove-all|run-now|launch|menu)"; exit 1 ;;
+    *) log_error "不明なサブコマンド: $1 (list|add|remove|remove-all|run-now|launch|bulk-register|menu)"; exit 1 ;;
   esac
 }
 

--- a/bin/monitor-sessions.sh
+++ b/bin/monitor-sessions.sh
@@ -282,20 +282,41 @@ mon__cron_register() {
   fi
 }
 
-# mon__onboard — 全プロジェクトを状態バッジ付きで選択し、自律管理に追加
+# mon__is_github <project> — .git + remote origin があれば 0 (GitHub レポジトリ判定)
+mon__is_github() {
+  local d; d="$(config_projects_dir)/$1"
+  [[ -d "$d/.git" ]] || return 1
+  git -C "$d" remote get-url origin >/dev/null 2>&1
+}
+
+# mon__onboard [filter] — 全プロジェクトを 状態/GitHub バッジ付きで選び、自律管理に追加
+#   filter="unmanaged" で未管理(⚪)のみ表示 (u/a キーで切替)
 mon__onboard() {
-  local -a projs; mapfile -t projs < <(mon__all_projects)
+  local filter="${1:-}"
+  local -a all; mapfile -t all < <(mon__all_projects)
+  local -a projs=(); local p
+  for p in "${all[@]}"; do
+    if [[ "$filter" == "unmanaged" && "$(mon__project_state_badge "$p")" != *"未管理"* ]]; then continue; fi
+    projs+=("$p")
+  done
   tput cnorm 2>/dev/null || true
   clear 2>/dev/null || true
-  printf '\n  %s== 🆕 新規プロジェクトを自律管理に追加 ==%s\n' "$C_CYAN" "$C_RESET"
+  printf '\n  %s== 🆕 新規プロジェクトを自律管理に追加%s ==%s\n' \
+    "$C_CYAN" "$([[ "$filter" == unmanaged ]] && printf ' (未管理のみ)')" "$C_RESET"
   if (( ${#projs[@]} == 0 )); then
-    printf '  プロジェクトがありません (%s)\n' "$(config_projects_dir)"
+    printf '  対象プロジェクトがありません%s\n' "$([[ "$filter" == unmanaged ]] && printf ' (未管理なし)')"
     read -rp "  Enter で戻る " _ || true; tput civis 2>/dev/null || true; return 0
   fi
-  local i; for i in "${!projs[@]}"; do
-    printf '   %s[%d]%s %-26s %s\n' "$C_YELLOW" "$((i + 1))" "$C_RESET" "${projs[$i]}" "$(mon__project_state_badge "${projs[$i]}")"
+  local i gh; for i in "${!projs[@]}"; do
+    if mon__is_github "${projs[$i]}"; then gh="🐙"; else gh="　"; fi
+    printf '   %s[%d]%s %s %-30s %s\n' "$C_YELLOW" "$((i + 1))" "$C_RESET" "$gh" "${projs[$i]}" "$(mon__project_state_badge "${projs[$i]}")"
   done
-  local sel p; read -rp "  番号 (0=キャンセル): " sel || true
+  printf '   %s🐙=GitHubレポジトリ  ⚪未管理 が追加候補%s\n' "$C_GRAY" "$C_RESET"
+  local sel p; read -rp "  番号 (0=キャンセル / u=未管理のみ / a=全表示): " sel || true
+  case "$sel" in
+    u|U) mon__onboard unmanaged; return 0 ;;
+    a|A) mon__onboard; return 0 ;;
+  esac
   if [[ "$sel" =~ ^[0-9]+$ ]] && (( sel >= 1 && sel <= ${#projs[@]} )); then
     p="${projs[$((sel - 1))]}"
     printf '\n  %s─ %s に対して ─%s\n' "$C_CYAN" "$p" "$C_RESET"

--- a/tests/bats/unit/cron-schedule.bats
+++ b/tests/bats/unit/cron-schedule.bats
@@ -24,6 +24,7 @@ JSON
   mkdir -p "$TEST_TEMP/projects/MyProj" "$TEST_TEMP/projects/Other"
   export CCSU_CRON_LAUNCHER="$TEST_TEMP/cron-launcher.sh"
   export CCSU_CRON_LOGS_DIR="$TEST_TEMP/logs"
+  export CCSU_SUP_DIR="$TEST_TEMP/sup"   # supervised 判定が実 ~/.claudeos を見ないように
   SCRIPT="$REPO_ROOT/bin/cron-schedule.sh"
 }
 teardown() { _bats_common_teardown; }
@@ -144,6 +145,35 @@ EOF
   run bash "$SCRIPT" launch --all
   [ "$status" -eq 0 ]
   [[ "$output" != *"BG 起動:"* ]]
+}
+
+@test "bulk-register: dry-run で曜日分散の計画を表示 (実登録しない)" {
+  run bash "$SCRIPT" bulk-register --dow 1,2 --start 9 --spacing 3
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"MyProj"* ]]
+  [[ "$output" == *"月曜 09:00"* ]]
+  # crontab には書かれない
+  [[ "$output" != *"crontab 更新"* ]]
+  run bash "$SCRIPT" list
+  [[ "$output" == *"ありません"* ]]
+}
+
+@test "bulk-register --apply: crontab に登録される" {
+  run bash "$SCRIPT" bulk-register --dow 1 --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"一括登録: 登録"* ]]
+  run cat "$CRON_STORE"
+  [[ "$output" == *"project=MyProj"* ]]
+  [[ "$output" == *"project=Other"* ]]
+}
+
+@test "bulk-register --unmanaged-only: cron 登録済みを除外" {
+  bash "$SCRIPT" add --project MyProj --time 21:00 --dow 1 >/dev/null
+  run bash "$SCRIPT" bulk-register --unmanaged-only --dow 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1 件"* ]]
+  [[ "$output" == *"Other"* ]]
 }
 
 @test "不明サブコマンドでエラー" {

--- a/tests/bats/unit/monitor-sessions.bats
+++ b/tests/bats/unit/monitor-sessions.bats
@@ -245,3 +245,15 @@ EOF
   run bash -c "source '$SCRIPT'; mon__project_state_badge Alpha"
   [[ "$output" == *"自律中"* ]]
 }
+
+@test "mon__is_github: .git + origin あれば 0" {
+  git -C "$TEST_TEMP/projects/Alpha" init -q 2>/dev/null || skip "git なし"
+  git -C "$TEST_TEMP/projects/Alpha" remote add origin https://example.com/x.git 2>/dev/null
+  run bash -c "source '$SCRIPT'; mon__is_github Alpha"
+  [ "$status" -eq 0 ]
+}
+
+@test "mon__is_github: .git なしは非0" {
+  run bash -c "source '$SCRIPT'; mon__is_github Beta"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## 変更内容（多数プロジェクト管理の効率化・ユーザー要望3点）
- **🐙 GitHub バッジ + 未管理フィルタ**: `n` ピッカーに `mon__is_github`（🐙）+ `u`(未管理のみ)/`a`(全表示)。32 プロジェクトから未管理の GitHub を一目で選べる
- **一括 cron 登録** (`bulk-register`): 未管理プロジェクトを**曜日 round-robin + 時刻スロットで負荷分散登録**（全件同時起動を回避）。既定 **dry-run**、既定間隔 = duration 時間で**同日重複ゼロ**、重複設定時は警告。`--apply` で実登録
- stale cron 掃除は運用で対応（現 crontab は既にクリーン）

## テスト結果
- `bulk-register` 3 件 + `mon__is_github` 2 件追加。全 bats **204 件** / shellcheck 0 / check-doc-versions v3.4.5
- 実データ dry-run: 未管理 GitHub **18 件**を 月〜土 × 09/14/19 時に**重複なく**分散できることを確認

## 影響範囲
- `n` ピッカーの表示拡張 + 新 CLI サブコマンド追加。既存挙動は維持（bulk-register は既定 dry-run）

🤖 Generated with [Claude Code](https://claude.com/claude-code)