### PR TITLE
feat(docker): Docker オーケストレーション統合 (v3.4.8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ DevTools-chrome-*
 .claude/memory/project-context.json
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+config/*.lock
 
 # hookify ローカルルール（ユーザー固有・コミット不要）
 # 推奨ルール集は docs/common/17_hookify-CTO-guard.md を参照

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 # CHANGELOG
 
+## [v3.4.8] - 2026-06-04 — Docker オーケストレーション統合 (compose 検出 / 台帳 CRUD / 雛形生成 / Hub 連携)
+
+### 🎯 概要
+登録プロジェクトの Docker 統合管理機能を新設。**自動インストール・自動ログインは一切行わず**、compose 検出・スタック判定・台帳 CRUD・サービス起動/停止・Hub イメージ一覧を提供。`bin/menu.sh` の `DK` メニューから対話操作可能。
+
+### 🔧 新規ファイル
+
+| ファイル | 内容 |
+|---|---|
+| `lib/docker-manager.sh` | Docker 統合ライブラリ（compose 検出 / スタック判定 / 台帳 CRUD / サービス制御 / Hub 連携） |
+| `bin/docker-control.sh` | CLI エントリ（status / scan / list / register / register-all / up / down / up-all / scaffold / login-status / hub-images） |
+| `config/docker-registry.json` | 登録プロジェクト台帳（初期登録済み）|
+| `tests/bats/unit/docker-manager.bats` | docker-manager.sh ユニットテスト 30 件（daemon 非依存の純関数のみ） |
+
+### 🔧 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `bin/menu.sh` | `DK` メニュー追加（`docker_submenu` 関数）|
+| `.gitignore` | `config/*.lock`（flock 副産物）除外追記 |
+
+### ✅ 内容
+
+- `docker_find_compose`: root → docker/ → infra/docker/ → deploy/ の優先順で compose ファイルを検出
+- `docker_detect_stack`: node / python / fullstack / go / rust / dotnet / java-maven / java-gradle / php / ruby / static / unknown を自動判定
+- `docker_registry_*`: `config/docker-registry.json` への CRUD（`jq`）
+- `_scaffold_fullstack`: multi-stage Dockerfile.frontend（Node build → nginx:alpine serve）を自動生成
+- login 状態検出: `docker_logged_in` は `~/.docker/config.json` の `auths` を確認するのみ。決してログインしない
+- 全 bats **232 件** / shellcheck error 0
+
+---
+
 ## [v3.4.7] - 2026-06-02 — プロジェクト列挙を「Git リポジトリのディレクトリのみ」に統一
 
 ### 🎯 概要

--- a/README.md
+++ b/README.md
@@ -311,9 +311,9 @@ bash bin/cron-schedule.sh add --project A --time 21:00 --dow 1,2,3,4,5,6
 
 | 項目 | 状態 |
 |------|------|
-| バージョン | **v3.4.7** — プロジェクト列挙を Git リポジトリのディレクトリのみに統一 / 旧: v3.4.6 |
+| バージョン | **v3.4.8** — Docker オーケストレーション統合（compose 検出 / 台帳 CRUD / 雛形生成 / Hub 連携） / 旧: v3.4.7 |
 | 実行基盤 | 🐧 **Linux ネイティブ**（`start.sh` / `bin/*.sh` / tmux / cron） |
-| テスト | ✅ **bats 194 件**（Linux）+ **Pester**（pwsh / Windows CI）/ shellcheck 0 |
+| テスト | ✅ **bats 232 件**（Linux）+ **Pester**（pwsh / Windows CI）/ shellcheck 0 |
 | CI | ✅ SUCCESS（ShellCheck+bats / test-and-validate / Secrets / PSScriptAnalyzer / CodeRabbit） |
 | ClaudeOS | **v9.0**（`/goal` 駆動 / Agent Teams A・B・C / Agent View / 動的判断 / 週次フェーズ制御 / Stop Conditions） |
 | Agents | **44体** の特化サブエージェント（CTO・開発・QA・Security・レビュー・ビルド解決・CMDB・監査…） |

--- a/bin/docker-control.sh
+++ b/bin/docker-control.sh
@@ -1,0 +1,555 @@
+#!/usr/bin/env bash
+# ============================================================
+# docker-control.sh — 登録プロジェクトの Docker 統合制御 CLI (Linux native)
+#
+# /home/kensan/Projects 配下の登録プロジェクトを Docker から起動・管理する。
+# 検出/台帳/Hub 連携の実体は lib/docker-manager.sh。本ファイルは CLI 表層。
+#
+# 使い方:
+#   docker-control.sh status                  # Docker 可用性・compose・login 状態
+#   docker-control.sh scan                     # Projects 走査 (compose/stack/登録状況)
+#   docker-control.sh list                     # 台帳の登録プロジェクト一覧
+#   docker-control.sh register <name> [--compose REL] [--no-autostart]
+#   docker-control.sh unregister <name>
+#   docker-control.sh up   <name>              # compose up -d
+#   docker-control.sh down <name>              # compose down
+#   docker-control.sh ps   <name>              # compose ps
+#   docker-control.sh logs <name> [args...]    # compose logs (既定 --tail=100)
+#   docker-control.sh up-all                   # autostart=true を一括起動
+#   docker-control.sh scaffold <name> [--force]# stack 検出で Dockerfile/compose 雛形生成
+#   docker-control.sh login-status             # login 検出のみ (未ログインは手動案内)
+#   docker-control.sh hub-images [namespace]   # Docker Hub のリポジトリ一覧
+#   docker-control.sh hub-pull <image>         # イメージ取得
+#   docker-control.sh help
+#
+# 設計上の厳守事項:
+#   - docker のインストールおよび `docker login` は決して自動実行しない。
+#     未ログイン時は `! docker login` の手動実行をユーザーへ案内するのみ。
+# ============================================================
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+# shellcheck source=lib/json.sh
+source "$SCRIPT_DIR/../lib/json.sh"
+# shellcheck source=lib/config-loader.sh
+source "$SCRIPT_DIR/../lib/config-loader.sh"
+# shellcheck source=lib/docker-manager.sh
+source "$SCRIPT_DIR/../lib/docker-manager.sh"
+
+# ------------------------------------------------------------
+# 表示ヘルパ
+# ------------------------------------------------------------
+_mark() { [[ "$1" -eq 0 ]] && printf '%s✅%s' "$C_GREEN" "$C_RESET" || printf '%s❌%s' "$C_RED" "$C_RESET"; }
+
+# ------------------------------------------------------------
+# status — Docker 環境の総合診断 (read-only)
+# ------------------------------------------------------------
+dc__status() {
+  printf '%s📦 Docker 環境診断%s\n' "$C_CYAN" "$C_RESET"
+
+  local cli_ok=1 daemon_ok=1
+  docker_cli_present && cli_ok=0
+  printf '  %s docker CLI       %s\n' "$(_mark "$cli_ok")" "$( (( cli_ok == 0 )) && command -v docker || echo '未インストール (手動: 公式手順)')"
+
+  if (( cli_ok == 0 )); then
+    printf '  ℹ️  client version  %s\n' "$(docker_version 2>/dev/null || echo '?')"
+  fi
+
+  docker_daemon_up && daemon_ok=0
+  printf '  %s docker daemon    %s\n' "$(_mark "$daemon_ok")" "$( (( daemon_ok == 0 )) && echo '到達OK' || echo '未到達 (sudo systemctl start docker など — 手動)')"
+
+  local cc; cc="$(docker_compose_cmd)"
+  if [[ -n "$cc" ]]; then
+    printf '  ✅ compose         %s\n' "$cc"
+  else
+    printf '  ❌ compose         利用不可 (docker compose プラグイン未導入)\n'
+  fi
+
+  if docker_logged_in; then
+    printf '  ✅ registry login  ログイン済み (user: %s)\n' "$(docker_hub_user 2>/dev/null || echo '?')"
+  else
+    printf '  ⚠️  registry login  未ログイン — 必要なら %s! docker login%s を手動実行\n' "$C_YELLOW" "$C_RESET"
+  fi
+
+  printf '  📁 台帳            %s (%s 件登録)\n' "$DOCKER_REGISTRY_PATH" "$(docker_registry_projects | grep -c . || true)"
+}
+
+# ------------------------------------------------------------
+# scan — Projects 配下を走査し compose/stack/登録状況を一覧
+# ------------------------------------------------------------
+dc__scan() {
+  local base; base="$(config_projects_dir)"
+  printf '%s🔍 プロジェクト走査%s (%s)\n' "$C_CYAN" "$C_RESET" "$base"
+  printf '  %-32s %-10s %-26s %-8s %s\n' 'PROJECT' 'STACK' 'COMPOSE' '登録' 'AUTOSTART'
+  printf '  %s\n' '----------------------------------------------------------------------------------------'
+  local name dir stack compose reg autostart
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    dir="$(docker_project_dir "$name")"
+    stack="$(docker_detect_stack "$dir")"
+    compose="$(docker_find_compose "$dir")"
+    [[ -z "$compose" ]] && compose='-'
+    if docker_registry_has "$name"; then
+      reg='yes'
+      autostart="$(docker_registry_get "$name" 'autostart' 'false')"
+    else
+      reg='-'; autostart='-'
+    fi
+    printf '  %-32s %-10s %-26s %-8s %s\n' "$name" "$stack" "$compose" "$reg" "$autostart"
+  done < <(config_project_list)
+}
+
+# ------------------------------------------------------------
+# list — 台帳の登録プロジェクト一覧
+# ------------------------------------------------------------
+dc__list() {
+  local n; n="$(docker_registry_projects | grep -c . || true)"
+  if [[ "$n" -eq 0 ]]; then
+    log_info "台帳に登録されたプロジェクトはありません ($DOCKER_REGISTRY_PATH)"
+    log_info "登録: docker-control.sh register <name>"
+    return 0
+  fi
+  printf '%s📋 Docker 管理台帳%s (%s 件)\n' "$C_CYAN" "$C_RESET" "$n"
+  printf '  %-32s %-10s %-26s %s\n' 'PROJECT' 'STACK' 'COMPOSE' 'AUTOSTART'
+  printf '  %s\n' '------------------------------------------------------------------------------'
+  local name
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    printf '  %-32s %-10s %-26s %s\n' \
+      "$name" \
+      "$(docker_registry_get "$name" 'stack' '?')" \
+      "$(docker_registry_get "$name" 'compose' '-')" \
+      "$(docker_registry_get "$name" 'autostart' 'false')"
+  done < <(docker_registry_projects)
+}
+
+# ------------------------------------------------------------
+# register / unregister
+# ------------------------------------------------------------
+dc__register() {
+  local name="" compose="" autostart="true"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --compose)      compose="$2"; shift 2 ;;
+      --no-autostart) autostart="false"; shift ;;
+      --*)            log_error "register: 不明な引数: $1"; return 1 ;;
+      *)              name="$1"; shift ;;
+    esac
+  done
+  [[ -n "$name" ]] || { log_error "register: <name> は必須"; return 1; }
+  docker_registry_register "$name" "$compose" "$autostart" || return 1
+  local c; c="$(docker_registry_get "$name" 'compose' '')"
+  if [[ -z "$c" || "$c" == "null" ]]; then
+    log_ok "登録: $name (compose 未検出 — scaffold で雛形生成可: docker-control.sh scaffold $name)"
+  else
+    log_ok "登録: $name (compose=$c, stack=$(docker_registry_get "$name" 'stack' '?'), autostart=$autostart)"
+  fi
+}
+
+dc__unregister() {
+  local name="${1:-}"
+  [[ -n "$name" ]] || { log_error "unregister: <name> は必須"; return 1; }
+  docker_registry_has "$name" || { log_warn "未登録: $name"; return 0; }
+  docker_registry_unregister "$name"
+  log_ok "登録解除: $name"
+}
+
+# ------------------------------------------------------------
+# register-all — compose 検出済みかつ未登録のプロジェクトを一括登録
+#   既存・今後新規の両方を拾う。compose 不在は scaffold 候補として報告のみ。
+#   既定 autostart=false (一括起動の暴発防止)。--autostart で true 化。
+# ------------------------------------------------------------
+dc__register_all() {
+  local autostart="false"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --autostart) autostart="true"; shift ;;
+      --*)         log_error "register-all: 不明な引数: $1"; return 1 ;;
+      *)           log_error "register-all: 余分な引数: $1"; return 1 ;;
+    esac
+  done
+  local added=0 skipped=0 scaffoldable=0 name dir compose
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    if docker_registry_has "$name"; then
+      skipped=$((skipped + 1)); continue
+    fi
+    dir="$(docker_project_dir "$name")"
+    compose="$(docker_find_compose "$dir")"
+    if [[ -z "$compose" ]]; then
+      scaffoldable=$((scaffoldable + 1))
+      log_info "  scaffold 候補: $name (compose 不在 — scaffold $name で雛形生成可)"
+      continue
+    fi
+    if docker_registry_register "$name" "$compose" "$autostart"; then
+      added=$((added + 1))
+      log_ok "登録: $name (compose=$compose, autostart=$autostart)"
+    else
+      log_warn "登録失敗: $name (継続)"
+    fi
+  done < <(config_project_list)
+  printf '%s📊 一括登録結果%s 追加=%d 既登録=%d scaffold候補=%d\n' \
+    "$C_CYAN" "$C_RESET" "$added" "$skipped" "$scaffoldable"
+  return 0
+}
+
+# ------------------------------------------------------------
+# サービス制御 (compose 経由) — docker 可用性を先に確認
+# ------------------------------------------------------------
+dc__require_docker() {
+  docker_available && return 0
+  log_error "Docker が利用できません (CLI 不在 or daemon 未到達)。status で確認してください"
+  log_info "  インストール/起動はユーザー手動対応 (このツールは自動化しません)"
+  return 1
+}
+
+dc__up() {
+  local name="${1:-}"; [[ -n "$name" ]] || { log_error "up: <name> は必須"; return 1; }
+  dc__require_docker || return 1
+  log_info "🚀 起動: $name"
+  docker_up "$name"
+}
+
+dc__down() {
+  local name="${1:-}"; [[ -n "$name" ]] || { log_error "down: <name> は必須"; return 1; }
+  dc__require_docker || return 1
+  log_info "🛑 停止: $name"
+  docker_down "$name"
+}
+
+dc__ps() {
+  local name="${1:-}"; [[ -n "$name" ]] || { log_error "ps: <name> は必須"; return 1; }
+  dc__require_docker || return 1
+  docker_ps "$name"
+}
+
+dc__logs() {
+  local name="${1:-}"; [[ -n "$name" ]] || { log_error "logs: <name> は必須"; return 1; }
+  shift
+  dc__require_docker || return 1
+  docker_logs "$name" "$@"
+}
+
+dc__up_all() {
+  dc__require_docker || return 1
+  local any=0 name
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    any=1
+    log_info "🚀 起動 (autostart): $name"
+    docker_up "$name" || log_warn "起動失敗: $name (継続)"
+  done < <(docker_registry_autostart_list)
+  (( any == 0 )) && log_info "autostart=true のプロジェクトはありません"
+  return 0
+}
+
+# ------------------------------------------------------------
+# login-status — 検出のみ。未ログインは手動案内 (自動ログイン禁止)
+# ------------------------------------------------------------
+dc__login_status() {
+  if docker_logged_in; then
+    log_ok "Docker registry ログイン済み (user: $(docker_hub_user 2>/dev/null || echo '?'))"
+    printf '  config: %s\n' "$(docker_config_json)"
+  else
+    log_warn "Docker registry に未ログインです"
+    printf '  Docker Hub と連携するには、以下を%s手動%sで実行してください:\n' "$C_YELLOW" "$C_RESET"
+    printf '    %s! docker login%s\n' "$C_CYAN" "$C_RESET"
+    printf '  (このツールは認証情報を扱わず、ログインを自動化しません)\n'
+  fi
+}
+
+# ------------------------------------------------------------
+# Docker Hub 連携
+# ------------------------------------------------------------
+dc__hub_images() {
+  local ns="${1:-}"
+  printf '%s🐳 Docker Hub リポジトリ一覧%s%s\n' "$C_CYAN" "$C_RESET" "${ns:+ ($ns)}"
+  local rows
+  rows="$(docker_hub_list_images "$ns")" || return 1
+  if [[ -z "$rows" ]]; then
+    log_info "リポジトリが見つかりません (公開リポジトリのみ無認証で列挙されます)"
+    return 0
+  fi
+  printf '  %-40s %-12s %s\n' 'REPOSITORY' 'PULLS' 'VISIBILITY'
+  printf '  %s\n' '----------------------------------------------------------------'
+  local repo pulls vis
+  while IFS=$'\t' read -r repo pulls vis; do
+    printf '  %-40s %-12s %s\n' "$repo" "$pulls" "$vis"
+  done <<< "$rows"
+}
+
+dc__hub_pull() {
+  local image="${1:-}"
+  [[ -n "$image" ]] || { log_error "hub-pull: <image> は必須 (例: user/repo:tag)"; return 1; }
+  dc__require_docker || return 1
+  log_info "⬇️  pull: $image"
+  if ! docker_hub_pull "$image"; then
+    log_error "pull に失敗しました。private イメージの場合は %s! docker login%s を手動実行してください" "$C_YELLOW" "$C_RESET"
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------
+# scaffold — stack 検出で Dockerfile/compose 雛形を <project>/docker/ に生成
+#   非破壊: 既存 compose があれば全体スキップ。個別ファイルも存在時スキップ。
+#   --force で上書き。
+# ------------------------------------------------------------
+# _scaffold_write <path> <force> — heredoc を受けてファイルを書く (非破壊)
+_scaffold_write() {
+  local path="$1" force="$2"
+  if [[ -f "$path" && "$force" != "1" ]]; then
+    log_info "  skip (既存): ${path#"$(config_projects_dir)"/}"
+    return 1
+  fi
+  mkdir -p "$(dirname "$path")"
+  cat > "$path"
+  log_ok "  生成: ${path#"$(config_projects_dir)"/}"
+  return 0
+}
+
+dc__scaffold() {
+  local name="" force=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force) force=1; shift ;;
+      --*)     log_error "scaffold: 不明な引数: $1"; return 1 ;;
+      *)       name="$1"; shift ;;
+    esac
+  done
+  [[ -n "$name" ]] || { log_error "scaffold: <name> は必須"; return 1; }
+
+  local dir; dir="$(docker_project_dir "$name")"
+  [[ -d "$dir" ]] || { log_error "プロジェクトが見つかりません: $dir"; return 1; }
+
+  if docker_has_compose "$dir" && (( force == 0 )); then
+    log_warn "既に compose が存在します: $(docker_find_compose "$dir") — scaffold をスキップ (--force で再生成)"
+    return 0
+  fi
+
+  local stack; stack="$(docker_detect_stack "$dir")"
+  log_info "🧱 scaffold: $name (stack=$stack) → $dir/docker/"
+
+  case "$stack" in
+    fullstack) _scaffold_fullstack "$dir" "$force" ;;
+    node)      _scaffold_node "$dir" "$force" ;;
+    python)    _scaffold_python "$dir" "$force" ;;
+    static)    _scaffold_static "$dir" "$force" ;;
+    *)
+      log_warn "stack=$stack の雛形は未対応です。汎用 compose のみ生成します"
+      _scaffold_generic "$dir" "$force" ;;
+  esac
+
+  log_info "  生成物を確認し、ポート/環境変数/起動コマンドを調整してから register/up してください"
+}
+
+_scaffold_node() {
+  local dir="$1" force="$2"
+  _scaffold_write "$dir/docker/Dockerfile" "$force" <<'EOF' || true
+# syntax=docker/dockerfile:1
+# Node.js アプリ用 雛形 (調整前提)
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev || npm install --omit=dev
+COPY . .
+ENV NODE_ENV=production
+EXPOSE 3000
+# TODO: 実際の起動コマンドへ調整
+CMD ["node", "index.js"]
+EOF
+  _scaffold_write "$dir/docker/docker-compose.yml" "$force" <<'EOF' || true
+# Docker Compose 雛形 (調整前提) — context はプロジェクトルート
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "3000:3000"   # TODO: 実ポートへ
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped
+EOF
+}
+
+_scaffold_python() {
+  local dir="$1" force="$2"
+  _scaffold_write "$dir/docker/Dockerfile" "$force" <<'EOF' || true
+# syntax=docker/dockerfile:1
+# Python アプリ用 雛形 (調整前提)
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+# requirements.txt / pyproject.toml いずれにも対応 (どちらか存在する方を採用)
+RUN if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt; \
+    elif [ -f pyproject.toml ]; then pip install --no-cache-dir .; \
+    else echo "WARN: 依存定義なし (requirements.txt/pyproject.toml)"; fi
+EXPOSE 8000
+# TODO: 実際の起動コマンドへ調整 (uvicorn/gunicorn/flask 等)
+CMD ["python", "main.py"]
+EOF
+  _scaffold_write "$dir/docker/docker-compose.yml" "$force" <<'EOF' || true
+# Docker Compose 雛形 (調整前提) — context はプロジェクトルート
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8000:8000"   # TODO: 実ポートへ
+    restart: unless-stopped
+EOF
+}
+
+_scaffold_static() {
+  local dir="$1" force="$2"
+  _scaffold_write "$dir/docker/Dockerfile" "$force" <<'EOF' || true
+# syntax=docker/dockerfile:1
+# 静的サイト用 雛形 (nginx 配信)
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80
+EOF
+  _scaffold_write "$dir/docker/docker-compose.yml" "$force" <<'EOF' || true
+# Docker Compose 雛形 (静的サイト) — context はプロジェクトルート
+services:
+  web:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8080:80"   # TODO: 実ポートへ
+    restart: unless-stopped
+EOF
+}
+
+_scaffold_fullstack() {
+  local dir="$1" force="$2"
+  _scaffold_write "$dir/docker/Dockerfile.backend" "$force" <<'EOF' || true
+# syntax=docker/dockerfile:1
+# バックエンド (Python) 雛形 — context はプロジェクトルート
+FROM python:3.12-slim
+WORKDIR /app
+COPY backend/ .
+# requirements.txt / pyproject.toml いずれにも対応
+RUN if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt; \
+    elif [ -f pyproject.toml ]; then pip install --no-cache-dir .; \
+    else echo "WARN: 依存定義なし (requirements.txt/pyproject.toml)"; fi
+EXPOSE 8000
+# TODO: 実際の起動コマンドへ調整 (uvicorn/gunicorn/flask 等)
+CMD ["python", "main.py"]
+EOF
+  _scaffold_write "$dir/docker/Dockerfile.frontend" "$force" <<'EOF' || true
+# syntax=docker/dockerfile:1
+# フロントエンド 雛形 — context はプロジェクトルート
+# 2 ステージ構成: build (Node) → 配信 (nginx)。Vite/Vue/React を想定
+# --- build stage ---
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY frontend/package*.json ./
+RUN npm ci || npm install
+COPY frontend/ .
+# build script があればビルド (Vite=dist / CRA=build)。無ければ空 dist を用意して停止回避
+RUN npm run build || (echo "WARN: build script なし — 空 dist を生成"; mkdir -p dist)
+# --- serve stage ---
+FROM nginx:alpine
+# TODO: ビルド出力先が build/ の場合は /app/dist を /app/build に変更
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+# nginx はベースイメージのデフォルト CMD で起動するため CMD 不要
+EOF
+  _scaffold_write "$dir/docker/docker-compose.yml" "$force" <<'EOF' || true
+# Docker Compose 雛形 (フルスタック) — context はプロジェクトルート
+services:
+  backend:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.backend
+    ports:
+      - "8000:8000"   # TODO: 実ポートへ
+    restart: unless-stopped
+  frontend:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.frontend
+    ports:
+      - "3000:80"     # nginx(80) をホスト 3000 へ公開。TODO: 実ポートへ
+    depends_on:
+      - backend
+    restart: unless-stopped
+EOF
+}
+
+_scaffold_generic() {
+  local dir="$1" force="$2"
+  _scaffold_write "$dir/docker/docker-compose.yml" "$force" <<'EOF' || true
+# Docker Compose 雛形 (汎用) — stack 自動判定不可。手動で image/build を指定してください
+services:
+  app:
+    # build: { context: .., dockerfile: docker/Dockerfile }  # ビルドする場合
+    image: alpine:latest   # TODO: 実イメージ or build へ置換
+    command: ["sh", "-c", "echo 'edit docker/docker-compose.yml'; sleep infinity"]
+    restart: unless-stopped
+EOF
+}
+
+# ------------------------------------------------------------
+# help
+# ------------------------------------------------------------
+dc__help() {
+  cat <<'EOF'
+📦 docker-control.sh — 登録プロジェクトの Docker 統合制御
+
+  status                          Docker 可用性・compose・login 状態を診断
+  scan                            Projects 走査 (compose/stack/登録状況)
+  list                            台帳の登録プロジェクト一覧
+  register <name> [opts]          台帳へ登録   --compose REL / --no-autostart
+  register-all [--autostart]      compose 検出済み未登録を一括登録 (既存+今後新規)
+  unregister <name>               台帳から解除
+  up <name>                       compose up -d
+  down <name>                     compose down
+  ps <name>                       compose ps
+  logs <name> [args...]           compose logs (既定 --tail=100)
+  up-all                          autostart=true を一括起動
+  scaffold <name> [--force]       stack 検出で Dockerfile/compose 雛形生成
+  login-status                    login 検出のみ (未ログインは手動案内)
+  hub-images [namespace]          Docker Hub のリポジトリ一覧
+  hub-pull <image>                イメージ取得
+  help                            このヘルプ
+
+  ⚠️ docker のインストールと `docker login` は自動化しません。
+     未ログイン時は `! docker login` を手動実行してください。
+EOF
+}
+
+# ------------------------------------------------------------
+# dispatch
+# ------------------------------------------------------------
+main() {
+  case "${1:-help}" in
+    status)       dc__status ;;
+    scan)         dc__scan ;;
+    list)         dc__list ;;
+    register)     shift; dc__register "$@" ;;
+    register-all) shift; dc__register_all "$@" ;;
+    unregister)   shift; dc__unregister "$@" ;;
+    up)           shift; dc__up "$@" ;;
+    down)         shift; dc__down "$@" ;;
+    ps)           shift; dc__ps "$@" ;;
+    logs)         shift; dc__logs "$@" ;;
+    up-all)       dc__up_all ;;
+    scaffold)     shift; dc__scaffold "$@" ;;
+    login-status) dc__login_status ;;
+    hub-images)   shift; dc__hub_images "${1:-}" ;;
+    hub-pull)     shift; dc__hub_pull "${1:-}" ;;
+    help|-h|--help|"") dc__help ;;
+    *) log_error "不明なサブコマンド: $1"; dc__help; exit 1 ;;
+  esac
+}
+
+# 直接実行時のみ main を呼ぶ (source 時=テストでは呼ばない)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/bin/menu.sh
+++ b/bin/menu.sh
@@ -98,6 +98,11 @@ show_menu() {
   done
   printf '\n'
 
+  # Docker
+  printf '  %s🐳 Docker 統合%s\n' "$C_BLUE" "$C_RESET"
+  printf '   %s DK %s  📦  登録プロジェクトの Docker 制御 (状態/走査/台帳/起動・停止/Hub連携)\n' "$C_BG_DKBLUE" "$C_RESET"
+  printf '\n'
+
   # Cron
   printf '  %s⏰ Linux Cron 管理%s\n' "$C_YELLOW" "$C_RESET"
   printf '   %s 14 %s  📅  Cron スケジュール 登録・編集・削除 / 選んで一括BG起動\n' "$C_BG_DKBLUE" "$C_RESET"
@@ -136,6 +141,46 @@ launch_claude() {
   run_menu_script "$BIN/start-claude.sh" --project "$project" "--$mode"
 }
 
+# DK: Docker 統合サブメニュー (docker-control.sh への薄い対話ラッパ)
+docker_submenu() {
+  local dc="$BIN/docker-control.sh"
+  if [[ ! -f "$dc" ]]; then log_warn "docker-control.sh が見つかりません"; sleep 1; return 0; fi
+  while true; do
+    printf '\n  %s🐳 Docker 統合制御%s\n' "$C_CYAN" "$C_RESET"
+    printf '   %s 1 %s  📊 状態 (status: daemon/compose/login)\n' "$C_BG_DKBLUE" "$C_RESET"
+    printf '   %s 2 %s  🔍 走査 (scan: Projects の compose/stack/登録状況)\n' "$C_BG_DKBLUE" "$C_RESET"
+    printf '   %s 3 %s  📒 台帳一覧 (list)\n' "$C_BG_DKBLUE" "$C_RESET"
+    printf '   %s 4 %s  ➕ 未登録を一括登録 (register-all)\n' "$C_BG_GREEN" "$C_RESET"
+    printf '   %s 5 %s  🚀 起動 (up <name>)\n' "$C_BG_GREEN" "$C_RESET"
+    printf '   %s 6 %s  🛑 停止 (down <name>)\n' "$C_BG_YELLOW" "$C_RESET"
+    printf '   %s 7 %s  🚀 autostart 一括起動 (up-all)\n' "$C_BG_GREEN" "$C_RESET"
+    printf '   %s 8 %s  🧱 雛形生成 (scaffold <name>)\n' "$C_BG_DKBLUE" "$C_RESET"
+    printf '   %s 9 %s  🔐 login 状態 (login-status: 未ログインは手動案内)\n' "$C_BG_DKBLUE" "$C_RESET"
+    printf '   %s10 %s  ☁️  Hub イメージ一覧 (hub-images)\n' "$C_BG_DKBLUE" "$C_RESET"
+    printf '    0  ⬅️  戻る\n'
+    local c; read -rp "  番号を入力してください: " c
+    case "$c" in
+      1) bash "$dc" status || true ;;
+      2) bash "$dc" scan || true ;;
+      3) bash "$dc" list || true ;;
+      4) bash "$dc" register-all || true ;;
+      5) bash "$dc" list || true; local n; read -rp "  起動するプロジェクト名: " n
+         [[ -n "$n" ]] && { bash "$dc" up "$n" || true; } ;;
+      6) bash "$dc" list || true; local n; read -rp "  停止するプロジェクト名: " n
+         [[ -n "$n" ]] && { bash "$dc" down "$n" || true; } ;;
+      7) bash "$dc" up-all || true ;;
+      8) local n; read -rp "  雛形生成するプロジェクト名: " n
+         [[ -n "$n" ]] && { bash "$dc" scaffold "$n" || true; } ;;
+      9) bash "$dc" login-status || true ;;
+      10) local ns; read -rp "  namespace (空欄=ログインユーザー): " ns
+          bash "$dc" hub-images ${ns:+"$ns"} || true ;;
+      0) return 0 ;;
+      *) printf '%s  無効な入力です。%s\n' "$C_RED" "$C_RESET"; sleep 1; continue ;;
+    esac
+    read -rp "  Enter で戻る " _ || true
+  done
+}
+
 menu_loop() {
   while true; do
     show_menu
@@ -156,6 +201,7 @@ menu_loop() {
       11) run_menu_script "$LIBEXEC/diag-architecture.sh" ;;
       12) run_menu_script "$BIN/set-statusline.sh" ;;
       13) run_menu_script "$LIBEXEC/watch-claude-log.sh" ;;
+      DK) docker_submenu ;;
       14) run_menu_script "$BIN/cron-schedule.sh" ;;
       15) bash "$LIBEXEC/watch-session.sh" || true ;;   # 内部に 0=戻る の対話メニューを持つため直接実行
       MO) bash "$BIN/monitor-sessions.sh" open || true ;;  # claudeos-monitor へ attach (Ctrl-b d / q で戻る)

--- a/config/docker-registry.json
+++ b/config/docker-registry.json
@@ -1,0 +1,119 @@
+{
+  "_comment": "Docker 管理対象プロジェクト台帳。docker-control.sh が読み書きする。compose=primary compose 相対パス, autostart=メニュー/cron 一括起動の対象, stack=検出スタック。",
+  "projects": {
+    "ArcSphere3D": {
+      "compose": "docker/docker-compose.yml",
+      "autostart": false,
+      "stack": "fullstack",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Civil-Construction-IMS": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "node",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Civil-Draw": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "node",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Civil-ITSM-Support": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "fullstack",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "CivilPDF-DX": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "unknown",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Construction-DX-OS": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "python",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Construction-DX-OnePlatform": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "fullstack",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Construction-Enterprise-OS": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "node",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Construction-LegalOps-DX": {
+      "compose": "infra/docker/docker-compose.yml",
+      "autostart": false,
+      "stack": "fullstack",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Enterprise-AI-HelpDesk-System": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "fullstack",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "IT-BCP-ITSCM-System": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "fullstack",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "ITSM-Management": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "fullstack",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Open-BIM-Information-Platform": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "fullstack",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "PC-Ops-Orchestrator": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "unknown",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Remote-Service-Platform": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "unknown",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "ServiceHub-Construction-Platform": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "fullstack",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Synapse-OS": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "node",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Weather-Marine-Construction-Decision-Support-System": {
+      "compose": "docker-compose.yml",
+      "autostart": false,
+      "stack": "python",
+      "registered_at": "2026-06-04T13:58:23+09:00"
+    },
+    "Windows-Deploy-Management-System": {
+      "compose": "docker/docker-compose.yml",
+      "autostart": false,
+      "stack": "fullstack",
+      "registered_at": "2026-06-04T13:59:27+09:00"
+    }
+  }
+}

--- a/lib/docker-manager.sh
+++ b/lib/docker-manager.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# ============================================================
+# docker-manager.sh — 登録プロジェクトの Docker 統合管理 (Linux native)
+#
+# 役割: /home/kensan/Projects 配下の登録プロジェクトに対し、
+#   - Docker 資産 (compose / Dockerfile) の検出
+#   - Docker からのサービス起動/停止/状態/ログ
+#   - 管理対象プロジェクトの台帳 (config/docker-registry.json) 管理
+#   - スタック検出ベースの雛形 (Dockerfile/compose) 生成
+#   - 同一アカウントの Docker Hub 連携 (イメージ一覧・pull)
+#   を提供する。
+#
+# 設計方針 (厳守):
+#   - docker login は「検出のみ」。本ライブラリは決してログインを自動化しない。
+#     認証が必要な場合は呼び出し側がユーザーへ `docker login` の手動実行を促す。
+#   - docker のインストールも自動実行しない (冪等な存在確認のみ)。
+#
+# 前提: common.sh / json.sh / config-loader.sh を source。
+#       docker CLI は実行エントリ側で存在確認すること
+#       (このライブラリは source 時に exit しない方針 = set -e なし)。
+# ============================================================
+
+[[ -n "${_CCSU_DOCKER_LOADED:-}" ]] && return 0
+_CCSU_DOCKER_LOADED=1
+
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/json.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/config-loader.sh"
+
+# --- 台帳パス (テスト時は CCSU_DOCKER_REGISTRY で差し替え) ---
+DOCKER_REGISTRY_PATH="${CCSU_DOCKER_REGISTRY:-$CCSU_ROOT/config/docker-registry.json}"
+
+# ------------------------------------------------------------
+# Docker 可用性
+# ------------------------------------------------------------
+# docker_cli_present — docker バイナリが PATH にあれば 0
+docker_cli_present() { has_cmd docker; }
+
+# docker_daemon_up — デーモンに到達できれば 0 (docker info が成功)
+docker_daemon_up() { docker info >/dev/null 2>&1; }
+
+# docker_available — CLI 在 + デーモン到達の両方を満たせば 0
+docker_available() { docker_cli_present && docker_daemon_up; }
+
+# docker_version — クライアントバージョン (取得不可なら空)
+docker_version() { docker_cli_present || return 0; docker version --format '{{.Server.Version}}' 2>/dev/null || true; }
+
+# ------------------------------------------------------------
+# compose コマンド解決 (v2 プラグイン優先 / v1 standalone フォールバック)
+#   echo: "docker compose" | "docker-compose" | "" (いずれも無し)
+# ------------------------------------------------------------
+docker_compose_cmd() {
+  if docker_cli_present && docker compose version >/dev/null 2>&1; then
+    printf 'docker compose'
+  elif has_cmd docker-compose; then
+    printf 'docker-compose'
+  else
+    printf ''
+  fi
+}
+
+# ------------------------------------------------------------
+# login 状態の検出 (DETECT ONLY — 決してログインしない)
+# ------------------------------------------------------------
+# docker_config_json — ~/.docker/config.json のパス
+docker_config_json() { printf '%s' "${DOCKER_CONFIG:-$HOME/.docker}/config.json"; }
+
+# docker_logged_in — auths に 1 件以上の登録があれば 0 (= 何らかの registry にログイン済み)
+docker_logged_in() {
+  local cfg; cfg="$(docker_config_json)"
+  [[ -f "$cfg" ]] || return 1
+  local n; n="$(jq -r '(.auths // {}) | length' "$cfg" 2>/dev/null || echo 0)"
+  [[ "${n:-0}" -gt 0 ]]
+}
+
+# docker_hub_user — Docker Hub のユーザー名を可能な範囲で推定 (検出のみ)
+#   優先: 環境変数 DOCKER_HUB_USER → config.json auths の docker.io 由来 → docker info
+docker_hub_user() {
+  if [[ -n "${DOCKER_HUB_USER:-}" ]]; then printf '%s' "$DOCKER_HUB_USER"; return 0; fi
+  local cfg; cfg="$(docker_config_json)"
+  if [[ -f "$cfg" ]]; then
+    local u
+    u="$(jq -r '(.auths // {}) | keys[] | select(test("docker.io|index.docker.io"))' "$cfg" 2>/dev/null | head -1 || true)"
+    # auths のキーは registry ホストなのでユーザー名そのものは入らない。
+    # ユーザー名は info の Username に出ることがある。
+  fi
+  docker_cli_present || { printf ''; return 0; }
+  docker info 2>/dev/null | sed -n 's/^ *Username: *//p' | head -1
+}
+
+# ------------------------------------------------------------
+# compose ファイル検出
+#   探索順 (primary = 最初に見つかった接尾辞なしの基本ファイル):
+#     1. <dir>/docker-compose.yml | .yaml
+#     2. <dir>/compose.yml | .yaml
+#     3. <dir>/docker/docker-compose.yml | .yaml
+#     4. <dir>/infra/docker/docker-compose.yml | .yaml
+#     5. <dir>/deploy/docker-compose.yml | .yaml
+#   echo: プロジェクトルートからの相対パス (見つからなければ空・exit 0)
+# ------------------------------------------------------------
+docker_find_compose() {
+  local dir="$1"
+  [[ -d "$dir" ]] || return 0
+  local sub f
+  for sub in '.' 'docker' 'infra/docker' 'deploy'; do
+    for f in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
+      local rel
+      if [[ "$sub" == '.' ]]; then rel="$f"; else rel="$sub/$f"; fi
+      if [[ -f "$dir/$rel" ]]; then printf '%s' "$rel"; return 0; fi
+    done
+  done
+  printf ''
+}
+
+# docker_has_compose <dir> — compose を持てば 0
+docker_has_compose() { [[ -n "$(docker_find_compose "$1")" ]]; }
+
+# docker_project_dir <name> — 登録プロジェクトの絶対パス
+docker_project_dir() { printf '%s/%s' "$(config_projects_dir)" "$1"; }
+
+# docker_project_compose <name> — 登録プロジェクト名から primary compose 相対パスを得る
+docker_project_compose() { docker_find_compose "$(docker_project_dir "$1")"; }
+
+# ------------------------------------------------------------
+# スタック検出 (雛形生成の入力)
+#   echo: node | python | fullstack | go | rust | dotnet | java-maven |
+#         java-gradle | php | ruby | static | unknown
+#   fullstack = backend(python) + frontend(node) の典型構成
+# ------------------------------------------------------------
+docker_detect_stack() {
+  local dir="$1"
+  [[ -d "$dir" ]] || { printf 'unknown'; return 0; }
+  local has_node=0 has_py=0
+  [[ -f "$dir/package.json" || -f "$dir/frontend/package.json" || -f "$dir/web/package.json" ]] && has_node=1
+  [[ -f "$dir/requirements.txt" || -f "$dir/pyproject.toml" || -f "$dir/backend/requirements.txt" || -f "$dir/backend/pyproject.toml" ]] && has_py=1
+
+  if (( has_node == 1 && has_py == 1 )); then printf 'fullstack'; return 0; fi
+  if (( has_py == 1 )); then printf 'python'; return 0; fi
+  if (( has_node == 1 )); then printf 'node'; return 0; fi
+
+  if [[ -f "$dir/go.mod" ]]; then printf 'go'; return 0; fi
+  if [[ -f "$dir/Cargo.toml" ]]; then printf 'rust'; return 0; fi
+  if compgen -G "$dir/*.csproj" >/dev/null 2>&1 || compgen -G "$dir/*.sln" >/dev/null 2>&1; then printf 'dotnet'; return 0; fi
+  if [[ -f "$dir/pom.xml" ]]; then printf 'java-maven'; return 0; fi
+  if [[ -f "$dir/build.gradle" || -f "$dir/build.gradle.kts" ]]; then printf 'java-gradle'; return 0; fi
+  if [[ -f "$dir/composer.json" ]]; then printf 'php'; return 0; fi
+  if [[ -f "$dir/Gemfile" ]]; then printf 'ruby'; return 0; fi
+  if [[ -f "$dir/index.html" ]]; then printf 'static'; return 0; fi
+  printf 'unknown'
+}
+
+# ------------------------------------------------------------
+# 台帳 (config/docker-registry.json) CRUD
+#   形: { "_comment": "...", "projects": { "<name>": {compose, autostart, stack, registered_at} } }
+# ------------------------------------------------------------
+# docker_registry_ensure — 不在ならスケルトンを生成
+docker_registry_ensure() {
+  [[ -f "$DOCKER_REGISTRY_PATH" ]] && return 0
+  json_set "$DOCKER_REGISTRY_PATH" \
+    '{_comment: $c, projects: {}}' \
+    --arg c "Docker 管理対象プロジェクト台帳。docker-control.sh が読み書きする。compose=primary compose 相対パス, autostart=メニュー/cron 一括起動の対象, stack=検出スタック。"
+}
+
+# docker_registry_projects — 登録済みプロジェクト名 (1 行 1 件・名前順)
+docker_registry_projects() {
+  [[ -f "$DOCKER_REGISTRY_PATH" ]] || return 0
+  jq -r '(.projects // {}) | keys[]' "$DOCKER_REGISTRY_PATH" 2>/dev/null | sort || true
+}
+
+# docker_registry_has <name> — 登録済みなら 0
+docker_registry_has() {
+  [[ -f "$DOCKER_REGISTRY_PATH" ]] || return 1
+  local v; v="$(jq -r --arg n "$1" '(.projects // {}) | has($n)' "$DOCKER_REGISTRY_PATH" 2>/dev/null || echo false)"
+  [[ "$v" == "true" ]]
+}
+
+# docker_registry_get <name> <field> [default] — 単一フィールド取得
+docker_registry_get() {
+  local name="$1" field="$2" default="${3:-}"
+  json_get "$DOCKER_REGISTRY_PATH" ".projects[\"$name\"].$field" "$default"
+}
+
+# docker_registry_register <name> [compose_rel] [autostart_bool]
+#   compose_rel 省略時は自動検出。autostart 省略時は true。
+docker_registry_register() {
+  local name="$1" compose="${2:-}" autostart="${3:-true}"
+  [[ -n "$name" ]] || { log_warn "register: プロジェクト名が空です"; return 1; }
+  local dir; dir="$(docker_project_dir "$name")"
+  [[ -d "$dir" ]] || { log_warn "register: プロジェクトが見つかりません: $dir"; return 1; }
+  [[ -z "$compose" ]] && compose="$(docker_find_compose "$dir")"
+  local stack; stack="$(docker_detect_stack "$dir")"
+  local now; now="$(date -Iseconds)"
+  docker_registry_ensure
+  json_set "$DOCKER_REGISTRY_PATH" \
+    '.projects[$n] = {compose: $c, autostart: ($a == "true"), stack: $s, registered_at: $t}' \
+    --arg n "$name" --arg c "$compose" --arg a "$autostart" --arg s "$stack" --arg t "$now"
+}
+
+# docker_registry_unregister <name>
+docker_registry_unregister() {
+  local name="$1"
+  [[ -f "$DOCKER_REGISTRY_PATH" ]] || return 0
+  json_set "$DOCKER_REGISTRY_PATH" 'del(.projects[$n])' --arg n "$name"
+}
+
+# docker_registry_autostart_list — autostart=true のプロジェクト名
+docker_registry_autostart_list() {
+  [[ -f "$DOCKER_REGISTRY_PATH" ]] || return 0
+  jq -r '(.projects // {}) | to_entries[] | select(.value.autostart == true) | .key' \
+    "$DOCKER_REGISTRY_PATH" 2>/dev/null | sort || true
+}
+
+# ------------------------------------------------------------
+# サービス制御 (compose 経由)
+#   各関数は compose ファイルの相対パスを台帳 or 自動検出で解決し、
+#   プロジェクトディレクトリを作業基準として compose を実行する。
+# ------------------------------------------------------------
+# _docker_resolve_compose <name> — 台帳の compose を優先、無ければ自動検出。echo: 相対パス
+_docker_resolve_compose() {
+  local name="$1" rel
+  rel="$(docker_registry_get "$name" 'compose' '')"
+  [[ -z "$rel" || "$rel" == "null" ]] && rel="$(docker_project_compose "$name")"
+  printf '%s' "$rel"
+}
+
+# _docker_compose_exec <name> <compose-subcmd...> — 解決済み compose で実行
+_docker_compose_exec() {
+  local name="$1"; shift
+  local dir; dir="$(docker_project_dir "$name")"
+  [[ -d "$dir" ]] || { log_error "プロジェクトが見つかりません: $dir"; return 1; }
+  local rel; rel="$(_docker_resolve_compose "$name")"
+  [[ -n "$rel" ]] || { log_error "compose ファイルが見つかりません: $name"; return 1; }
+  [[ -f "$dir/$rel" ]] || { log_error "compose ファイルが存在しません: $dir/$rel"; return 1; }
+  local cc; cc="$(docker_compose_cmd)"
+  [[ -n "$cc" ]] || { log_error "docker compose が利用できません"; return 1; }
+  # shellcheck disable=SC2086  # cc は "docker compose" の 2 語を意図的に分割
+  ( cd "$dir" && $cc -f "$rel" -p "$(ccsu_safe_name "$name")" "$@" )
+}
+
+# docker_up <name> [extra args] — サービス起動 (-d デタッチ既定)
+docker_up()   { local n="$1"; shift; _docker_compose_exec "$n" up -d "$@"; }
+# docker_down <name> [extra args] — 停止
+docker_down() { local n="$1"; shift; _docker_compose_exec "$n" down "$@"; }
+# docker_ps <name> — 状態
+docker_ps()   { _docker_compose_exec "$1" ps; }
+# docker_logs <name> [args] — ログ (既定 --tail 100)
+docker_logs() { local n="$1"; shift; _docker_compose_exec "$n" logs "${@:---tail=100}"; }
+
+# ------------------------------------------------------------
+# Docker Hub 連携 (同一アカウント)
+#   公開リポジトリは無認証で列挙可能 (manual-login 制約に抵触しない)。
+#   private を含めたい場合のみ任意の PAT を DOCKER_HUB_TOKEN で渡す。
+# ------------------------------------------------------------
+# docker_hub_list_images [namespace] — 指定 (or 推定) アカウントのリポジトリ名一覧
+docker_hub_list_images() {
+  local ns="${1:-$(docker_hub_user)}"
+  [[ -n "$ns" ]] || { log_error "Docker Hub ユーザーを特定できません (DOCKER_HUB_USER で指定可)"; return 1; }
+  has_cmd curl || { log_error "curl が必要です"; return 1; }
+  local url="https://hub.docker.com/v2/repositories/${ns}/?page_size=100"
+  local auth=()
+  [[ -n "${DOCKER_HUB_TOKEN:-}" ]] && auth=(-H "Authorization: Bearer ${DOCKER_HUB_TOKEN}")
+  local resp
+  resp="$(curl -fsSL "${auth[@]}" "$url" 2>/dev/null || true)"
+  [[ -n "$resp" ]] || { log_error "Docker Hub API へ到達できません: $url"; return 1; }
+  printf '%s' "$resp" | jq -r --arg ns "$ns" '
+    (.results // [])[] | "\($ns)/\(.name)\t\(.pull_count // 0)\t\(if .is_private then "private" else "public" end)"
+  ' 2>/dev/null || { log_error "Docker Hub 応答の解析に失敗しました"; return 1; }
+}
+
+# docker_hub_pull <image> — イメージ取得 (private で失敗したら手動 login を促すのは呼び出し側)
+docker_hub_pull() {
+  local image="$1"
+  [[ -n "$image" ]] || { log_error "イメージ名が空です"; return 1; }
+  docker_cli_present || { log_error "docker CLI が見つかりません"; return 1; }
+  docker pull "$image"
+}
+
+# docker_local_images [namespace] — ローカル取得済みイメージ (namespace で絞り込み可)
+docker_local_images() {
+  docker_cli_present || return 0
+  local ns="${1:-}"
+  if [[ -n "$ns" ]]; then
+    docker images --format '{{.Repository}}:{{.Tag}}\t{{.Size}}' 2>/dev/null | grep -E "^${ns}/" || true
+  else
+    docker images --format '{{.Repository}}:{{.Tag}}\t{{.Size}}' 2>/dev/null || true
+  fi
+}

--- a/tests/bats/unit/docker-manager.bats
+++ b/tests/bats/unit/docker-manager.bats
@@ -1,0 +1,299 @@
+#!/usr/bin/env bats
+# ============================================================
+# docker-manager.bats — lib/docker-manager.sh のユニットテスト
+#
+# 範囲: daemon 非依存の純関数のみ検証する。
+#   - compose 検出 (docker_find_compose / docker_has_compose)
+#   - スタック検出 (docker_detect_stack)
+#   - 台帳 CRUD (docker_registry_*)
+#   - login 状態の検出 (docker_logged_in / docker_hub_user) ※DETECT ONLY
+#
+# 除外: docker info / compose 実行 (up/down/ps/logs)・Hub API は
+#       daemon / ネットワーク依存のため対象外。
+#
+# 設計上の注意:
+#   - CCSU_DOCKER_REGISTRY と AI_STARTUP_CONFIG_PATH は source 前に export する
+#     (DOCKER_REGISTRY_PATH / CCSU_CONFIG_PATH は読み込み時に確定するため)。
+#   - autostart=false は jq の `false // empty` 罠で json_get が空になるため、
+#     真偽の検証は docker_registry_autostart_list (select で厳密比較) で行う。
+# ============================================================
+
+load '../helpers/common-setup'
+
+setup() {
+  _bats_common_setup
+
+  # config: linuxBase を一時 projects ディレクトリに向ける
+  export AI_STARTUP_CONFIG_PATH="$TEST_TEMP/config.json"
+  printf '{ "linuxBase": "%s" }\n' "$TEST_TEMP/projects" > "$AI_STARTUP_CONFIG_PATH"
+  mkdir -p "$TEST_TEMP/projects"
+
+  # 台帳: 一時パスへ差し替え
+  export CCSU_DOCKER_REGISTRY="$TEST_TEMP/docker-registry.json"
+
+  # docker config: 既定で「未ログイン」を保証 (存在しないパス)
+  export DOCKER_CONFIG="$TEST_TEMP/dockercfg"
+
+  source "$REPO_ROOT/lib/docker-manager.sh"
+}
+teardown() { _bats_common_teardown; }
+
+# --- ヘルパ: 一時プロジェクトを作る ---
+_mkproj() { mkdir -p "$TEST_TEMP/projects/$1"; }
+
+# ============================================================
+# docker_find_compose / docker_has_compose
+# ============================================================
+
+@test "docker_find_compose: ルートの docker-compose.yml を検出" {
+  _mkproj Root
+  touch "$TEST_TEMP/projects/Root/docker-compose.yml"
+  run docker_find_compose "$TEST_TEMP/projects/Root"
+  [ "$status" -eq 0 ]
+  [ "$output" = "docker-compose.yml" ]
+}
+
+@test "docker_find_compose: docker/ サブディレクトリを検出" {
+  _mkproj Sub
+  mkdir -p "$TEST_TEMP/projects/Sub/docker"
+  touch "$TEST_TEMP/projects/Sub/docker/docker-compose.yml"
+  run docker_find_compose "$TEST_TEMP/projects/Sub"
+  [ "$output" = "docker/docker-compose.yml" ]
+}
+
+@test "docker_find_compose: ルートがサブディレクトリより優先" {
+  _mkproj Pri
+  mkdir -p "$TEST_TEMP/projects/Pri/docker"
+  touch "$TEST_TEMP/projects/Pri/compose.yml"
+  touch "$TEST_TEMP/projects/Pri/docker/docker-compose.yml"
+  run docker_find_compose "$TEST_TEMP/projects/Pri"
+  [ "$output" = "compose.yml" ]
+}
+
+@test "docker_find_compose: 同一ディレクトリでは docker-compose.yml が compose.yml より優先" {
+  _mkproj Ord
+  touch "$TEST_TEMP/projects/Ord/compose.yml"
+  touch "$TEST_TEMP/projects/Ord/docker-compose.yml"
+  run docker_find_compose "$TEST_TEMP/projects/Ord"
+  [ "$output" = "docker-compose.yml" ]
+}
+
+@test "docker_find_compose: infra/docker と deploy も探索する" {
+  _mkproj Infra
+  mkdir -p "$TEST_TEMP/projects/Infra/infra/docker"
+  touch "$TEST_TEMP/projects/Infra/infra/docker/compose.yaml"
+  run docker_find_compose "$TEST_TEMP/projects/Infra"
+  [ "$output" = "infra/docker/compose.yaml" ]
+
+  _mkproj Dep
+  mkdir -p "$TEST_TEMP/projects/Dep/deploy"
+  touch "$TEST_TEMP/projects/Dep/deploy/docker-compose.yaml"
+  run docker_find_compose "$TEST_TEMP/projects/Dep"
+  [ "$output" = "deploy/docker-compose.yaml" ]
+}
+
+@test "docker_find_compose: compose なしは空・exit 0" {
+  _mkproj Empty
+  run docker_find_compose "$TEST_TEMP/projects/Empty"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "docker_find_compose: 存在しないディレクトリは空・exit 0" {
+  run docker_find_compose "$TEST_TEMP/projects/NoSuchDir"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "docker_has_compose: 有無で 0/非0 を返す" {
+  _mkproj Has
+  touch "$TEST_TEMP/projects/Has/docker-compose.yml"
+  run docker_has_compose "$TEST_TEMP/projects/Has"
+  [ "$status" -eq 0 ]
+
+  _mkproj Hasnt
+  run docker_has_compose "$TEST_TEMP/projects/Hasnt"
+  [ "$status" -ne 0 ]
+}
+
+# ============================================================
+# docker_detect_stack
+# ============================================================
+
+@test "docker_detect_stack: node (package.json)" {
+  _mkproj N
+  touch "$TEST_TEMP/projects/N/package.json"
+  run docker_detect_stack "$TEST_TEMP/projects/N"
+  [ "$output" = "node" ]
+}
+
+@test "docker_detect_stack: python (requirements.txt)" {
+  _mkproj P
+  touch "$TEST_TEMP/projects/P/requirements.txt"
+  run docker_detect_stack "$TEST_TEMP/projects/P"
+  [ "$output" = "python" ]
+}
+
+@test "docker_detect_stack: python (pyproject.toml)" {
+  _mkproj Pp
+  touch "$TEST_TEMP/projects/Pp/pyproject.toml"
+  run docker_detect_stack "$TEST_TEMP/projects/Pp"
+  [ "$output" = "python" ]
+}
+
+@test "docker_detect_stack: fullstack (frontend node + backend python)" {
+  _mkproj F
+  mkdir -p "$TEST_TEMP/projects/F/frontend" "$TEST_TEMP/projects/F/backend"
+  touch "$TEST_TEMP/projects/F/frontend/package.json"
+  touch "$TEST_TEMP/projects/F/backend/requirements.txt"
+  run docker_detect_stack "$TEST_TEMP/projects/F"
+  [ "$output" = "fullstack" ]
+}
+
+@test "docker_detect_stack: go (go.mod)" {
+  _mkproj G
+  touch "$TEST_TEMP/projects/G/go.mod"
+  run docker_detect_stack "$TEST_TEMP/projects/G"
+  [ "$output" = "go" ]
+}
+
+@test "docker_detect_stack: rust (Cargo.toml)" {
+  _mkproj R
+  touch "$TEST_TEMP/projects/R/Cargo.toml"
+  run docker_detect_stack "$TEST_TEMP/projects/R"
+  [ "$output" = "rust" ]
+}
+
+@test "docker_detect_stack: static (index.html のみ)" {
+  _mkproj S
+  touch "$TEST_TEMP/projects/S/index.html"
+  run docker_detect_stack "$TEST_TEMP/projects/S"
+  [ "$output" = "static" ]
+}
+
+@test "docker_detect_stack: 何もなければ unknown" {
+  _mkproj U
+  run docker_detect_stack "$TEST_TEMP/projects/U"
+  [ "$output" = "unknown" ]
+}
+
+@test "docker_detect_stack: 存在しないディレクトリは unknown・exit 0" {
+  run docker_detect_stack "$TEST_TEMP/projects/Ghost"
+  [ "$status" -eq 0 ]
+  [ "$output" = "unknown" ]
+}
+
+# ============================================================
+# 台帳 CRUD (docker_registry_*)
+# ============================================================
+
+@test "docker_registry_ensure: スケルトンを生成 (_comment + 空 projects)" {
+  run docker_registry_ensure
+  [ "$status" -eq 0 ]
+  [ -f "$CCSU_DOCKER_REGISTRY" ]
+  run jq -r '._comment' "$CCSU_DOCKER_REGISTRY"
+  [[ "$output" == *"台帳"* ]]
+  run jq -r '.projects | length' "$CCSU_DOCKER_REGISTRY"
+  [ "$output" = "0" ]
+}
+
+@test "docker_registry_has: 登録前は非0" {
+  docker_registry_ensure
+  run docker_registry_has Alpha
+  [ "$status" -ne 0 ]
+}
+
+@test "docker_registry_register: 登録後に has=0 + フィールド取得" {
+  _mkproj Alpha
+  touch "$TEST_TEMP/projects/Alpha/package.json"
+  touch "$TEST_TEMP/projects/Alpha/docker-compose.yml"
+  run docker_registry_register Alpha
+  [ "$status" -eq 0 ]
+
+  run docker_registry_has Alpha
+  [ "$status" -eq 0 ]
+
+  run docker_registry_get Alpha compose
+  [ "$output" = "docker-compose.yml" ]
+
+  run docker_registry_get Alpha stack
+  [ "$output" = "node" ]
+}
+
+@test "docker_registry_register: 存在しないプロジェクトは失敗 (非0)" {
+  run docker_registry_register Ghost
+  [ "$status" -ne 0 ]
+}
+
+@test "docker_registry_get: 未登録フィールドは既定値を返す" {
+  docker_registry_ensure
+  run docker_registry_get Missing stack NOPE
+  [ "$output" = "NOPE" ]
+}
+
+@test "docker_registry_projects: 名前順で列挙" {
+  _mkproj Bravo; _mkproj Alpha; _mkproj Charlie
+  docker_registry_register Bravo '' false
+  docker_registry_register Alpha '' false
+  docker_registry_register Charlie '' false
+  run docker_registry_projects
+  [ "${lines[0]}" = "Alpha" ]
+  [ "${lines[1]}" = "Bravo" ]
+  [ "${lines[2]}" = "Charlie" ]
+}
+
+@test "docker_registry_autostart_list: autostart=true のみ抽出" {
+  _mkproj OnA; _mkproj OffB
+  docker_registry_register OnA '' true
+  docker_registry_register OffB '' false
+  run docker_registry_autostart_list
+  [[ "$output" == *"OnA"* ]]
+  [[ "$output" != *"OffB"* ]]
+}
+
+@test "docker_registry_register: autostart 省略時は既定 true" {
+  _mkproj DefA
+  docker_registry_register DefA
+  run docker_registry_autostart_list
+  [[ "$output" == *"DefA"* ]]
+}
+
+@test "docker_registry_unregister: 削除後に has=非0" {
+  _mkproj Del
+  docker_registry_register Del '' false
+  run docker_registry_has Del
+  [ "$status" -eq 0 ]
+
+  docker_registry_unregister Del
+  run docker_registry_has Del
+  [ "$status" -ne 0 ]
+}
+
+# ============================================================
+# login 状態の検出 (DETECT ONLY — 決してログインしない)
+# ============================================================
+
+@test "docker_logged_in: config なしは非0 (未ログイン)" {
+  run docker_logged_in
+  [ "$status" -ne 0 ]
+}
+
+@test "docker_logged_in: auths に登録があれば 0 (ログイン済み)" {
+  mkdir -p "$DOCKER_CONFIG"
+  printf '{ "auths": { "https://index.docker.io/v1/": { "auth": "x" } } }\n' \
+    > "$DOCKER_CONFIG/config.json"
+  run docker_logged_in
+  [ "$status" -eq 0 ]
+}
+
+@test "docker_logged_in: auths が空配列なら非0" {
+  mkdir -p "$DOCKER_CONFIG"
+  printf '{ "auths": {} }\n' > "$DOCKER_CONFIG/config.json"
+  run docker_logged_in
+  [ "$status" -ne 0 ]
+}
+
+@test "docker_hub_user: DOCKER_HUB_USER 環境変数を優先" {
+  DOCKER_HUB_USER=myhubuser run docker_hub_user
+  [ "$output" = "myhubuser" ]
+}


### PR DESCRIPTION
## 📌 概要

登録プロジェクトの **Docker 統合管理** 機能を新設。compose 検出・スタック判定・台帳 CRUD・サービス制御・Docker Hub 連携を bash ネイティブで実装。

> ⚠️ **セキュリティ設計原則**: docker login の自動化・インストールの自動化は一切行わない。login 状態の「検出のみ」。ユーザーが手動で `docker login` を実行する設計。

## 🔧 変更内容

| ファイル | 内容 |
|---|---|
| `lib/docker-manager.sh` (新規 288 行) | compose 検出 / スタック判定 / 台帳 CRUD / サービス制御 / Hub 連携 |
| `bin/docker-control.sh` (新規 555 行) | CLI エントリ (status/scan/list/register/register-all/up/down/up-all/scaffold/login-status/hub-images) |
| `config/docker-registry.json` (新規) | 登録プロジェクト台帳（初期登録済み） |
| `tests/bats/unit/docker-manager.bats` (新規 30 件) | daemon 非依存の純関数テスト |
| `bin/menu.sh` | `DK` メニュー追加（docker_submenu） |
| `.gitignore` | `config/*.lock`（flock 副産物）除外追記 |

## ✅ テスト結果

- **bats 232 件 / 0 failures** (docker-manager 30 件含む)
- **shellcheck error 0**
- **doc-version**: README=v3.4.8, agents=44 同期済み
- **state-example.js**: PASS

## 📊 主要設計ポイント

- `docker_find_compose`: `root → docker/ → infra/docker/ → deploy/` 優先順、同一ディレクトリでは `docker-compose.yml > compose.yml`
- `docker_detect_stack`: 12 スタック自動判定（fullstack = has_node + has_py の組合せ）
- `_scaffold_fullstack`: multi-stage Dockerfile.frontend（Node build stage → nginx:alpine serve stage）
- `CCSU_DOCKER_REGISTRY` env で台帳パスを差し替え可能（bats テスト用）
- `autostart=false` の jq `false // empty` 罠: `docker_registry_autostart_list` は `select(.value.autostart == true)` で厳密比較

## 🔍 影響範囲

- 新規ファイルのみ追加（既存機能への破壊的変更なし）
- `bin/menu.sh` に `DK` ケース追加（既存ケース群への影響なし）

## 📋 残課題

なし（全 CI ゲート通過済み）