### PR TITLE
fix(menu): タイトルバージョンを v3.3 → v3.4.8 に更新

### DIFF
--- a/bin/menu.sh
+++ b/bin/menu.sh
@@ -51,9 +51,9 @@ show_menu() {
   [[ "$deploy_ready" == "true" && $is_maint -eq 0 ]] && deploy_badge=" 🚀 デプロイ準備完了!"
 
   printf '\n'
-  printf '  %s╔══════════════════════════════════════════════════╗%s\n' "$C_CYAN" "$C_RESET"
-  printf '  %s║  🤖 ClaudeCode スタートアップツール v3.3 (Linux) ║%s\n' "$C_CYAN" "$C_RESET"
-  printf '  %s╚══════════════════════════════════════════════════╝%s\n' "$C_CYAN" "$C_RESET"
+  printf '  %s╔════════════════════════════════════════════════════╗%s\n' "$C_CYAN" "$C_RESET"
+  printf '  %s║  🤖 ClaudeCode スタートアップツール v3.4.8 (Linux) ║%s\n' "$C_CYAN" "$C_RESET"
+  printf '  %s╚════════════════════════════════════════════════════╝%s\n' "$C_CYAN" "$C_RESET"
   printf '  %s📋 フェーズ: %s%s%s%s\n' "$C_GRAY" "$C_RESET" "$phase_color" "$phase_label$deploy_badge" "$C_RESET"
   printf '  %s📂 %s%s%s\n' "$C_GREEN" "$C_DKGREEN" "$local_dir" "$C_RESET"
   printf '\n'


### PR DESCRIPTION
## 📌 概要

メニューヘッダーのバージョン表記が `v3.3` のままだったのを `v3.4.8` へ修正。ボックス幅も2列拡張して表示崩れを解消。

## ✅ 確認済み

- `bash bin/menu.sh --render` でボックス上下と中央行が揃うことを確認
- shellcheck / bats への影響なし（TUI 描画行のみ変更）