### PR TITLE
feat(projects): プロジェクト列挙を Git リポジトリのディレクトリのみに統一 (v3.4.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 # CHANGELOG
 
+## [v3.4.7] - 2026-06-02 — プロジェクト列挙を「Git リポジトリのディレクトリのみ」に統一
+
+### 🎯 概要
+プロジェクト選択の対象を **「ディレクトリ かつ Git リポジトリ（`.git` 保有）」** に限定。ファイル（`.md`/`.sh`/`.json` 等）や非 Git ディレクトリ（整理用フォルダ等）を一覧から除外。共通ヘルパ `config_project_list` を新設し、`n` ピッカー / cron 登録 / 手動起動（L1/S1）で共有（単一の定義 = SoT）。
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `lib/config-loader.sh` | **`config_project_list`** 新設（`config_projects_dir` 直下の dir かつ `.git` 保有のみ。ファイル/非 Git/隠しは `*/` グロブ＋`.git` チェックで除外） |
+| `bin/monitor-sessions.sh` / `bin/cron-schedule.sh` / `lib/launcher-common.sh` | 各 `*_project_list` を `config_project_list` に統一 |
+| `tests/bats/unit/*` | `config_project_list` + 非 Git/ファイル除外 のテスト追加 |
+
+### ✅ 内容
+
+- 実データ: 32 項目（6 ファイル + 5 非 Git ディレクトリ + 21 Git リポジトリ）→ 一覧は **21 件のみ**に
+- `n` ピッカー / cron 登録 / 手動起動（L1/S1）すべてで一貫（GitHub origin の有無は 🐙 バッジで表示）
+- 全 bats **206 件** / shellcheck error 0
+
+---
+
 ## [v3.4.6] - 2026-06-02 — コントロールセンターの画面チラつき修正 + オンボード操作の明確化
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ bash bin/autonomy.sh list                      # すべての Supervisor 一覧
 > 🧠 **裏側のしくみ（安心ポイント）**: 「追加」とは “supervisor を開始する／cron に登録する” こと **そのもの**です。
 > 別の管理リストを作らないので、画面の表示と実際の動きが**ズレません**。
 
-**🐙 GitHub バッジ & フィルタ**: 一覧では GitHub レポジトリを持つプロジェクトに `🐙` が付きます。
+**📂 一覧に出る条件**: `config_projects_dir`（既定 `~/Projects`）直下の **ディレクトリ かつ Git リポジトリ（`.git` を持つ）** のみが対象です。ファイル（`.md`/`.sh`/`.json` 等）や非 Git の整理用フォルダは**自動で除外**されます。
+
+**🐙 GitHub バッジ & フィルタ**: GitHub のリモート（origin）を持つプロジェクトに `🐙` が付きます。
 プロジェクトが多いときは `u`（未管理のみ）/ `a`（全表示）で絞り込めます。
 
 ### 📅 たくさんのプロジェクトをまとめて登録（曜日分散）
@@ -309,7 +311,7 @@ bash bin/cron-schedule.sh add --project A --time 21:00 --dow 1,2,3,4,5,6
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.4.6** — コントロールセンターの画面チラつき修正 + オンボード操作の明確化 / 旧: v3.4.5 |
+| バージョン | **v3.4.7** — プロジェクト列挙を Git リポジトリのディレクトリのみに統一 / 旧: v3.4.6 |
 | 実行基盤 | 🐧 **Linux ネイティブ**（`start.sh` / `bin/*.sh` / tmux / cron） |
 | テスト | ✅ **bats 194 件**（Linux）+ **Pester**（pwsh / Windows CI）/ shellcheck 0 |
 | CI | ✅ SUCCESS（ShellCheck+bats / test-and-validate / Secrets / PSScriptAnalyzer / CodeRabbit） |

--- a/bin/cron-schedule.sh
+++ b/bin/cron-schedule.sh
@@ -29,12 +29,8 @@ source "$SCRIPT_DIR/../lib/cron-manager.sh"
 CRON_LAUNCHER="${CCSU_CRON_LAUNCHER:-$HOME/.claudeos/cron-launcher.sh}"
 DEFAULT_DURATION=300
 
-# --- プロジェクト一覧 (ローカル ls。New-CronSchedule の ssh ls を置換) ---
-cs__project_list() {
-  local base; base="$(config_projects_dir)"
-  [[ -d "$base" ]] || return 0
-  ls -1 "$base" 2>/dev/null | grep -v '^\.' || true
-}
+# --- プロジェクト一覧 (config_project_list: dir かつ Git リポジトリのみ) ---
+cs__project_list() { config_project_list; }
 
 # --- 一覧表示 (cron__format_display で整形) ---
 cs__list_display() {

--- a/bin/monitor-sessions.sh
+++ b/bin/monitor-sessions.sh
@@ -253,12 +253,8 @@ mon__action() {
 # 新規プロジェクトのオンボード (n キー: 全プロジェクトから選んで管理下へ)
 # ------------------------------------------------------------
 
-# mon__all_projects — config_projects_dir 配下の全プロジェクト名 (隠し除外)
-mon__all_projects() {
-  local base; base="$(config_projects_dir)"
-  [[ -d "$base" ]] || return 0
-  ls -1 "$base" 2>/dev/null | grep -v '^\.' || true
-}
+# mon__all_projects — プロジェクト列挙 (config_project_list: dir かつ Git リポジトリのみ)
+mon__all_projects() { config_project_list; }
 
 # mon__project_state_badge <project> — 現状を表す状態バッジ (誤操作防止の可視化)
 mon__project_state_badge() {

--- a/lib/config-loader.sh
+++ b/lib/config-loader.sh
@@ -30,6 +30,21 @@ config_projects_dir() {
   if [[ -n "$base" ]]; then printf '%s' "$base"; else config_get '.projectsDir' "$HOME/Projects"; fi
 }
 
+# --- プロジェクト列挙 (正本) ---
+#   条件: config_projects_dir 直下の「ディレクトリ かつ Git リポジトリ(.git 保有)」のみ。
+#   ファイル・非 Git ディレクトリ・隠しエントリは除外。出力は名前を 1 行 1 件 (名前順)。
+#   ※ */ グロブがディレクトリのみ・隠し除外を満たすため、.md/.sh/.json 等は自然に落ちる。
+config_project_list() {
+  local base; base="$(config_projects_dir)"
+  [[ -d "$base" ]] || return 0
+  local d
+  for d in "$base"/*/; do
+    [[ -d "$d" ]] || continue         # マッチ無し時の literal "*/" 対策
+    [[ -d "${d}.git" ]] || continue   # Git リポジトリのみ (.git サブディレクトリ保有)
+    basename "$d"
+  done
+}
+
 # --- 接続情報 (移行後はローカル実行のため参考値) ---
 config_linux_host() { config_get '.linuxHost' ''; }
 config_linux_user() { config_get '.linuxUser' "$USER"; }

--- a/lib/launcher-common.sh
+++ b/lib/launcher-common.sh
@@ -16,12 +16,8 @@ _CCSU_LAUNCHER_LOADED=1
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/config-loader.sh"
 
-# launcher__project_list — config_projects_dir 配下のプロジェクト名 (隠し除外)
-launcher__project_list() {
-  local base; base="$(config_projects_dir)"
-  [[ -d "$base" ]] || return 0
-  ls -1 "$base" 2>/dev/null | grep -v '^\.' || true
-}
+# launcher__project_list — プロジェクト列挙 (config_project_list: dir かつ Git リポジトリのみ)
+launcher__project_list() { config_project_list; }
 
 # launcher__project_dir <project> — プロジェクトの絶対パス
 launcher__project_dir() { printf '%s/%s' "$(config_projects_dir)" "$1"; }

--- a/tests/bats/unit/config.bats
+++ b/tests/bats/unit/config.bats
@@ -104,3 +104,17 @@ teardown() { _bats_common_teardown; }
   run config_require
   [ "$status" -ne 0 ]
 }
+
+@test "config_project_list: dir+.git のみ列挙 (ファイル/非Git/隠し除外)" {
+  local base="$TEST_TEMP/pl"
+  mkdir -p "$base/RepoA/.git" "$base/RepoB/.git" "$base/PlainDir"
+  touch "$base/file.md" "$base/.hidden"
+  printf '{ "linuxBase": "%s" }\n' "$base" > "$TEST_TEMP/pl-config.json"
+  CCSU_CONFIG_PATH="$TEST_TEMP/pl-config.json"
+  run config_project_list
+  [[ "$output" == *"RepoA"* ]]
+  [[ "$output" == *"RepoB"* ]]
+  [[ "$output" != *"PlainDir"* ]]
+  [[ "$output" != *"file.md"* ]]
+  [[ "$output" != *".hidden"* ]]
+}

--- a/tests/bats/unit/cron-schedule.bats
+++ b/tests/bats/unit/cron-schedule.bats
@@ -21,7 +21,7 @@ esac
   cat > "$AI_STARTUP_CONFIG_PATH" <<JSON
 { "linuxBase": "$TEST_TEMP/projects", "projectsDir": "$TEST_TEMP/projects" }
 JSON
-  mkdir -p "$TEST_TEMP/projects/MyProj" "$TEST_TEMP/projects/Other"
+  mkdir -p "$TEST_TEMP/projects/MyProj/.git" "$TEST_TEMP/projects/Other/.git"
   export CCSU_CRON_LAUNCHER="$TEST_TEMP/cron-launcher.sh"
   export CCSU_CRON_LOGS_DIR="$TEST_TEMP/logs"
   export CCSU_SUP_DIR="$TEST_TEMP/sup"   # supervised 判定が実 ~/.claudeos を見ないように

--- a/tests/bats/unit/launcher-common.bats
+++ b/tests/bats/unit/launcher-common.bats
@@ -12,8 +12,9 @@ setup() {
   cat > "$AI_STARTUP_CONFIG_PATH" <<JSON
 { "linuxBase": "$TEST_TEMP/projects", "projectsDir": "$TEST_TEMP/projects" }
 JSON
-  mkdir -p "$TEST_TEMP/projects/Alpha" "$TEST_TEMP/projects/Beta"
-  touch "$TEST_TEMP/projects/.hidden"
+  mkdir -p "$TEST_TEMP/projects/Alpha/.git" "$TEST_TEMP/projects/Beta/.git"
+  mkdir -p "$TEST_TEMP/projects/NotGit"   # 非Gitディレクトリ (除外対象)
+  touch "$TEST_TEMP/projects/.hidden" "$TEST_TEMP/projects/notes.md"  # 隠し/ファイル (除外対象)
   source "$REPO_ROOT/lib/launcher-common.sh"
 }
 teardown() { _bats_common_teardown; }
@@ -27,6 +28,13 @@ teardown() { _bats_common_teardown; }
 @test "launcher__project_list: 隠しエントリを除外" {
   run launcher__project_list
   [[ "$output" != *".hidden"* ]]
+}
+
+@test "launcher__project_list: 非Gitディレクトリとファイルを除外 (dir+.git のみ)" {
+  run launcher__project_list
+  [[ "$output" != *"NotGit"* ]]
+  [[ "$output" != *"notes.md"* ]]
+  [[ "$output" == *"Alpha"* ]]
 }
 
 @test "launcher__project_dir: 絶対パスを返す" {

--- a/tests/bats/unit/monitor-sessions.bats
+++ b/tests/bats/unit/monitor-sessions.bats
@@ -50,7 +50,7 @@ esac
   # config (全プロジェクト列挙 mon__all_projects 用)
   export AI_STARTUP_CONFIG_PATH="$TEST_TEMP/config.json"
   printf '{ "linuxBase": "%s/projects" }\n' "$TEST_TEMP" > "$AI_STARTUP_CONFIG_PATH"
-  mkdir -p "$TEST_TEMP/projects/Alpha" "$TEST_TEMP/projects/Beta"
+  mkdir -p "$TEST_TEMP/projects/Alpha/.git" "$TEST_TEMP/projects/Beta/.git"
 }
 teardown() { _bats_common_teardown; }
 
@@ -253,7 +253,8 @@ EOF
   [ "$status" -eq 0 ]
 }
 
-@test "mon__is_github: .git なしは非0" {
-  run bash -c "source '$SCRIPT'; mon__is_github Beta"
+@test "mon__is_github: .git なし/origin なしは非0" {
+  mkdir -p "$TEST_TEMP/projects/PlainDir"   # .git を持たないディレクトリ
+  run bash -c "source '$SCRIPT'; mon__is_github PlainDir"
   [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
## 変更内容（ユーザー要望: 選択条件の明確化）
プロジェクト選択の対象を **「ディレクトリ かつ Git リポジトリ（`.git` 保有）」** に限定。ファイル（`.md`/`.sh`/`.json`）や非 Git ディレクトリ（整理用フォルダ）を一覧から除外。

- `lib/config-loader.sh`: **`config_project_list`** を新設（正本）。`*/` グロブ + `.git` チェックで dir かつ git リポジトリのみ
- `monitor-sessions.sh` / `cron-schedule.sh` / `launcher-common.sh`: 各 `*_project_list` を共通ヘルパに統一（SoT）。`n` ピッカー / cron 登録 / 手動起動（L1/S1）で一貫

## テスト結果
- 実データ: 32 項目（6 ファイル + 5 非 Git dir + 21 git リポジトリ）→ 一覧は **21 件のみ**に（ファイル/非 Git 除外を確認）
- `config_project_list` + 非 Git/ファイル除外 のテスト追加。全 bats **206 件** / shellcheck 0 / check-doc-versions v3.4.7

## 影響範囲
- プロジェクト列挙の条件変更（全選択 UI で一貫）。GitHub origin の有無は 🐙 バッジで表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * プロジェクト一覧の表示条件を明確化：Git リポジトリのディレクトリのみを対象に、非 Git ディレクトリは自動除外
  * GitHub リモート（origin）を持つプロジェクトに GitHub バッジを表示
  * バージョン v3.4.7 に更新し、関連する変更内容をドキュメントに反映

<!-- end of auto-generated comment: release notes by coderabbit.ai -->