### PR TITLE
feat(workflows): dynamic workflows ブログ(Thariq/Sid)パターン取り込み — 4 workflow + SOT 配布 (#323)

### DIFF
--- a/.claude/workflows/gate-verification-sweep.js
+++ b/.claude/workflows/gate-verification-sweep.js
@@ -1,0 +1,264 @@
+// gate-verification-sweep — 検証チェックリスト全項目を「1項目=1検証」で並列スイープ
+// ---------------------------------------------------------------------------
+// 出典: dynamic workflows "Memory & Rule Adherence / rule-verifier" パターン
+//   (Thariq Shihipar & Sid Bidasaria, 2026-06-02
+//    "A harness for every task: dynamic workflows in Claude Code")
+//
+// 対象: Claude/templates/claudeos/docs/webui-full-verification-checklist.md (250項目)
+// 目的: webui-full-verification-checklist の Gate-1/2/3 を人手に頼らず並列検証し、
+//       CLAUDE.md §11 の終了報告「必須3区分」(実行した検証/未実行/未実行理由) を自動生成する。
+//
+// 使い方:
+//   /gate-verification-sweep                                   (gate-1 既定)
+//   args 例: { "gate": "gate-3", "skipConditions": ["no_mobile_support","no_PWA"],
+//              "batchSize": 8, "appUrl": "http://localhost:3737" }
+//
+//   gate     : "gate-1" | "gate-2" | "gate-3" | "all"  (既定 gate-1)
+//   batchSize: 1検証エージェントが担当する項目数        (既定 10。1 で完全 1:1)
+//   skipConditions: このプロジェクトで真の skip_if キーワード配列 (例 no_mobile_support)
+//   changedFilesHint: gate-2 用。変更ファイルパス配列 (近傍項目の判定に使用)
+//   appUrl   : E2E/Playwright 項目で叩く起動済み URL (無ければ E2E は not_run)
+//   checklistPath: チェックリストのパス上書き (既定: 自動探索)
+// ---------------------------------------------------------------------------
+
+export const meta = {
+  name: "gate-verification-sweep",
+  description: "検証チェックリスト全項目を1項目=1検証エージェントで並列スイープし、終了報告3区分(実行/未実行/未実行理由)を自動生成",
+  phases: [
+    { title: "Preflight",  detail: "共有の自動チェック(lint/build/typecheck/test/security)を1回だけ実行" },
+    { title: "Parse",      detail: "チェックリストを解析し Gate で対象項目を絞り込み" },
+    { title: "Verify",     detail: "項目バッチごとに検証エージェントが並列で実検証" },
+    { title: "Synthesize", detail: "終了報告3区分レポート + STABLE ゲート判定を生成" },
+  ],
+};
+
+// --- スキーマ定義 ----------------------------------------------------------
+
+const PREFLIGHT_SCHEMA = {
+  type: "object",
+  required: ["checks"],
+  properties: {
+    checks: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["name", "status", "summary"],
+        properties: {
+          name:    { type: "string" },                                   // lint/build/typecheck/unit/security/e2e
+          command: { type: "string" },                                   // 実行コマンド (無ければ空)
+          status:  { type: "string", enum: ["pass", "fail", "skip", "not_available"] },
+          summary: { type: "string" },                                   // 結果要約 (失敗時は要点)
+        },
+      },
+    },
+  },
+};
+
+const PARSE_SCHEMA = {
+  type: "object",
+  required: ["gate", "total_in_file", "selected", "items"],
+  properties: {
+    gate:          { type: "string" },
+    total_in_file: { type: "number" },
+    selected:      { type: "number" },
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["num", "name", "mandatory", "method", "timing", "skip_if", "skip_planned"],
+        properties: {
+          num:           { type: "number" },
+          name:          { type: "string" },
+          mandatory:     { type: "string", enum: ["必須", "条件", "任意"] },
+          method:        { type: "string" },                             // 自動/半自動/目視
+          timing:        { type: "string" },                             // PR/merge/nightly/release/incident
+          evidence_type: { type: "string" },
+          skip_if:       { type: "string" },
+          skip_planned:  { type: "boolean" },                            // skipConditions により事前スキップ確定
+        },
+      },
+    },
+  },
+};
+
+const VERIFY_SCHEMA = {
+  type: "object",
+  required: ["results"],
+  properties: {
+    results: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["num", "name", "status", "evidence", "reason"],
+        properties: {
+          num:      { type: "number" },
+          name:     { type: "string" },
+          status:   { type: "string", enum: ["pass", "fail", "skip", "not_run", "blocked"] },
+          evidence: { type: "string" },   // コマンド出力要約 / file:line / screenshot パス
+          reason:   { type: "string" },   // skip/not_run/fail/blocked では必須。pass では空可
+        },
+      },
+    },
+  },
+};
+
+// --- 入力 ------------------------------------------------------------------
+
+const gate          = (args?.gate || "gate-1").toLowerCase();
+const batchSize     = Math.max(1, Number(args?.batchSize) || 10);
+const skipConditions = Array.isArray(args?.skipConditions) ? args.skipConditions : [];
+const changedFiles  = Array.isArray(args?.changedFilesHint) ? args.changedFilesHint : [];
+const appUrl        = args?.appUrl || "";
+const checklistPath = args?.checklistPath || "";
+
+// gate ごとの選別ルール (Parse エージェントへ渡す自然言語仕様)
+const GATE_RULES = {
+  "gate-1": "必須度=「必須」かつ タイミング=「PR」 の項目のみ選別。",
+  "gate-2": "(必須度=「必須」かつ タイミング∈{PR,merge}) に加え、主要回帰項目 #1・#22・#31・#51・#71・#111・#131・#141・#231〜#241 を必ず含める。" +
+            (changedFiles.length ? ` さらに変更ファイル [${changedFiles.join(", ")}] に関連する項目も含める。` : ""),
+  "gate-3": "必須度∈{「必須」,「条件」} の全項目を選別 (release スイープ)。「任意」は除外。",
+  "all":    "全250項目を選別。",
+};
+const gateRule = GATE_RULES[gate] || GATE_RULES["gate-1"];
+
+log(`🧪 Gate 検証スイープ開始 — gate=${gate} / batchSize=${batchSize}`);
+if (skipConditions.length) log(`⏭ 事前スキップ条件: ${skipConditions.join(", ")}`);
+if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);
+
+// --- Phase 1: Preflight (共有自動チェックを1回だけ) ------------------------
+
+phase("Preflight");
+const preflight = await agent(
+  `このプロジェクトの標準的な自動品質チェックを「1回だけ」実行し、結果を構造化して返してください。\n` +
+  `package.json があれば scripts (lint/build/typecheck/test 等) を確認して実行。\n` +
+  `PowerShell 主体なら PSScriptAnalyzer / Pester、Node なら npm audit、Python なら対応ツールを使用。\n` +
+  `各チェックは name(lint/build/typecheck/unit/security/e2e 等)・command・status(pass/fail/skip/not_available)・summary を返す。\n` +
+  `存在しないチェックは status=not_available とし、無理に実行しないこと。これは後続の各項目検証で共有する基準値です。`,
+  { label: "preflight:auto-checks", phase: "Preflight", schema: PREFLIGHT_SCHEMA }
+);
+const preflightText = (preflight?.checks || [])
+  .map(c => `- ${c.name} [${c.status}] ${c.command ? `(${c.command}) ` : ""}${c.summary}`)
+  .join("\n") || "(自動チェック結果なし)";
+log(`✅ Preflight 完了: ${(preflight?.checks || []).length} 種`);
+
+// --- Phase 2: Parse (チェックリスト解析 + Gate 絞り込み) -------------------
+
+phase("Parse");
+const parsed = await agent(
+  `検証チェックリストを読み、対象項目を構造化して返してください。\n\n` +
+  `【手順】\n` +
+  `1. チェックリストを探して読む: ${checklistPath ? `パス "${checklistPath}"` :
+     `Glob "**/webui-full-verification-checklist.md" で探索し、.claude/claudeos/docs/ 配下を優先`}。\n` +
+  `2. 各セクションの表 (列: # / 項目名 / 必須度 / 実行方法 / 担当Agent / タイミング / 証跡 / skip_if) を全行パースする。\n` +
+  `3. 次の Gate ルールで選別する: ${gateRule}\n` +
+  `4. 選別した各項目について、skip_if 値が次の事前スキップ条件配列 [${skipConditions.join(", ") || "なし"}] に含まれる場合は skip_planned=true とする (それ以外は false)。\n` +
+  `5. total_in_file=ファイル内総項目数、selected=選別後件数、items=選別項目配列 を返す。\n` +
+  `項目数が多い。要約せず、選別対象は1件も省略しないこと。`,
+  { label: `parse:${gate}`, phase: "Parse", schema: PARSE_SCHEMA }
+);
+
+const items = (parsed?.items || []).filter(it => it && typeof it.num === "number");
+log(`📋 解析完了: ファイル総数 ${parsed?.total_in_file ?? "?"} → ${gate} 選別 ${items.length} 件`);
+
+if (items.length === 0) {
+  log("⚠️ 対象項目が0件です。gate / checklistPath を確認してください。");
+  return { gate, selected: 0, summary: "対象項目なし", report: "選別された検証項目がありませんでした。" };
+}
+
+// --- Phase 3: Verify (バッチごとに並列実検証) ------------------------------
+
+function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+const batches = chunk(items, batchSize);
+log(`🔁 検証バッチ ${batches.length} 個 (${batchSize}項目/バッチ) を並列スイープ`);
+
+const verifyOut = await pipeline(
+  batches,
+  (batch, _orig, idx) => agent(
+    `以下の検証項目バッチを「1項目ずつ実際に検証」してください。手抜き・一括 pass・捏造は厳禁です。\n\n` +
+    `【共有 Preflight 結果 (自動チェックの基準値)】\n${preflightText}\n\n` +
+    `${appUrl ? `【E2E/Playwright 用 URL】${appUrl} ← このアプリは起動済み・到達確認済み。\n` +
+      `  画面操作が要る項目は Playwright MCP で「この URL に直接 navigate」して実検証すること。\n` +
+      `  自前でサーバを起動し直さない (ポート不一致・二重起動の原因)。実際に使った URL を evidence に必ず残す。\n` +
+      `  ${appUrl} が万一到達不能な場合のみ、起動コマンドとポートを evidence に明記した上で起動してよい。\n` +
+      `  not_run にできるのは Playwright MCP 自体が使えない時、または E2E spec/ツールチェーンが repo に存在しない時に限る。\n\n`
+      : `【E2E/Playwright】起動 URL 未指定。画面実操作が必要な項目はコードを確認のうえ not_run + 理由とすること。\n\n`}` +
+    `【検証対象 (${batch.length}件)】\n${JSON.stringify(batch, null, 2)}\n\n` +
+    `【各項目の status 判定基準】\n` +
+    `- pass    : 実際に検証して問題なし。evidence にコマンド出力要約 / file:line / screenshot パス等の証跡を必ず記載。\n` +
+    `- fail    : 検証して問題を確認。reason に何がどう失敗したかを記載。\n` +
+    `- skip    : skip_planned=true、または skip_if 条件がこのプロジェクトで真。reason に該当条件を記載。\n` +
+    `- not_run : この環境で検証不能 (人間の目視 / Staging / 実機 / 外部サービス依存等)。reason に不能理由を記載。\n` +
+    `- blocked : 依存先の不具合で検証できない。reason に依存先を記載。\n\n` +
+    `【厳守】証跡なく pass にしない。判断できなければ not_run + 正直な理由。自動項目は Preflight 結果を証跡に引用してよい。\n` +
+    `Read/Grep/Bash 等で実際にコード・設定・コマンド結果を確認してから判定すること。`,
+    { label: `verify:batch${idx + 1}/${batches.length}`, phase: "Verify", schema: VERIFY_SCHEMA }
+  ).then(r => (r?.results || []))
+);
+
+const results = verifyOut.filter(Boolean).flat();
+
+// --- 集計 (JS 側で確定。エージェントの自己申告に依存しない) ----------------
+
+const byStatus = { pass: [], fail: [], skip: [], not_run: [], blocked: [] };
+for (const r of results) (byStatus[r.status] || byStatus.not_run).push(r);
+
+const itemByNum = new Map(items.map(it => [it.num, it]));
+const mandatoryFail = byStatus.fail.filter(r => itemByNum.get(r.num)?.mandatory === "必須");
+const mandatoryNotRun = byStatus.not_run.filter(r => itemByNum.get(r.num)?.mandatory === "必須");
+const mandatoryBlocked = byStatus.blocked.filter(r => itemByNum.get(r.num)?.mandatory === "必須");
+
+// STABLE ゲート: 必須項目に fail/blocked が無く、未検証(必須)が無いこと
+const gatePassed = mandatoryFail.length === 0 && mandatoryBlocked.length === 0 && mandatoryNotRun.length === 0;
+
+// 検証確定 (pass+fail) のうち pass の割合。not_run/skip は分母から除外し「実検証の質」を示す
+const decided = byStatus.pass.length + byStatus.fail.length;
+const verifiedPassRate = decided ? Math.round((byStatus.pass.length / decided) * 100) : 0;
+
+const counts = {
+  selected: items.length,
+  verified: results.length,
+  pass: byStatus.pass.length,
+  fail: byStatus.fail.length,
+  skip: byStatus.skip.length,
+  not_run: byStatus.not_run.length,
+  blocked: byStatus.blocked.length,
+  verified_pass_rate: verifiedPassRate,
+  mandatory_fail: mandatoryFail.length,
+  mandatory_not_run: mandatoryNotRun.length,
+  mandatory_blocked: mandatoryBlocked.length,
+  gate_passed: gatePassed,
+};
+
+log(`📊 検証結果: ✅${counts.pass} ❌${counts.fail} ⏭${counts.skip} ⬜${counts.not_run} 🚧${counts.blocked} / 実検証合格率 ${verifiedPassRate}% / STABLE-Gate=${gatePassed ? "PASS" : "FAIL"}`);
+
+// --- Phase 4: Synthesize (終了報告3区分レポート) --------------------------
+
+phase("Synthesize");
+const report = await agent(
+  `以下の Gate 検証スイープ結果を、CLAUDE.md §11「終了報告の必須3区分」形式の日本語レポートにまとめてください。\n\n` +
+  `gate=${gate} / 選別 ${counts.selected} 件 / 検証 ${counts.verified} 件\n` +
+  `✅pass=${counts.pass} ❌fail=${counts.fail} ⏭skip=${counts.skip} ⬜not_run=${counts.not_run} 🚧blocked=${counts.blocked} / 実検証合格率=${verifiedPassRate}%\n` +
+  `必須項目の未達: fail=${counts.mandatory_fail} not_run=${counts.mandatory_not_run} blocked=${counts.mandatory_blocked}\n` +
+  `STABLE ゲート判定: ${gatePassed ? "PASS (必須項目すべて検証済み)" : "FAIL (必須項目に未達あり → merge/deploy 不可)"}\n\n` +
+  `全結果:\n${JSON.stringify(results, null, 2)}\n\n` +
+  `【出力フォーマット (この見出しを厳守)】\n` +
+  `## 🧪 Gate 検証サマリー (${gate})\n` +
+  `📊 ゲート判定: ${gatePassed ? "✅ PASS" : "❌ FAIL"}\n` +
+  `### ✅ 実行した検証（件数・証跡）\n` +
+  `  pass/fail 項目を番号・項目名・証跡付きで列挙。\n` +
+  `### ⬜ 未実行の検証（件数・項目番号）\n` +
+  `  not_run/blocked/skip 項目を番号で列挙。skip と not_run は区別する。\n` +
+  `### 📝 未実行理由\n` +
+  `  項目番号ごとに not_run/blocked/skip の理由を記載。\n` +
+  `### ❌ 要対応 (fail / 必須未達)\n` +
+  `  fail と 必須項目の not_run/blocked を最優先課題として列挙。無ければ「なし」。`,
+  { label: "synthesize:report", phase: "Synthesize" }
+);
+
+log(gatePassed ? "🎉 STABLE-Gate PASS" : "⚠️ STABLE-Gate FAIL — 必須項目に未達あり");
+
+return { gate, counts, summary: `gate=${gate} pass=${counts.pass}/${counts.verified} STABLE-Gate=${gatePassed ? "PASS" : "FAIL"}`, report, results };

--- a/.claude/workflows/issue-triage.js
+++ b/.claude/workflows/issue-triage.js
@@ -1,0 +1,173 @@
+// issue-triage — GitHub Issue を大規模分類・重複除去・アクション提案
+// ---------------------------------------------------------------------------
+// 出典: dynamic workflows "Triage at Scale" パターン
+//   (Thariq Shihipar & Sid Bidasaria, 2026-06-02)
+//
+// 用途: open Issue を分類 (P1/P2/P3・カテゴリ)、既存との重複を検出、
+//       ラベル付け/重複クローズ/エスカレーションのアクションを提案する。
+//       ClaudeOS の Issue Factory / Agent Communication Protocol を補完。
+//
+// 安全既定: apply=false (提案のみ。Issue は変更しない)。
+//           apply=true でラベル付けのみ実行 (クローズは安全のため常に提案止まり)。
+//
+// 使い方:
+//   /issue-triage
+//   args 例: { "limit": 50, "batchSize": 8, "apply": false }
+// ---------------------------------------------------------------------------
+
+export const meta = {
+  name: "issue-triage",
+  description: "open GitHub Issue を分類・重複除去・アクション提案 (既定 dry-run・apply でラベル付けのみ実行)",
+  phases: [
+    { title: "Fetch",      detail: "open Issue を取得" },
+    { title: "Classify",   detail: "バッチ単位で優先度・カテゴリ・重複候補を分類" },
+    { title: "Synthesize", detail: "重複統合 + アクション計画レポート" },
+  ],
+};
+
+const FETCH_SCHEMA = {
+  type: "object",
+  required: ["issues", "total"],
+  properties: {
+    total: { type: "number" },
+    issues: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["number", "title"],
+        properties: {
+          number:       { type: "number" },
+          title:        { type: "string" },
+          labels:       { type: "array", items: { type: "string" } },
+          created:      { type: "string" },
+          body_excerpt: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+const CLASSIFY_SCHEMA = {
+  type: "object",
+  required: ["results"],
+  properties: {
+    results: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["number", "priority", "category", "suggested_labels", "action", "reasoning"],
+        properties: {
+          number:               { type: "number" },
+          priority:             { type: "string", enum: ["P1", "P2", "P3"] },
+          category:             { type: "string" },   // ci/security/quality/ux/docs/infra 等
+          suggested_labels:     { type: "array", items: { type: "string" } },
+          possible_duplicate_of:{ type: "number" },    // 重複候補の Issue 番号 (無ければ 0)
+          action:               { type: "string", enum: ["triage", "close-dup", "escalate", "needs-info"] },
+          reasoning:            { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+const limit     = Math.max(1, Number(args?.limit) || 50);
+const batchSize  = Math.max(1, Number(args?.batchSize) || 8);
+const apply     = args?.apply === true;
+
+log(`📋 issue-triage — ${apply ? "⚡ APPLY (ラベル付けのみ)" : "🔍 DRY-RUN (提案のみ)"} / limit=${limit}`);
+if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);
+
+// --- Phase 1: Fetch --------------------------------------------------------
+
+phase("Fetch");
+const fetched = await agent(
+  `gh issue list --state open --limit ${limit} --json number,title,labels,createdAt,body を実行し、` +
+  `open Issue を取得して構造化してください。body_excerpt は先頭 200 字程度に要約。` +
+  `agent-msg 等の運用メッセージ Issue も含めて全件返す。total も返す。`,
+  { label: "fetch", phase: "Fetch", schema: FETCH_SCHEMA }
+);
+const issues = (fetched?.issues || []).filter(i => i && typeof i.number === "number");
+log(`📥 open Issue ${issues.length} 件取得`);
+
+if (issues.length === 0) {
+  log("✅ open Issue なし — triage 不要");
+  return { total: 0, classified: [], report: "open Issue はありませんでした。" };
+}
+
+// --- Phase 2: Classify (バッチ並列) ----------------------------------------
+
+function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+const batches = chunk(issues, batchSize);
+
+phase("Classify");
+log(`🔁 ${batches.length} バッチで分類 (全 Issue リストを各バッチへ渡し重複検出を可能にする)`);
+
+const allTitles = issues.map(i => `#${i.number} ${i.title}`).join("\n");
+const classifiedOut = await pipeline(
+  batches,
+  (batch, _o, idx) => agent(
+    `以下の Issue バッチを分類してください。\n\n` +
+    `【分類対象 (${batch.length}件)】\n${JSON.stringify(batch, null, 2)}\n\n` +
+    `【全 open Issue 一覧 (重複候補判定用)】\n${allTitles}\n\n` +
+    `各 Issue に対し:\n` +
+    `- priority: P1(CI/セキュリティ/データ影響) / P2(品質/UX/テスト) / P3(軽微)\n` +
+    `- category: ci/security/quality/ux/docs/infra/agent-msg 等\n` +
+    `- suggested_labels: 付与推奨ラベル\n` +
+    `- possible_duplicate_of: 重複と思われる別 Issue 番号 (無ければ 0)\n` +
+    `- action: triage(通常) / close-dup(重複) / escalate(緊急) / needs-info(情報不足)\n` +
+    `必要なら gh issue view で本文を確認すること。`,
+    { label: `classify:batch${idx + 1}/${batches.length}`, phase: "Classify", schema: CLASSIFY_SCHEMA }
+  ).then(r => (r?.results || []))
+);
+const classified = classifiedOut.filter(Boolean).flat();
+
+const byPrio = { P1: [], P2: [], P3: [] };
+for (const c of classified) (byPrio[c.priority] || byPrio.P3).push(c);
+const dups = classified.filter(c => c.possible_duplicate_of && c.possible_duplicate_of > 0);
+log(`📊 分類: P1=${byPrio.P1.length} P2=${byPrio.P2.length} P3=${byPrio.P3.length} / 重複候補 ${dups.length} 件`);
+
+// --- Phase 2b: ラベル付け (apply 時のみ) -----------------------------------
+
+let labelResult = { applied: 0, note: "apply=false のためラベル付けなし" };
+if (apply) {
+  const withLabels = classified.filter(c => (c.suggested_labels || []).length > 0);
+  const labeled = await pipeline(
+    withLabels,
+    (c) => agent(
+      `Issue #${c.number} に対し、既存ラベルと矛盾しない範囲で次のラベルを ` +
+      `gh issue edit ${c.number} --add-label でラベル付けしてください: ${c.suggested_labels.join(", ")}\n` +
+      `存在しないラベルは作らず skip。結果を "added: <labels>" か "skipped: <reason>" で1行返す。` +
+      `クローズや本文編集は行わないこと。`,
+      { label: `label:#${c.number}`, phase: "Classify" }
+    )
+  );
+  labelResult = { applied: labeled.filter(Boolean).length, note: "ラベル付けのみ実行 (クローズは提案止まり)" };
+  log(`🏷 ラベル付け ${labelResult.applied} 件`);
+}
+
+// --- Phase 3: Synthesize ---------------------------------------------------
+
+phase("Synthesize");
+const report = await agent(
+  `Issue triage 結果を日本語レポートにまとめてください。\n\n` +
+  `総数 ${issues.length} / P1=${byPrio.P1.length} P2=${byPrio.P2.length} P3=${byPrio.P3.length} / 重複候補 ${dups.length}\n` +
+  `モード: ${apply ? "APPLY (ラベル付け済)" : "DRY-RUN (提案のみ)"}\n\n` +
+  `分類結果:\n${JSON.stringify(classified, null, 2)}\n\n` +
+  `レポート構成: ## Triage サマリー / ### 🔴 P1 (即対応) / ### 🟡 P2 / ### ⚪ P3 / ` +
+  `### 重複候補 (close-dup 提案) / ### 情報不足 (needs-info) / ### 次アクション。` +
+  `重複候補は「#X は #Y の重複」の形で明示し、クローズは提案として記載 (自動クローズしない)。`,
+  { label: "synthesize", phase: "Synthesize" }
+);
+
+return {
+  total: issues.length,
+  apply,
+  counts: { P1: byPrio.P1.length, P2: byPrio.P2.length, P3: byPrio.P3.length, duplicates: dups.length },
+  labelResult,
+  classified,
+  report,
+};

--- a/.claude/workflows/migration-sweep.js
+++ b/.claude/workflows/migration-sweep.js
@@ -1,0 +1,213 @@
+// migration-sweep — コードベース横断の移行/リファクタを discover → transform → verify
+// ---------------------------------------------------------------------------
+// 出典: dynamic workflows "Migrations & Refactors" パターン
+//   (Thariq Shihipar & Sid Bidasaria, 2026-06-02)
+//
+// 用途: SSH 名残削除・API 名称変更・依存差し替え等、多数のサイトに散らばる
+//       機械的だが文脈依存の移行を、ファイル単位エージェントで並列適用する。
+//
+// 安全既定: apply=false (discover + 変更案レポートのみ。実ファイルは触らない)。
+//           apply=true で実編集。プロジェクト全体の --dry-run/--apply 規約に準拠。
+//
+// 使い方:
+//   /migration-sweep            (args 必須。下記)
+//   args 例: {
+//     "description": "SSH 経由実行を Windows ローカル実行へ置換",
+//     "find": "ssh |Invoke-SSH|linuxHost",     // 対象サイトの検索語/正規表現
+//     "globs": ["scripts/**/*.ps1","scripts/**/*.js"],  // 走査スコープ
+//     "verifyCmd": "node --check",              // 変換後の検証 (任意)
+//     "apply": false                            // true で実編集
+//   }
+// ---------------------------------------------------------------------------
+
+export const meta = {
+  name: "migration-sweep",
+  description: "コードベース横断の移行/リファクタを discover→transform→verify で並列実行 (既定 dry-run・apply で実適用)",
+  phases: [
+    { title: "Discover",  detail: "移行対象サイトを横断検索しファイル単位に集約" },
+    { title: "Transform", detail: "ファイル単位エージェントが変換 (apply 時のみ実編集)" },
+    { title: "Verify",    detail: "検証コマンド実行 + 変更レビュー + レポート生成" },
+  ],
+};
+
+const DISCOVER_SCHEMA = {
+  type: "object",
+  required: ["files", "total_files", "total_sites"],
+  properties: {
+    total_files: { type: "number" },
+    total_sites: { type: "number" },
+    files: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["path", "occurrences", "sites"],
+        properties: {
+          path:        { type: "string" },
+          occurrences: { type: "number" },
+          sites: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["line", "snippet", "reason"],
+              properties: {
+                line:    { type: "number" },
+                snippet: { type: "string" },
+                reason:  { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const TRANSFORM_SCHEMA = {
+  type: "object",
+  required: ["path", "status", "changes", "note"],
+  properties: {
+    path:   { type: "string" },
+    status: { type: "string", enum: ["transformed", "planned", "skipped", "failed"] },
+    changes: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["line", "before", "after"],
+        properties: {
+          line:   { type: "number" },
+          before: { type: "string" },
+          after:  { type: "string" },
+        },
+      },
+    },
+    note: { type: "string" },
+  },
+};
+
+const VERIFY_SCHEMA = {
+  type: "object",
+  required: ["status", "summary"],
+  properties: {
+    status:  { type: "string", enum: ["pass", "fail", "skip"] },
+    summary: { type: "string" },
+  },
+};
+
+// --- 入力 ------------------------------------------------------------------
+
+const description = args?.description || "";
+const find        = args?.find || "";
+const globs       = Array.isArray(args?.globs) ? args.globs : [];
+const verifyCmd   = args?.verifyCmd || "";
+const apply       = args?.apply === true;
+
+if (!description || !find) {
+  log("⚠️ args.description と args.find は必須です。中止します。");
+  return { error: "args.description と args.find が必要", description, find };
+}
+
+log(`🔧 migration-sweep — ${apply ? "⚡ APPLY (実編集)" : "🔍 DRY-RUN (変更案のみ)"}`);
+log(`🎯 目標: ${description}`);
+log(`🔎 検索: ${find}${globs.length ? ` / scope: ${globs.join(", ")}` : ""}`);
+if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);
+
+// --- Phase 1: Discover -----------------------------------------------------
+
+phase("Discover");
+const discovered = await agent(
+  `移行対象サイトを横断検索してファイル単位に集約してください。\n\n` +
+  `【移行目標】${description}\n` +
+  `【検索語/正規表現】${find}\n` +
+  `【走査スコープ】${globs.length ? globs.join(", ") : "リポジトリ全体 (node_modules/.git/dist は除外)"}\n\n` +
+  `Grep/Glob で全該当箇所を洗い出し、ファイルごとに occurrences と sites(line/snippet/該当理由) を集約。\n` +
+  `移行目標に照らして「変更すべき箇所」のみ含める (誤検知・コメント内の無関係一致は除外)。\n` +
+  `1件も省略せず、total_files / total_sites も返すこと。`,
+  { label: "discover", phase: "Discover", schema: DISCOVER_SCHEMA }
+);
+
+const files = (discovered?.files || []).filter(f => f && f.path);
+log(`📋 発見: ${discovered?.total_files ?? files.length} ファイル / ${discovered?.total_sites ?? "?"} サイト`);
+
+if (files.length === 0) {
+  log("✅ 対象サイトなし — 移行不要、または検索語の見直しが必要");
+  return { apply, discovered: { total_files: 0, total_sites: 0 }, transformed: [], summary: "対象サイトなし" };
+}
+
+// --- Phase 2: Transform (ファイル単位・並列) -------------------------------
+// ファイル単位に分離しているため同一ファイルの並列編集衝突は起きない。
+// worktree 隔離は使わない (変更を本ブランチへ着地させるため)。
+
+phase("Transform");
+log(`🔁 ${files.length} ファイルを${apply ? "変換" : "変換案作成"} (並列)`);
+
+const transformed = await pipeline(
+  files,
+  (f) => agent(
+    `次の1ファイルだけを移行対象として扱ってください (他ファイルには触れない)。\n\n` +
+    `【移行目標】${description}\n` +
+    `【対象ファイル】${f.path}\n` +
+    `【該当サイト】\n${JSON.stringify(f.sites, null, 2)}\n\n` +
+    (apply
+      ? `【APPLY モード】実際に Edit/Write でこのファイルを編集してください。\n` +
+        `- 周辺コードのスタイル・命名・コメント密度に合わせる\n` +
+        `- 挙動を変えない (純粋な移行)。判断に迷う箇所は編集せず note に残す\n` +
+        `- 編集後に node --check 等で壊れていないか確認\n` +
+        `- 実施した変更を changes(line/before/after) に列挙し status=transformed\n` +
+        `- 変更不要だった場合 status=skipped`
+      : `【DRY-RUN モード】ファイルは編集しないでください。\n` +
+        `- 各サイトの変更案を changes(line/before/after) として提示\n` +
+        `- status=planned (変更案あり) / skipped (変更不要)\n` +
+        `- リスク・要確認点は note に記載`) +
+    `\nファイルを Read で実際に確認してから判断すること。`,
+    { label: `${apply ? "apply" : "plan"}:${f.path.split(/[\\/]/).pop()}`, phase: "Transform", schema: TRANSFORM_SCHEMA }
+  )
+);
+
+const results = transformed.filter(Boolean);
+const tStatus = { transformed: [], planned: [], skipped: [], failed: [] };
+for (const r of results) (tStatus[r.status] || tStatus.failed).push(r);
+const changedCount = (apply ? tStatus.transformed : tStatus.planned).length;
+const totalChanges = results.reduce((n, r) => n + (r.changes?.length || 0), 0);
+log(`📊 ${apply ? "変換" : "変換案"}: ${changedCount} ファイル / 変更 ${totalChanges} 箇所 / skip ${tStatus.skipped.length} / failed ${tStatus.failed.length}`);
+
+// --- Phase 3: Verify -------------------------------------------------------
+
+phase("Verify");
+let verify = { status: "skip", summary: "apply=false のため検証スキップ" };
+
+if (apply && (tStatus.transformed.length > 0)) {
+  verify = await agent(
+    `移行適用後の検証をしてください。\n\n` +
+    `【移行目標】${description}\n` +
+    `【変更ファイル】${tStatus.transformed.map(r => r.path).join(", ")}\n` +
+    (verifyCmd ? `【検証コマンド】${verifyCmd} を変更ファイルに対して実行し結果を確認。\n` : `【検証】変更ファイルを node --check / 対応 linter 等で確認。\n`) +
+    `さらに git diff を確認し、移行目標から外れた変更・残し漏れ・壊れた構文が無いか adversarial に点検。\n` +
+    `status(pass/fail/skip) と summary を返す。`,
+    { label: "verify", phase: "Verify", schema: VERIFY_SCHEMA }
+  ) || verify;
+  log(`🧪 検証: ${verify.status} — ${verify.summary}`);
+}
+
+// --- レポート --------------------------------------------------------------
+
+const report = await agent(
+  `移行スイープ結果を日本語レポートにまとめてください。\n\n` +
+  `モード: ${apply ? "APPLY (実編集済)" : "DRY-RUN (変更案のみ)"}\n` +
+  `目標: ${description}\n` +
+  `発見: ${files.length} ファイル / ${discovered?.total_sites ?? "?"} サイト\n` +
+  `${apply ? "変換" : "変換案"}: ${changedCount} ファイル / 変更 ${totalChanges} 箇所 / skip ${tStatus.skipped.length} / failed ${tStatus.failed.length}\n` +
+  `検証: ${verify.status} — ${verify.summary}\n\n` +
+  `詳細:\n${JSON.stringify(results, null, 2)}\n\n` +
+  `レポート構成: ## 移行サマリー / ### 変更ファイル一覧 / ### 要確認・スキップ / ### 次アクション` +
+  `${apply ? "" : " (apply=true で実適用する手順を含める)"}。`,
+  { label: "report", phase: "Verify" }
+);
+
+return {
+  apply,
+  discovered: { total_files: files.length, total_sites: discovered?.total_sites },
+  counts: { changed: changedCount, total_changes: totalChanges, skipped: tStatus.skipped.length, failed: tStatus.failed.length },
+  verify,
+  transformed: results,
+  report,
+};

--- a/.claude/workflows/rule-distillation.js
+++ b/.claude/workflows/rule-distillation.js
@@ -1,0 +1,178 @@
+// rule-distillation — セッション/レビュー/履歴から運用ルールを蒸留 (提案のみ)
+// ---------------------------------------------------------------------------
+// 出典: dynamic workflows "Memory & Rule Adherence" パターン
+//   (Thariq Shihipar & Sid Bidasaria, 2026-06-02)
+//
+// 用途: reasoning-bank・git 履歴・CodeRabbit/Codex 指摘・MEMORY.md を横断マイニングし、
+//       繰り返し現れる是正をクラスタ化→反証検証→生き残りを CLAUDE.md/MEMORY.md 追記案へ蒸留。
+//       ClaudeOS の EvolutionManager / self-evolution を支援する。
+//
+// 重要: CLAUDE.md §18 (CLAUDE.md/settings.json/hooks の自己書換禁止) を尊重し、
+//       本 workflow は **常に提案のみ** (ファイルは編集しない)。採用は人間が判断する。
+//
+// 使い方:
+//   /rule-distillation
+//   args 例: { "lookback": 50, "target": "MEMORY.md" }
+//     lookback: 走査する直近 git コミット数 (既定 40)
+//     target  : 蒸留先の想定 ("MEMORY.md" | "CLAUDE.md")。既定 "MEMORY.md"
+// ---------------------------------------------------------------------------
+
+export const meta = {
+  name: "rule-distillation",
+  description: "セッション/レビュー/履歴から繰り返しの是正を蒸留し運用ルール追記案を生成 (提案のみ・自動適用なし)",
+  phases: [
+    { title: "Mine",     detail: "複数ソースを並列マイニングし候補ルールを抽出" },
+    { title: "Cluster",  detail: "候補を統合・重複排除" },
+    { title: "Verify",   detail: "各候補を adversarial 検証 (実在性・既出チェック)" },
+    { title: "Distill",  detail: "生存候補を追記案へ蒸留" },
+  ],
+};
+
+const MINE_SCHEMA = {
+  type: "object",
+  required: ["source", "candidates"],
+  properties: {
+    source: { type: "string" },
+    candidates: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["rule", "evidence", "frequency"],
+        properties: {
+          rule:      { type: "string" },   // 「〜すべき/〜してはいけない」形の運用ルール
+          evidence:  { type: "string" },   // 根拠 (コミット/指摘/パターンの引用)
+          frequency: { type: "number" },   // 観測回数の目安
+        },
+      },
+    },
+  },
+};
+
+const VERIFY_SCHEMA = {
+  type: "object",
+  required: ["rule", "is_real", "already_documented", "recommendation", "reasoning"],
+  properties: {
+    rule:               { type: "string" },
+    is_real:            { type: "boolean" },  // 本当に繰り返す是正か (一度きりの偶発でない)
+    already_documented: { type: "boolean" },  // 既に CLAUDE.md/MEMORY.md にあるか
+    recommendation:     { type: "string", enum: ["adopt", "merge", "drop"] },
+    reasoning:          { type: "string" },
+  },
+};
+
+const lookback = Math.max(5, Number(args?.lookback) || 40);
+const target   = args?.target === "CLAUDE.md" ? "CLAUDE.md" : "MEMORY.md";
+
+log(`🧬 rule-distillation — 提案のみ (自動適用なし) / target=${target} / lookback=${lookback}コミット`);
+if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);
+
+// --- Phase 1: Mine (ソース別並列) ------------------------------------------
+
+const SOURCES = [
+  {
+    key: "reasoning-bank",
+    prompt: `.claude/claudeos/data/reasoning-bank.json を読み、success_patterns / failure_patterns から ` +
+            `「今後こうすべき」という運用ルール候補を抽出してください。各候補に根拠と観測頻度を付ける。`,
+  },
+  {
+    key: "git-history",
+    prompt: `直近 ${lookback} コミット (git log -n ${lookback} --format=...) を確認し、` +
+            `「同種の修正が繰り返されている」パターン (例: 同じ種類の lint 修正・docs ドリフト修正・命名是正) を` +
+            `運用ルール候補として抽出してください。fix/revert が多いテーマは是正ルールの種。`,
+  },
+  {
+    key: "review-comments",
+    prompt: `CodeRabbit / Codex のレビュー指摘の痕跡 (reports/・PR コメント・コミットの "CodeRabbit"/"Codex" 言及) を` +
+            `gh / Grep で確認し、繰り返し指摘される観点を運用ルール候補として抽出してください。`,
+  },
+  {
+    key: "existing-memory",
+    prompt: `既存の MEMORY.md (memory ディレクトリ) と CLAUDE.md の feedback/禁止事項を読み、` +
+            `「既に明文化されている運用ルール」を列挙してください (後段の既出チェックの基準にする)。` +
+            `これらは新規候補ではなく "既出リスト" として rule に記し frequency は 0 とする。`,
+  },
+];
+
+phase("Mine");
+const mined = await parallel(
+  SOURCES.map(s => () => agent(s.prompt, { label: `mine:${s.key}`, phase: "Mine", schema: MINE_SCHEMA }))
+);
+const allCandidates = mined.filter(Boolean).flatMap(m => (m.candidates || []).map(c => ({ ...c, source: m.source })));
+log(`📋 候補 ${allCandidates.length} 件 (既出リスト含む) → クラスタリングへ`);
+
+if (allCandidates.length === 0) {
+  log("✅ 抽出候補なし");
+  return { target, proposals: "抽出された候補ルールはありませんでした。", candidates: [] };
+}
+
+// --- Phase 2: Cluster (統合・重複排除) -------------------------------------
+
+phase("Cluster");
+const CLUSTER_SCHEMA = {
+  type: "object",
+  required: ["clusters"],
+  properties: {
+    clusters: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["rule", "evidence", "frequency"],
+        properties: {
+          rule:      { type: "string" },
+          evidence:  { type: "string" },
+          frequency: { type: "number" },
+        },
+      },
+    },
+  },
+};
+const clustered = await agent(
+  `以下の候補ルール群を意味の近いもので統合・重複排除してください。\n\n` +
+  `${JSON.stringify(allCandidates, null, 2)}\n\n` +
+  `同義のルールは1件に統合し evidence をまとめ frequency を合算。` +
+  `source=existing-memory 由来の "既出" は統合先の判断材料に使うが、それ自体は新規 cluster にしない。` +
+  `新規性のある運用ルールのみ clusters に残す。`,
+  { label: "cluster", phase: "Cluster", schema: CLUSTER_SCHEMA }
+);
+const clusters = (clustered?.clusters || []).filter(c => c && c.rule);
+log(`🔗 クラスタ ${clusters.length} 件 → adversarial 検証へ`);
+
+// --- Phase 3: Verify (候補ごと adversarial) --------------------------------
+
+phase("Verify");
+const verified = await pipeline(
+  clusters,
+  (c) => agent(
+    `次の運用ルール候補を adversarial に検証してください。\n\n` +
+    `候補: ${c.rule}\n根拠: ${c.evidence}\n観測頻度: ${c.frequency}\n\n` +
+    `判定:\n` +
+    `- is_real: 一度きりの偶発でなく「繰り返す是正」か (疑わしければ false)\n` +
+    `- already_documented: CLAUDE.md / MEMORY.md に既に同趣旨があるか (実際に Grep して確認)\n` +
+    `- recommendation: adopt(新規採用) / merge(既存へ統合) / drop(不採用)\n` +
+    `デフォルトは保守的に。曖昧なら drop。`,
+    { label: `verify:${c.rule.slice(0, 24)}`, phase: "Verify", schema: VERIFY_SCHEMA }
+  ).then(v => v ? { ...c, ...v } : null)
+);
+const survivors = verified.filter(Boolean).filter(v => v.is_real && v.recommendation !== "drop");
+log(`🎯 生存候補 ${survivors.length} 件 (adopt/merge) → 蒸留へ`);
+
+// --- Phase 4: Distill (追記案生成・提案のみ) -------------------------------
+
+phase("Distill");
+const proposals = await agent(
+  `以下の生存ルールを ${target} への追記案として日本語で蒸留してください。**提案のみ。ファイルは編集しないこと。**\n\n` +
+  `${JSON.stringify(survivors, null, 2)}\n\n` +
+  (target === "MEMORY.md"
+    ? `各ルールを memory ファイル形式 (frontmatter: name/description/metadata.type=feedback, 本文に Why/How to apply) の追記案として提示。`
+    : `各ルールを CLAUDE.md の適切な節 (例: 禁止事項 / 行動原則) への追記案として提示。§18 により自動適用はせず人間レビュー前提と明記。`) +
+  `\n各案に「採用/統合(merge 先)/見送り」の推奨と理由を添える。`,
+  { label: "distill", phase: "Distill" }
+);
+
+return {
+  target,
+  counts: { mined: allCandidates.length, clustered: clusters.length, survivors: survivors.length },
+  survivors,
+  proposals,
+  note: "提案のみ。CLAUDE.md/MEMORY.md への反映は人間が判断する (§18)。",
+};

--- a/Claude/templates/claude/workflows/bug-investigation.js
+++ b/Claude/templates/claude/workflows/bug-investigation.js
@@ -1,0 +1,97 @@
+export const meta = {
+  name: "bug-investigation",
+  description: "バグを複数の競合仮説で並列調査し、議論・反証を経て根本原因を特定",
+  phases: [
+    { title: "Hypothesize", detail: "5エージェントが独立した仮説を立案" },
+    { title: "Debate",      detail: "各エージェントが他の仮説を反証" },
+    { title: "Converge",    detail: "生き残った仮説から根本原因を特定" },
+  ],
+};
+
+const HYPOTHESIS_SCHEMA = {
+  type: "object",
+  required: ["hypothesis", "evidence", "investigation_steps", "confidence"],
+  properties: {
+    hypothesis:          { type: "string" },
+    evidence:            { type: "array", items: { type: "string" } },
+    investigation_steps: { type: "array", items: { type: "string" } },
+    confidence:          { type: "number", minimum: 0, maximum: 1 },
+  },
+};
+
+const DEBATE_SCHEMA = {
+  type: "object",
+  required: ["target_hypothesis", "refutation", "survives", "confidence_after"],
+  properties: {
+    target_hypothesis: { type: "string" },
+    refutation:        { type: "string" },
+    survives:          { type: "boolean" },
+    confidence_after:  { type: "number", minimum: 0, maximum: 1 },
+  },
+};
+
+const bugDescription = args?.bug || "バグの症状を args.bug に渡してください";
+
+log(`🐛 調査対象: ${bugDescription}`);
+
+phase("Hypothesize");
+const hypotheses = await parallel([
+  () => agent(
+    `バグ: "${bugDescription}"\n仮説1: ネットワーク/API 通信の問題（タイムアウト・レスポンス形式・認証）の観点で調査し、原因仮説を立ててください。コードを実際に確認してください。`,
+    { label: "hyp:network", phase: "Hypothesize", schema: HYPOTHESIS_SCHEMA }
+  ),
+  () => agent(
+    `バグ: "${bugDescription}"\n仮説2: 状態管理・データフローの問題（変数の初期化・非同期処理・競合状態）の観点で調査し、原因仮説を立ててください。コードを実際に確認してください。`,
+    { label: "hyp:state", phase: "Hypothesize", schema: HYPOTHESIS_SCHEMA }
+  ),
+  () => agent(
+    `バグ: "${bugDescription}"\n仮説3: 入力バリデーション・型変換の問題（null チェック漏れ・型不一致・エッジケース）の観点で調査し、原因仮説を立ててください。コードを実際に確認してください。`,
+    { label: "hyp:validation", phase: "Hypothesize", schema: HYPOTHESIS_SCHEMA }
+  ),
+  () => agent(
+    `バグ: "${bugDescription}"\n仮説4: 外部依存（ライブラリのバージョン・環境設定・DB状態）の問題の観点で調査し、原因仮説を立ててください。コードを実際に確認してください。`,
+    { label: "hyp:deps", phase: "Hypothesize", schema: HYPOTHESIS_SCHEMA }
+  ),
+  () => agent(
+    `バグ: "${bugDescription}"\n仮説5: ロジックエラー（条件式の誤り・境界値・off-by-one）の観点で調査し、原因仮説を立ててください。コードを実際に確認してください。`,
+    { label: "hyp:logic", phase: "Hypothesize", schema: HYPOTHESIS_SCHEMA }
+  ),
+]);
+
+const validHyps = hypotheses.filter(Boolean);
+log(`📋 仮説 ${validHyps.length} 件 → 相互反証へ`);
+
+phase("Debate");
+const debateResults = await pipeline(
+  validHyps,
+  h => agent(
+    `以下の仮説を科学的に反証してください。他の仮説と比較し、この仮説が正しくない理由を探してください。\n\n` +
+    `仮説: ${h.hypothesis}\n` +
+    `根拠: ${(h.evidence || []).join(", ")}\n\n` +
+    `全仮説:\n${validHyps.map((v, i) => `${i+1}. ${v.hypothesis}`).join("\n")}\n\n` +
+    `この仮説の弱点・反証を詳細に示してください。デフォルトは survives=false（反証できたら false）。`,
+    { label: `debate:${h.hypothesis.slice(0, 30)}`, phase: "Debate", schema: DEBATE_SCHEMA }
+  )
+);
+
+const survivors = debateResults
+  .filter(Boolean)
+  .filter(d => d.survives)
+  .map(d => ({ ...validHyps.find(h => h.hypothesis === d.target_hypothesis || d.target_hypothesis?.includes(h.hypothesis?.slice(0,20))), ...d }));
+
+log(`🎯 生き残った仮説: ${survivors.length} 件`);
+
+phase("Converge");
+const conclusion = await agent(
+  `バグ "${bugDescription}" について、競合仮説の議論・反証を経た結果を分析してください。\n\n` +
+  `生き残った仮説 (${survivors.length}件):\n${JSON.stringify(survivors, null, 2)}\n\n` +
+  `全仮説とデバート結果:\n${JSON.stringify(debateResults.filter(Boolean), null, 2)}\n\n` +
+  `以下を日本語で出力してください:\n` +
+  `1. 根本原因（最も可能性が高い仮説とその理由）\n` +
+  `2. 修正方針（具体的なコード変更箇所と方法）\n` +
+  `3. 検証方法（修正が正しいことを確認するテスト）\n` +
+  `4. 再発防止策`,
+  { label: "converge:conclusion", phase: "Converge" }
+);
+
+return { survivors, conclusion };

--- a/Claude/templates/claude/workflows/code-review-parallel.js
+++ b/Claude/templates/claude/workflows/code-review-parallel.js
@@ -1,0 +1,119 @@
+export const meta = {
+  name: "code-review-parallel",
+  description: "PR を Security/Performance/TestCoverage の3視点で並列レビューし、統合レポートを生成",
+  phases: [
+    { title: "Review", detail: "3エージェントが独立したレビュー観点で同時レビュー" },
+    { title: "Verify", detail: "各指摘を独立エージェントが adversarial 検証" },
+    { title: "Synthesize", detail: "統合レポート生成" },
+  ],
+};
+
+const REVIEW_SCHEMA = {
+  type: "object",
+  required: ["dimension", "findings"],
+  properties: {
+    dimension: { type: "string" },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["title", "severity", "file", "description", "recommendation"],
+        properties: {
+          title:          { type: "string" },
+          severity:       { type: "string", enum: ["critical", "high", "medium", "low"] },
+          file:           { type: "string" },
+          description:    { type: "string" },
+          recommendation: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+const VERDICT_SCHEMA = {
+  type: "object",
+  required: ["isReal", "reasoning"],
+  properties: {
+    isReal:    { type: "boolean" },
+    reasoning: { type: "string" },
+  },
+};
+
+// Diff to review (defaults to main branch)
+const baseBranch = args?.baseBranch || "main";
+
+const DIMENSIONS = [
+  {
+    key: "security",
+    prompt: `git diff ${baseBranch}...HEAD を取得し、セキュリティ観点でレビューしてください。
+特に確認: XSS/CSRF/SQL Injection/IDOR/Path Traversal/SSRF/認証バイパス/シークレット漏洩/依存関係の脆弱性。
+各指摘は severity(critical/high/medium/low)・file・description・recommendation を含めてください。`,
+  },
+  {
+    key: "performance",
+    prompt: `git diff ${baseBranch}...HEAD を取得し、パフォーマンス観点でレビューしてください。
+特に確認: N+1 クエリ/不要なループ/メモリリーク/blocking I/O/大きなバンドルサイズ/キャッシュ未活用。
+各指摘は severity(critical/high/medium/low)・file・description・recommendation を含めてください。`,
+  },
+  {
+    key: "test-coverage",
+    prompt: `git diff ${baseBranch}...HEAD を取得し、テストカバレッジ観点でレビューしてください。
+特に確認: 変更ファイルに対応するテストの有無・エッジケースの未テスト・モックの過剰使用・E2E 不足。
+各指摘は severity(critical/high/medium/low)・file・description・recommendation を含めてください。`,
+  },
+];
+
+phase("Review");
+const reviews = await pipeline(
+  DIMENSIONS,
+  d => agent(d.prompt, { label: `review:${d.key}`, phase: "Review", schema: REVIEW_SCHEMA })
+);
+
+const allFindings = reviews
+  .filter(Boolean)
+  .flatMap(r => (r.findings || []).map(f => ({ ...f, dimension: r.dimension })));
+
+if (allFindings.length === 0) {
+  log("✅ 指摘なし — レビュー完了");
+  return { summary: "No issues found", findings: [] };
+}
+
+log(`🔍 指摘 ${allFindings.length} 件 → adversarial 検証へ`);
+
+phase("Verify");
+const verified = await pipeline(
+  allFindings,
+  f => agent(
+    `以下の指摘を adversarial に検証してください。本当に問題があるか、誤検知でないかを評価してください。\n\n` +
+    `指摘: ${f.title}\n` +
+    `観点: ${f.dimension}\n` +
+    `ファイル: ${f.file}\n` +
+    `説明: ${f.description}\n\n` +
+    `デフォルトは isReal=false (疑わしければ誤検知扱い)。明確な問題がある場合のみ isReal=true。`,
+    { label: `verify:${f.file}:${f.severity}`, phase: "Verify", schema: VERDICT_SCHEMA }
+  ).then(v => v ? { ...f, verdict: v } : null)
+);
+
+const confirmed = verified.filter(Boolean).filter(f => f.verdict?.isReal);
+const bySeverity = { critical: [], high: [], medium: [], low: [] };
+for (const f of confirmed) {
+  (bySeverity[f.severity] || bySeverity.low).push(f);
+}
+
+phase("Synthesize");
+const report = await agent(
+  `以下のコードレビュー結果を日本語で統合レポートにまとめてください。\n\n` +
+  `Critical: ${bySeverity.critical.length}件\n` +
+  `High: ${bySeverity.high.length}件\n` +
+  `Medium: ${bySeverity.medium.length}件\n` +
+  `Low: ${bySeverity.low.length}件\n\n` +
+  `各指摘の詳細:\n${JSON.stringify(confirmed, null, 2)}\n\n` +
+  `レポートには: エグゼクティブサマリー / Critical・High の必須修正リスト / Medium 推奨修正 / Low 任意対応 を含めてください。`,
+  { label: "synthesize:report", phase: "Synthesize" }
+);
+
+return {
+  summary: `Critical=${bySeverity.critical.length} High=${bySeverity.high.length} Medium=${bySeverity.medium.length} Low=${bySeverity.low.length}`,
+  confirmed,
+  report,
+};

--- a/Claude/templates/claude/workflows/feature-development.js
+++ b/Claude/templates/claude/workflows/feature-development.js
@@ -1,0 +1,93 @@
+export const meta = {
+  name: "feature-development",
+  description: "フィーチャーを Backend/Frontend/Test の3チームが並列実装し、統合・レビューまで完結",
+  phases: [
+    { title: "Design",      detail: "Architect がアーキテクチャ設計・タスク分解" },
+    { title: "Implement",   detail: "Backend/Frontend/Test が並列実装" },
+    { title: "Integrate",   detail: "統合確認・CI ステータス確認" },
+  ],
+};
+
+const DESIGN_SCHEMA = {
+  type: "object",
+  required: ["architecture", "backend_tasks", "frontend_tasks", "test_tasks"],
+  properties: {
+    architecture:    { type: "string" },
+    backend_tasks:   { type: "array", items: { type: "string" } },
+    frontend_tasks:  { type: "array", items: { type: "string" } },
+    test_tasks:      { type: "array", items: { type: "string" } },
+    files_to_create: { type: "array", items: { type: "string" } },
+    files_to_modify: { type: "array", items: { type: "string" } },
+  },
+};
+
+const featureDescription = args?.feature || "実装する機能を args.feature に渡してください";
+const issueNumber = args?.issue ? `Issue #${args.issue}` : "";
+
+log(`🚀 機能実装開始: ${featureDescription} ${issueNumber}`);
+
+phase("Design");
+const design = await agent(
+  `機能: "${featureDescription}" ${issueNumber ? `(${issueNumber})` : ""}\n\n` +
+  `現在のコードベースを分析して、この機能の実装設計を行ってください:\n` +
+  `1. アーキテクチャ概要（どのファイルをどう変更するか）\n` +
+  `2. Backend タスクリスト（API/DB/ビジネスロジック）\n` +
+  `3. Frontend タスクリスト（UI/UX/状態管理）\n` +
+  `4. テストタスクリスト（Unit/Integration/E2E）\n` +
+  `各タスクは独立して実装できる粒度に分解してください。`,
+  { label: "design:architect", phase: "Design", schema: DESIGN_SCHEMA }
+);
+
+if (!design) {
+  log("❌ 設計フェーズ失敗");
+  return { error: "Design phase failed" };
+}
+
+log(`📐 設計完了 → Backend ${design.backend_tasks.length}タスク / Frontend ${design.frontend_tasks.length}タスク / Test ${design.test_tasks.length}タスク`);
+
+phase("Implement");
+const [backendResult, frontendResult, testResult] = await parallel([
+  () => agent(
+    `機能: "${featureDescription}"\n\n` +
+    `担当: Backend 実装\n` +
+    `アーキテクチャ: ${design.architecture}\n\n` +
+    `実装タスク:\n${design.backend_tasks.map((t, i) => `${i+1}. ${t}`).join("\n")}\n\n` +
+    `変更ファイル候補: ${design.files_to_modify?.join(", ")}\n` +
+    `上記タスクを実装してください。テストは test チームが担当するので、ロジック実装に集中してください。`,
+    { label: "impl:backend", phase: "Implement" }
+  ),
+  () => agent(
+    `機能: "${featureDescription}"\n\n` +
+    `担当: Frontend 実装\n` +
+    `アーキテクチャ: ${design.architecture}\n\n` +
+    `実装タスク:\n${design.frontend_tasks.map((t, i) => `${i+1}. ${t}`).join("\n")}\n\n` +
+    `上記タスクを実装してください。Backend API は別チームが実装します。型定義・インターフェースを先に定義して進めてください。`,
+    { label: "impl:frontend", phase: "Implement" }
+  ),
+  () => agent(
+    `機能: "${featureDescription}"\n\n` +
+    `担当: テスト実装\n` +
+    `アーキテクチャ: ${design.architecture}\n\n` +
+    `テストタスク:\n${design.test_tasks.map((t, i) => `${i+1}. ${t}`).join("\n")}\n\n` +
+    `テストを先行実装（TDD）してください。実装コードが未完成でもテストは書けます。モックを活用し、インターフェースに対してテストを書いてください。`,
+    { label: "impl:test", phase: "Implement" }
+  ),
+]);
+
+phase("Integrate");
+const integration = await agent(
+  `機能 "${featureDescription}" の実装が完了しました。統合確認を行ってください:\n\n` +
+  `1. git diff --stat で変更ファイルを確認\n` +
+  `2. テストを実行して全件通過を確認\n` +
+  `3. lint/typecheck を実行\n` +
+  `4. CI 状態を確認（gh run list --limit 3）\n` +
+  `5. PR 作成準備（変更内容・テスト結果・影響範囲をまとめる）\n\n` +
+  `問題があれば修正してください。`,
+  { label: "integrate:verify", phase: "Integrate" }
+);
+
+return {
+  design,
+  implementation: { backend: backendResult, frontend: frontendResult, tests: testResult },
+  integration,
+};

--- a/Claude/templates/claude/workflows/gate-verification-sweep.js
+++ b/Claude/templates/claude/workflows/gate-verification-sweep.js
@@ -1,0 +1,264 @@
+// gate-verification-sweep — 検証チェックリスト全項目を「1項目=1検証」で並列スイープ
+// ---------------------------------------------------------------------------
+// 出典: dynamic workflows "Memory & Rule Adherence / rule-verifier" パターン
+//   (Thariq Shihipar & Sid Bidasaria, 2026-06-02
+//    "A harness for every task: dynamic workflows in Claude Code")
+//
+// 対象: Claude/templates/claudeos/docs/webui-full-verification-checklist.md (250項目)
+// 目的: webui-full-verification-checklist の Gate-1/2/3 を人手に頼らず並列検証し、
+//       CLAUDE.md §11 の終了報告「必須3区分」(実行した検証/未実行/未実行理由) を自動生成する。
+//
+// 使い方:
+//   /gate-verification-sweep                                   (gate-1 既定)
+//   args 例: { "gate": "gate-3", "skipConditions": ["no_mobile_support","no_PWA"],
+//              "batchSize": 8, "appUrl": "http://localhost:3737" }
+//
+//   gate     : "gate-1" | "gate-2" | "gate-3" | "all"  (既定 gate-1)
+//   batchSize: 1検証エージェントが担当する項目数        (既定 10。1 で完全 1:1)
+//   skipConditions: このプロジェクトで真の skip_if キーワード配列 (例 no_mobile_support)
+//   changedFilesHint: gate-2 用。変更ファイルパス配列 (近傍項目の判定に使用)
+//   appUrl   : E2E/Playwright 項目で叩く起動済み URL (無ければ E2E は not_run)
+//   checklistPath: チェックリストのパス上書き (既定: 自動探索)
+// ---------------------------------------------------------------------------
+
+export const meta = {
+  name: "gate-verification-sweep",
+  description: "検証チェックリスト全項目を1項目=1検証エージェントで並列スイープし、終了報告3区分(実行/未実行/未実行理由)を自動生成",
+  phases: [
+    { title: "Preflight",  detail: "共有の自動チェック(lint/build/typecheck/test/security)を1回だけ実行" },
+    { title: "Parse",      detail: "チェックリストを解析し Gate で対象項目を絞り込み" },
+    { title: "Verify",     detail: "項目バッチごとに検証エージェントが並列で実検証" },
+    { title: "Synthesize", detail: "終了報告3区分レポート + STABLE ゲート判定を生成" },
+  ],
+};
+
+// --- スキーマ定義 ----------------------------------------------------------
+
+const PREFLIGHT_SCHEMA = {
+  type: "object",
+  required: ["checks"],
+  properties: {
+    checks: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["name", "status", "summary"],
+        properties: {
+          name:    { type: "string" },                                   // lint/build/typecheck/unit/security/e2e
+          command: { type: "string" },                                   // 実行コマンド (無ければ空)
+          status:  { type: "string", enum: ["pass", "fail", "skip", "not_available"] },
+          summary: { type: "string" },                                   // 結果要約 (失敗時は要点)
+        },
+      },
+    },
+  },
+};
+
+const PARSE_SCHEMA = {
+  type: "object",
+  required: ["gate", "total_in_file", "selected", "items"],
+  properties: {
+    gate:          { type: "string" },
+    total_in_file: { type: "number" },
+    selected:      { type: "number" },
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["num", "name", "mandatory", "method", "timing", "skip_if", "skip_planned"],
+        properties: {
+          num:           { type: "number" },
+          name:          { type: "string" },
+          mandatory:     { type: "string", enum: ["必須", "条件", "任意"] },
+          method:        { type: "string" },                             // 自動/半自動/目視
+          timing:        { type: "string" },                             // PR/merge/nightly/release/incident
+          evidence_type: { type: "string" },
+          skip_if:       { type: "string" },
+          skip_planned:  { type: "boolean" },                            // skipConditions により事前スキップ確定
+        },
+      },
+    },
+  },
+};
+
+const VERIFY_SCHEMA = {
+  type: "object",
+  required: ["results"],
+  properties: {
+    results: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["num", "name", "status", "evidence", "reason"],
+        properties: {
+          num:      { type: "number" },
+          name:     { type: "string" },
+          status:   { type: "string", enum: ["pass", "fail", "skip", "not_run", "blocked"] },
+          evidence: { type: "string" },   // コマンド出力要約 / file:line / screenshot パス
+          reason:   { type: "string" },   // skip/not_run/fail/blocked では必須。pass では空可
+        },
+      },
+    },
+  },
+};
+
+// --- 入力 ------------------------------------------------------------------
+
+const gate          = (args?.gate || "gate-1").toLowerCase();
+const batchSize     = Math.max(1, Number(args?.batchSize) || 10);
+const skipConditions = Array.isArray(args?.skipConditions) ? args.skipConditions : [];
+const changedFiles  = Array.isArray(args?.changedFilesHint) ? args.changedFilesHint : [];
+const appUrl        = args?.appUrl || "";
+const checklistPath = args?.checklistPath || "";
+
+// gate ごとの選別ルール (Parse エージェントへ渡す自然言語仕様)
+const GATE_RULES = {
+  "gate-1": "必須度=「必須」かつ タイミング=「PR」 の項目のみ選別。",
+  "gate-2": "(必須度=「必須」かつ タイミング∈{PR,merge}) に加え、主要回帰項目 #1・#22・#31・#51・#71・#111・#131・#141・#231〜#241 を必ず含める。" +
+            (changedFiles.length ? ` さらに変更ファイル [${changedFiles.join(", ")}] に関連する項目も含める。` : ""),
+  "gate-3": "必須度∈{「必須」,「条件」} の全項目を選別 (release スイープ)。「任意」は除外。",
+  "all":    "全250項目を選別。",
+};
+const gateRule = GATE_RULES[gate] || GATE_RULES["gate-1"];
+
+log(`🧪 Gate 検証スイープ開始 — gate=${gate} / batchSize=${batchSize}`);
+if (skipConditions.length) log(`⏭ 事前スキップ条件: ${skipConditions.join(", ")}`);
+if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);
+
+// --- Phase 1: Preflight (共有自動チェックを1回だけ) ------------------------
+
+phase("Preflight");
+const preflight = await agent(
+  `このプロジェクトの標準的な自動品質チェックを「1回だけ」実行し、結果を構造化して返してください。\n` +
+  `package.json があれば scripts (lint/build/typecheck/test 等) を確認して実行。\n` +
+  `PowerShell 主体なら PSScriptAnalyzer / Pester、Node なら npm audit、Python なら対応ツールを使用。\n` +
+  `各チェックは name(lint/build/typecheck/unit/security/e2e 等)・command・status(pass/fail/skip/not_available)・summary を返す。\n` +
+  `存在しないチェックは status=not_available とし、無理に実行しないこと。これは後続の各項目検証で共有する基準値です。`,
+  { label: "preflight:auto-checks", phase: "Preflight", schema: PREFLIGHT_SCHEMA }
+);
+const preflightText = (preflight?.checks || [])
+  .map(c => `- ${c.name} [${c.status}] ${c.command ? `(${c.command}) ` : ""}${c.summary}`)
+  .join("\n") || "(自動チェック結果なし)";
+log(`✅ Preflight 完了: ${(preflight?.checks || []).length} 種`);
+
+// --- Phase 2: Parse (チェックリスト解析 + Gate 絞り込み) -------------------
+
+phase("Parse");
+const parsed = await agent(
+  `検証チェックリストを読み、対象項目を構造化して返してください。\n\n` +
+  `【手順】\n` +
+  `1. チェックリストを探して読む: ${checklistPath ? `パス "${checklistPath}"` :
+     `Glob "**/webui-full-verification-checklist.md" で探索し、.claude/claudeos/docs/ 配下を優先`}。\n` +
+  `2. 各セクションの表 (列: # / 項目名 / 必須度 / 実行方法 / 担当Agent / タイミング / 証跡 / skip_if) を全行パースする。\n` +
+  `3. 次の Gate ルールで選別する: ${gateRule}\n` +
+  `4. 選別した各項目について、skip_if 値が次の事前スキップ条件配列 [${skipConditions.join(", ") || "なし"}] に含まれる場合は skip_planned=true とする (それ以外は false)。\n` +
+  `5. total_in_file=ファイル内総項目数、selected=選別後件数、items=選別項目配列 を返す。\n` +
+  `項目数が多い。要約せず、選別対象は1件も省略しないこと。`,
+  { label: `parse:${gate}`, phase: "Parse", schema: PARSE_SCHEMA }
+);
+
+const items = (parsed?.items || []).filter(it => it && typeof it.num === "number");
+log(`📋 解析完了: ファイル総数 ${parsed?.total_in_file ?? "?"} → ${gate} 選別 ${items.length} 件`);
+
+if (items.length === 0) {
+  log("⚠️ 対象項目が0件です。gate / checklistPath を確認してください。");
+  return { gate, selected: 0, summary: "対象項目なし", report: "選別された検証項目がありませんでした。" };
+}
+
+// --- Phase 3: Verify (バッチごとに並列実検証) ------------------------------
+
+function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+const batches = chunk(items, batchSize);
+log(`🔁 検証バッチ ${batches.length} 個 (${batchSize}項目/バッチ) を並列スイープ`);
+
+const verifyOut = await pipeline(
+  batches,
+  (batch, _orig, idx) => agent(
+    `以下の検証項目バッチを「1項目ずつ実際に検証」してください。手抜き・一括 pass・捏造は厳禁です。\n\n` +
+    `【共有 Preflight 結果 (自動チェックの基準値)】\n${preflightText}\n\n` +
+    `${appUrl ? `【E2E/Playwright 用 URL】${appUrl} ← このアプリは起動済み・到達確認済み。\n` +
+      `  画面操作が要る項目は Playwright MCP で「この URL に直接 navigate」して実検証すること。\n` +
+      `  自前でサーバを起動し直さない (ポート不一致・二重起動の原因)。実際に使った URL を evidence に必ず残す。\n` +
+      `  ${appUrl} が万一到達不能な場合のみ、起動コマンドとポートを evidence に明記した上で起動してよい。\n` +
+      `  not_run にできるのは Playwright MCP 自体が使えない時、または E2E spec/ツールチェーンが repo に存在しない時に限る。\n\n`
+      : `【E2E/Playwright】起動 URL 未指定。画面実操作が必要な項目はコードを確認のうえ not_run + 理由とすること。\n\n`}` +
+    `【検証対象 (${batch.length}件)】\n${JSON.stringify(batch, null, 2)}\n\n` +
+    `【各項目の status 判定基準】\n` +
+    `- pass    : 実際に検証して問題なし。evidence にコマンド出力要約 / file:line / screenshot パス等の証跡を必ず記載。\n` +
+    `- fail    : 検証して問題を確認。reason に何がどう失敗したかを記載。\n` +
+    `- skip    : skip_planned=true、または skip_if 条件がこのプロジェクトで真。reason に該当条件を記載。\n` +
+    `- not_run : この環境で検証不能 (人間の目視 / Staging / 実機 / 外部サービス依存等)。reason に不能理由を記載。\n` +
+    `- blocked : 依存先の不具合で検証できない。reason に依存先を記載。\n\n` +
+    `【厳守】証跡なく pass にしない。判断できなければ not_run + 正直な理由。自動項目は Preflight 結果を証跡に引用してよい。\n` +
+    `Read/Grep/Bash 等で実際にコード・設定・コマンド結果を確認してから判定すること。`,
+    { label: `verify:batch${idx + 1}/${batches.length}`, phase: "Verify", schema: VERIFY_SCHEMA }
+  ).then(r => (r?.results || []))
+);
+
+const results = verifyOut.filter(Boolean).flat();
+
+// --- 集計 (JS 側で確定。エージェントの自己申告に依存しない) ----------------
+
+const byStatus = { pass: [], fail: [], skip: [], not_run: [], blocked: [] };
+for (const r of results) (byStatus[r.status] || byStatus.not_run).push(r);
+
+const itemByNum = new Map(items.map(it => [it.num, it]));
+const mandatoryFail = byStatus.fail.filter(r => itemByNum.get(r.num)?.mandatory === "必須");
+const mandatoryNotRun = byStatus.not_run.filter(r => itemByNum.get(r.num)?.mandatory === "必須");
+const mandatoryBlocked = byStatus.blocked.filter(r => itemByNum.get(r.num)?.mandatory === "必須");
+
+// STABLE ゲート: 必須項目に fail/blocked が無く、未検証(必須)が無いこと
+const gatePassed = mandatoryFail.length === 0 && mandatoryBlocked.length === 0 && mandatoryNotRun.length === 0;
+
+// 検証確定 (pass+fail) のうち pass の割合。not_run/skip は分母から除外し「実検証の質」を示す
+const decided = byStatus.pass.length + byStatus.fail.length;
+const verifiedPassRate = decided ? Math.round((byStatus.pass.length / decided) * 100) : 0;
+
+const counts = {
+  selected: items.length,
+  verified: results.length,
+  pass: byStatus.pass.length,
+  fail: byStatus.fail.length,
+  skip: byStatus.skip.length,
+  not_run: byStatus.not_run.length,
+  blocked: byStatus.blocked.length,
+  verified_pass_rate: verifiedPassRate,
+  mandatory_fail: mandatoryFail.length,
+  mandatory_not_run: mandatoryNotRun.length,
+  mandatory_blocked: mandatoryBlocked.length,
+  gate_passed: gatePassed,
+};
+
+log(`📊 検証結果: ✅${counts.pass} ❌${counts.fail} ⏭${counts.skip} ⬜${counts.not_run} 🚧${counts.blocked} / 実検証合格率 ${verifiedPassRate}% / STABLE-Gate=${gatePassed ? "PASS" : "FAIL"}`);
+
+// --- Phase 4: Synthesize (終了報告3区分レポート) --------------------------
+
+phase("Synthesize");
+const report = await agent(
+  `以下の Gate 検証スイープ結果を、CLAUDE.md §11「終了報告の必須3区分」形式の日本語レポートにまとめてください。\n\n` +
+  `gate=${gate} / 選別 ${counts.selected} 件 / 検証 ${counts.verified} 件\n` +
+  `✅pass=${counts.pass} ❌fail=${counts.fail} ⏭skip=${counts.skip} ⬜not_run=${counts.not_run} 🚧blocked=${counts.blocked} / 実検証合格率=${verifiedPassRate}%\n` +
+  `必須項目の未達: fail=${counts.mandatory_fail} not_run=${counts.mandatory_not_run} blocked=${counts.mandatory_blocked}\n` +
+  `STABLE ゲート判定: ${gatePassed ? "PASS (必須項目すべて検証済み)" : "FAIL (必須項目に未達あり → merge/deploy 不可)"}\n\n` +
+  `全結果:\n${JSON.stringify(results, null, 2)}\n\n` +
+  `【出力フォーマット (この見出しを厳守)】\n` +
+  `## 🧪 Gate 検証サマリー (${gate})\n` +
+  `📊 ゲート判定: ${gatePassed ? "✅ PASS" : "❌ FAIL"}\n` +
+  `### ✅ 実行した検証（件数・証跡）\n` +
+  `  pass/fail 項目を番号・項目名・証跡付きで列挙。\n` +
+  `### ⬜ 未実行の検証（件数・項目番号）\n` +
+  `  not_run/blocked/skip 項目を番号で列挙。skip と not_run は区別する。\n` +
+  `### 📝 未実行理由\n` +
+  `  項目番号ごとに not_run/blocked/skip の理由を記載。\n` +
+  `### ❌ 要対応 (fail / 必須未達)\n` +
+  `  fail と 必須項目の not_run/blocked を最優先課題として列挙。無ければ「なし」。`,
+  { label: "synthesize:report", phase: "Synthesize" }
+);
+
+log(gatePassed ? "🎉 STABLE-Gate PASS" : "⚠️ STABLE-Gate FAIL — 必須項目に未達あり");
+
+return { gate, counts, summary: `gate=${gate} pass=${counts.pass}/${counts.verified} STABLE-Gate=${gatePassed ? "PASS" : "FAIL"}`, report, results };

--- a/Claude/templates/claude/workflows/issue-triage.js
+++ b/Claude/templates/claude/workflows/issue-triage.js
@@ -1,0 +1,173 @@
+// issue-triage — GitHub Issue を大規模分類・重複除去・アクション提案
+// ---------------------------------------------------------------------------
+// 出典: dynamic workflows "Triage at Scale" パターン
+//   (Thariq Shihipar & Sid Bidasaria, 2026-06-02)
+//
+// 用途: open Issue を分類 (P1/P2/P3・カテゴリ)、既存との重複を検出、
+//       ラベル付け/重複クローズ/エスカレーションのアクションを提案する。
+//       ClaudeOS の Issue Factory / Agent Communication Protocol を補完。
+//
+// 安全既定: apply=false (提案のみ。Issue は変更しない)。
+//           apply=true でラベル付けのみ実行 (クローズは安全のため常に提案止まり)。
+//
+// 使い方:
+//   /issue-triage
+//   args 例: { "limit": 50, "batchSize": 8, "apply": false }
+// ---------------------------------------------------------------------------
+
+export const meta = {
+  name: "issue-triage",
+  description: "open GitHub Issue を分類・重複除去・アクション提案 (既定 dry-run・apply でラベル付けのみ実行)",
+  phases: [
+    { title: "Fetch",      detail: "open Issue を取得" },
+    { title: "Classify",   detail: "バッチ単位で優先度・カテゴリ・重複候補を分類" },
+    { title: "Synthesize", detail: "重複統合 + アクション計画レポート" },
+  ],
+};
+
+const FETCH_SCHEMA = {
+  type: "object",
+  required: ["issues", "total"],
+  properties: {
+    total: { type: "number" },
+    issues: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["number", "title"],
+        properties: {
+          number:       { type: "number" },
+          title:        { type: "string" },
+          labels:       { type: "array", items: { type: "string" } },
+          created:      { type: "string" },
+          body_excerpt: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+const CLASSIFY_SCHEMA = {
+  type: "object",
+  required: ["results"],
+  properties: {
+    results: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["number", "priority", "category", "suggested_labels", "action", "reasoning"],
+        properties: {
+          number:               { type: "number" },
+          priority:             { type: "string", enum: ["P1", "P2", "P3"] },
+          category:             { type: "string" },   // ci/security/quality/ux/docs/infra 等
+          suggested_labels:     { type: "array", items: { type: "string" } },
+          possible_duplicate_of:{ type: "number" },    // 重複候補の Issue 番号 (無ければ 0)
+          action:               { type: "string", enum: ["triage", "close-dup", "escalate", "needs-info"] },
+          reasoning:            { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+const limit     = Math.max(1, Number(args?.limit) || 50);
+const batchSize  = Math.max(1, Number(args?.batchSize) || 8);
+const apply     = args?.apply === true;
+
+log(`📋 issue-triage — ${apply ? "⚡ APPLY (ラベル付けのみ)" : "🔍 DRY-RUN (提案のみ)"} / limit=${limit}`);
+if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);
+
+// --- Phase 1: Fetch --------------------------------------------------------
+
+phase("Fetch");
+const fetched = await agent(
+  `gh issue list --state open --limit ${limit} --json number,title,labels,createdAt,body を実行し、` +
+  `open Issue を取得して構造化してください。body_excerpt は先頭 200 字程度に要約。` +
+  `agent-msg 等の運用メッセージ Issue も含めて全件返す。total も返す。`,
+  { label: "fetch", phase: "Fetch", schema: FETCH_SCHEMA }
+);
+const issues = (fetched?.issues || []).filter(i => i && typeof i.number === "number");
+log(`📥 open Issue ${issues.length} 件取得`);
+
+if (issues.length === 0) {
+  log("✅ open Issue なし — triage 不要");
+  return { total: 0, classified: [], report: "open Issue はありませんでした。" };
+}
+
+// --- Phase 2: Classify (バッチ並列) ----------------------------------------
+
+function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+const batches = chunk(issues, batchSize);
+
+phase("Classify");
+log(`🔁 ${batches.length} バッチで分類 (全 Issue リストを各バッチへ渡し重複検出を可能にする)`);
+
+const allTitles = issues.map(i => `#${i.number} ${i.title}`).join("\n");
+const classifiedOut = await pipeline(
+  batches,
+  (batch, _o, idx) => agent(
+    `以下の Issue バッチを分類してください。\n\n` +
+    `【分類対象 (${batch.length}件)】\n${JSON.stringify(batch, null, 2)}\n\n` +
+    `【全 open Issue 一覧 (重複候補判定用)】\n${allTitles}\n\n` +
+    `各 Issue に対し:\n` +
+    `- priority: P1(CI/セキュリティ/データ影響) / P2(品質/UX/テスト) / P3(軽微)\n` +
+    `- category: ci/security/quality/ux/docs/infra/agent-msg 等\n` +
+    `- suggested_labels: 付与推奨ラベル\n` +
+    `- possible_duplicate_of: 重複と思われる別 Issue 番号 (無ければ 0)\n` +
+    `- action: triage(通常) / close-dup(重複) / escalate(緊急) / needs-info(情報不足)\n` +
+    `必要なら gh issue view で本文を確認すること。`,
+    { label: `classify:batch${idx + 1}/${batches.length}`, phase: "Classify", schema: CLASSIFY_SCHEMA }
+  ).then(r => (r?.results || []))
+);
+const classified = classifiedOut.filter(Boolean).flat();
+
+const byPrio = { P1: [], P2: [], P3: [] };
+for (const c of classified) (byPrio[c.priority] || byPrio.P3).push(c);
+const dups = classified.filter(c => c.possible_duplicate_of && c.possible_duplicate_of > 0);
+log(`📊 分類: P1=${byPrio.P1.length} P2=${byPrio.P2.length} P3=${byPrio.P3.length} / 重複候補 ${dups.length} 件`);
+
+// --- Phase 2b: ラベル付け (apply 時のみ) -----------------------------------
+
+let labelResult = { applied: 0, note: "apply=false のためラベル付けなし" };
+if (apply) {
+  const withLabels = classified.filter(c => (c.suggested_labels || []).length > 0);
+  const labeled = await pipeline(
+    withLabels,
+    (c) => agent(
+      `Issue #${c.number} に対し、既存ラベルと矛盾しない範囲で次のラベルを ` +
+      `gh issue edit ${c.number} --add-label でラベル付けしてください: ${c.suggested_labels.join(", ")}\n` +
+      `存在しないラベルは作らず skip。結果を "added: <labels>" か "skipped: <reason>" で1行返す。` +
+      `クローズや本文編集は行わないこと。`,
+      { label: `label:#${c.number}`, phase: "Classify" }
+    )
+  );
+  labelResult = { applied: labeled.filter(Boolean).length, note: "ラベル付けのみ実行 (クローズは提案止まり)" };
+  log(`🏷 ラベル付け ${labelResult.applied} 件`);
+}
+
+// --- Phase 3: Synthesize ---------------------------------------------------
+
+phase("Synthesize");
+const report = await agent(
+  `Issue triage 結果を日本語レポートにまとめてください。\n\n` +
+  `総数 ${issues.length} / P1=${byPrio.P1.length} P2=${byPrio.P2.length} P3=${byPrio.P3.length} / 重複候補 ${dups.length}\n` +
+  `モード: ${apply ? "APPLY (ラベル付け済)" : "DRY-RUN (提案のみ)"}\n\n` +
+  `分類結果:\n${JSON.stringify(classified, null, 2)}\n\n` +
+  `レポート構成: ## Triage サマリー / ### 🔴 P1 (即対応) / ### 🟡 P2 / ### ⚪ P3 / ` +
+  `### 重複候補 (close-dup 提案) / ### 情報不足 (needs-info) / ### 次アクション。` +
+  `重複候補は「#X は #Y の重複」の形で明示し、クローズは提案として記載 (自動クローズしない)。`,
+  { label: "synthesize", phase: "Synthesize" }
+);
+
+return {
+  total: issues.length,
+  apply,
+  counts: { P1: byPrio.P1.length, P2: byPrio.P2.length, P3: byPrio.P3.length, duplicates: dups.length },
+  labelResult,
+  classified,
+  report,
+};

--- a/Claude/templates/claude/workflows/migration-sweep.js
+++ b/Claude/templates/claude/workflows/migration-sweep.js
@@ -1,0 +1,213 @@
+// migration-sweep — コードベース横断の移行/リファクタを discover → transform → verify
+// ---------------------------------------------------------------------------
+// 出典: dynamic workflows "Migrations & Refactors" パターン
+//   (Thariq Shihipar & Sid Bidasaria, 2026-06-02)
+//
+// 用途: SSH 名残削除・API 名称変更・依存差し替え等、多数のサイトに散らばる
+//       機械的だが文脈依存の移行を、ファイル単位エージェントで並列適用する。
+//
+// 安全既定: apply=false (discover + 変更案レポートのみ。実ファイルは触らない)。
+//           apply=true で実編集。プロジェクト全体の --dry-run/--apply 規約に準拠。
+//
+// 使い方:
+//   /migration-sweep            (args 必須。下記)
+//   args 例: {
+//     "description": "SSH 経由実行を Windows ローカル実行へ置換",
+//     "find": "ssh |Invoke-SSH|linuxHost",     // 対象サイトの検索語/正規表現
+//     "globs": ["scripts/**/*.ps1","scripts/**/*.js"],  // 走査スコープ
+//     "verifyCmd": "node --check",              // 変換後の検証 (任意)
+//     "apply": false                            // true で実編集
+//   }
+// ---------------------------------------------------------------------------
+
+export const meta = {
+  name: "migration-sweep",
+  description: "コードベース横断の移行/リファクタを discover→transform→verify で並列実行 (既定 dry-run・apply で実適用)",
+  phases: [
+    { title: "Discover",  detail: "移行対象サイトを横断検索しファイル単位に集約" },
+    { title: "Transform", detail: "ファイル単位エージェントが変換 (apply 時のみ実編集)" },
+    { title: "Verify",    detail: "検証コマンド実行 + 変更レビュー + レポート生成" },
+  ],
+};
+
+const DISCOVER_SCHEMA = {
+  type: "object",
+  required: ["files", "total_files", "total_sites"],
+  properties: {
+    total_files: { type: "number" },
+    total_sites: { type: "number" },
+    files: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["path", "occurrences", "sites"],
+        properties: {
+          path:        { type: "string" },
+          occurrences: { type: "number" },
+          sites: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["line", "snippet", "reason"],
+              properties: {
+                line:    { type: "number" },
+                snippet: { type: "string" },
+                reason:  { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const TRANSFORM_SCHEMA = {
+  type: "object",
+  required: ["path", "status", "changes", "note"],
+  properties: {
+    path:   { type: "string" },
+    status: { type: "string", enum: ["transformed", "planned", "skipped", "failed"] },
+    changes: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["line", "before", "after"],
+        properties: {
+          line:   { type: "number" },
+          before: { type: "string" },
+          after:  { type: "string" },
+        },
+      },
+    },
+    note: { type: "string" },
+  },
+};
+
+const VERIFY_SCHEMA = {
+  type: "object",
+  required: ["status", "summary"],
+  properties: {
+    status:  { type: "string", enum: ["pass", "fail", "skip"] },
+    summary: { type: "string" },
+  },
+};
+
+// --- 入力 ------------------------------------------------------------------
+
+const description = args?.description || "";
+const find        = args?.find || "";
+const globs       = Array.isArray(args?.globs) ? args.globs : [];
+const verifyCmd   = args?.verifyCmd || "";
+const apply       = args?.apply === true;
+
+if (!description || !find) {
+  log("⚠️ args.description と args.find は必須です。中止します。");
+  return { error: "args.description と args.find が必要", description, find };
+}
+
+log(`🔧 migration-sweep — ${apply ? "⚡ APPLY (実編集)" : "🔍 DRY-RUN (変更案のみ)"}`);
+log(`🎯 目標: ${description}`);
+log(`🔎 検索: ${find}${globs.length ? ` / scope: ${globs.join(", ")}` : ""}`);
+if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);
+
+// --- Phase 1: Discover -----------------------------------------------------
+
+phase("Discover");
+const discovered = await agent(
+  `移行対象サイトを横断検索してファイル単位に集約してください。\n\n` +
+  `【移行目標】${description}\n` +
+  `【検索語/正規表現】${find}\n` +
+  `【走査スコープ】${globs.length ? globs.join(", ") : "リポジトリ全体 (node_modules/.git/dist は除外)"}\n\n` +
+  `Grep/Glob で全該当箇所を洗い出し、ファイルごとに occurrences と sites(line/snippet/該当理由) を集約。\n` +
+  `移行目標に照らして「変更すべき箇所」のみ含める (誤検知・コメント内の無関係一致は除外)。\n` +
+  `1件も省略せず、total_files / total_sites も返すこと。`,
+  { label: "discover", phase: "Discover", schema: DISCOVER_SCHEMA }
+);
+
+const files = (discovered?.files || []).filter(f => f && f.path);
+log(`📋 発見: ${discovered?.total_files ?? files.length} ファイル / ${discovered?.total_sites ?? "?"} サイト`);
+
+if (files.length === 0) {
+  log("✅ 対象サイトなし — 移行不要、または検索語の見直しが必要");
+  return { apply, discovered: { total_files: 0, total_sites: 0 }, transformed: [], summary: "対象サイトなし" };
+}
+
+// --- Phase 2: Transform (ファイル単位・並列) -------------------------------
+// ファイル単位に分離しているため同一ファイルの並列編集衝突は起きない。
+// worktree 隔離は使わない (変更を本ブランチへ着地させるため)。
+
+phase("Transform");
+log(`🔁 ${files.length} ファイルを${apply ? "変換" : "変換案作成"} (並列)`);
+
+const transformed = await pipeline(
+  files,
+  (f) => agent(
+    `次の1ファイルだけを移行対象として扱ってください (他ファイルには触れない)。\n\n` +
+    `【移行目標】${description}\n` +
+    `【対象ファイル】${f.path}\n` +
+    `【該当サイト】\n${JSON.stringify(f.sites, null, 2)}\n\n` +
+    (apply
+      ? `【APPLY モード】実際に Edit/Write でこのファイルを編集してください。\n` +
+        `- 周辺コードのスタイル・命名・コメント密度に合わせる\n` +
+        `- 挙動を変えない (純粋な移行)。判断に迷う箇所は編集せず note に残す\n` +
+        `- 編集後に node --check 等で壊れていないか確認\n` +
+        `- 実施した変更を changes(line/before/after) に列挙し status=transformed\n` +
+        `- 変更不要だった場合 status=skipped`
+      : `【DRY-RUN モード】ファイルは編集しないでください。\n` +
+        `- 各サイトの変更案を changes(line/before/after) として提示\n` +
+        `- status=planned (変更案あり) / skipped (変更不要)\n` +
+        `- リスク・要確認点は note に記載`) +
+    `\nファイルを Read で実際に確認してから判断すること。`,
+    { label: `${apply ? "apply" : "plan"}:${f.path.split(/[\\/]/).pop()}`, phase: "Transform", schema: TRANSFORM_SCHEMA }
+  )
+);
+
+const results = transformed.filter(Boolean);
+const tStatus = { transformed: [], planned: [], skipped: [], failed: [] };
+for (const r of results) (tStatus[r.status] || tStatus.failed).push(r);
+const changedCount = (apply ? tStatus.transformed : tStatus.planned).length;
+const totalChanges = results.reduce((n, r) => n + (r.changes?.length || 0), 0);
+log(`📊 ${apply ? "変換" : "変換案"}: ${changedCount} ファイル / 変更 ${totalChanges} 箇所 / skip ${tStatus.skipped.length} / failed ${tStatus.failed.length}`);
+
+// --- Phase 3: Verify -------------------------------------------------------
+
+phase("Verify");
+let verify = { status: "skip", summary: "apply=false のため検証スキップ" };
+
+if (apply && (tStatus.transformed.length > 0)) {
+  verify = await agent(
+    `移行適用後の検証をしてください。\n\n` +
+    `【移行目標】${description}\n` +
+    `【変更ファイル】${tStatus.transformed.map(r => r.path).join(", ")}\n` +
+    (verifyCmd ? `【検証コマンド】${verifyCmd} を変更ファイルに対して実行し結果を確認。\n` : `【検証】変更ファイルを node --check / 対応 linter 等で確認。\n`) +
+    `さらに git diff を確認し、移行目標から外れた変更・残し漏れ・壊れた構文が無いか adversarial に点検。\n` +
+    `status(pass/fail/skip) と summary を返す。`,
+    { label: "verify", phase: "Verify", schema: VERIFY_SCHEMA }
+  ) || verify;
+  log(`🧪 検証: ${verify.status} — ${verify.summary}`);
+}
+
+// --- レポート --------------------------------------------------------------
+
+const report = await agent(
+  `移行スイープ結果を日本語レポートにまとめてください。\n\n` +
+  `モード: ${apply ? "APPLY (実編集済)" : "DRY-RUN (変更案のみ)"}\n` +
+  `目標: ${description}\n` +
+  `発見: ${files.length} ファイル / ${discovered?.total_sites ?? "?"} サイト\n` +
+  `${apply ? "変換" : "変換案"}: ${changedCount} ファイル / 変更 ${totalChanges} 箇所 / skip ${tStatus.skipped.length} / failed ${tStatus.failed.length}\n` +
+  `検証: ${verify.status} — ${verify.summary}\n\n` +
+  `詳細:\n${JSON.stringify(results, null, 2)}\n\n` +
+  `レポート構成: ## 移行サマリー / ### 変更ファイル一覧 / ### 要確認・スキップ / ### 次アクション` +
+  `${apply ? "" : " (apply=true で実適用する手順を含める)"}。`,
+  { label: "report", phase: "Verify" }
+);
+
+return {
+  apply,
+  discovered: { total_files: files.length, total_sites: discovered?.total_sites },
+  counts: { changed: changedCount, total_changes: totalChanges, skipped: tStatus.skipped.length, failed: tStatus.failed.length },
+  verify,
+  transformed: results,
+  report,
+};

--- a/Claude/templates/claude/workflows/rule-distillation.js
+++ b/Claude/templates/claude/workflows/rule-distillation.js
@@ -1,0 +1,178 @@
+// rule-distillation — セッション/レビュー/履歴から運用ルールを蒸留 (提案のみ)
+// ---------------------------------------------------------------------------
+// 出典: dynamic workflows "Memory & Rule Adherence" パターン
+//   (Thariq Shihipar & Sid Bidasaria, 2026-06-02)
+//
+// 用途: reasoning-bank・git 履歴・CodeRabbit/Codex 指摘・MEMORY.md を横断マイニングし、
+//       繰り返し現れる是正をクラスタ化→反証検証→生き残りを CLAUDE.md/MEMORY.md 追記案へ蒸留。
+//       ClaudeOS の EvolutionManager / self-evolution を支援する。
+//
+// 重要: CLAUDE.md §18 (CLAUDE.md/settings.json/hooks の自己書換禁止) を尊重し、
+//       本 workflow は **常に提案のみ** (ファイルは編集しない)。採用は人間が判断する。
+//
+// 使い方:
+//   /rule-distillation
+//   args 例: { "lookback": 50, "target": "MEMORY.md" }
+//     lookback: 走査する直近 git コミット数 (既定 40)
+//     target  : 蒸留先の想定 ("MEMORY.md" | "CLAUDE.md")。既定 "MEMORY.md"
+// ---------------------------------------------------------------------------
+
+export const meta = {
+  name: "rule-distillation",
+  description: "セッション/レビュー/履歴から繰り返しの是正を蒸留し運用ルール追記案を生成 (提案のみ・自動適用なし)",
+  phases: [
+    { title: "Mine",     detail: "複数ソースを並列マイニングし候補ルールを抽出" },
+    { title: "Cluster",  detail: "候補を統合・重複排除" },
+    { title: "Verify",   detail: "各候補を adversarial 検証 (実在性・既出チェック)" },
+    { title: "Distill",  detail: "生存候補を追記案へ蒸留" },
+  ],
+};
+
+const MINE_SCHEMA = {
+  type: "object",
+  required: ["source", "candidates"],
+  properties: {
+    source: { type: "string" },
+    candidates: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["rule", "evidence", "frequency"],
+        properties: {
+          rule:      { type: "string" },   // 「〜すべき/〜してはいけない」形の運用ルール
+          evidence:  { type: "string" },   // 根拠 (コミット/指摘/パターンの引用)
+          frequency: { type: "number" },   // 観測回数の目安
+        },
+      },
+    },
+  },
+};
+
+const VERIFY_SCHEMA = {
+  type: "object",
+  required: ["rule", "is_real", "already_documented", "recommendation", "reasoning"],
+  properties: {
+    rule:               { type: "string" },
+    is_real:            { type: "boolean" },  // 本当に繰り返す是正か (一度きりの偶発でない)
+    already_documented: { type: "boolean" },  // 既に CLAUDE.md/MEMORY.md にあるか
+    recommendation:     { type: "string", enum: ["adopt", "merge", "drop"] },
+    reasoning:          { type: "string" },
+  },
+};
+
+const lookback = Math.max(5, Number(args?.lookback) || 40);
+const target   = args?.target === "CLAUDE.md" ? "CLAUDE.md" : "MEMORY.md";
+
+log(`🧬 rule-distillation — 提案のみ (自動適用なし) / target=${target} / lookback=${lookback}コミット`);
+if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);
+
+// --- Phase 1: Mine (ソース別並列) ------------------------------------------
+
+const SOURCES = [
+  {
+    key: "reasoning-bank",
+    prompt: `.claude/claudeos/data/reasoning-bank.json を読み、success_patterns / failure_patterns から ` +
+            `「今後こうすべき」という運用ルール候補を抽出してください。各候補に根拠と観測頻度を付ける。`,
+  },
+  {
+    key: "git-history",
+    prompt: `直近 ${lookback} コミット (git log -n ${lookback} --format=...) を確認し、` +
+            `「同種の修正が繰り返されている」パターン (例: 同じ種類の lint 修正・docs ドリフト修正・命名是正) を` +
+            `運用ルール候補として抽出してください。fix/revert が多いテーマは是正ルールの種。`,
+  },
+  {
+    key: "review-comments",
+    prompt: `CodeRabbit / Codex のレビュー指摘の痕跡 (reports/・PR コメント・コミットの "CodeRabbit"/"Codex" 言及) を` +
+            `gh / Grep で確認し、繰り返し指摘される観点を運用ルール候補として抽出してください。`,
+  },
+  {
+    key: "existing-memory",
+    prompt: `既存の MEMORY.md (memory ディレクトリ) と CLAUDE.md の feedback/禁止事項を読み、` +
+            `「既に明文化されている運用ルール」を列挙してください (後段の既出チェックの基準にする)。` +
+            `これらは新規候補ではなく "既出リスト" として rule に記し frequency は 0 とする。`,
+  },
+];
+
+phase("Mine");
+const mined = await parallel(
+  SOURCES.map(s => () => agent(s.prompt, { label: `mine:${s.key}`, phase: "Mine", schema: MINE_SCHEMA }))
+);
+const allCandidates = mined.filter(Boolean).flatMap(m => (m.candidates || []).map(c => ({ ...c, source: m.source })));
+log(`📋 候補 ${allCandidates.length} 件 (既出リスト含む) → クラスタリングへ`);
+
+if (allCandidates.length === 0) {
+  log("✅ 抽出候補なし");
+  return { target, proposals: "抽出された候補ルールはありませんでした。", candidates: [] };
+}
+
+// --- Phase 2: Cluster (統合・重複排除) -------------------------------------
+
+phase("Cluster");
+const CLUSTER_SCHEMA = {
+  type: "object",
+  required: ["clusters"],
+  properties: {
+    clusters: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["rule", "evidence", "frequency"],
+        properties: {
+          rule:      { type: "string" },
+          evidence:  { type: "string" },
+          frequency: { type: "number" },
+        },
+      },
+    },
+  },
+};
+const clustered = await agent(
+  `以下の候補ルール群を意味の近いもので統合・重複排除してください。\n\n` +
+  `${JSON.stringify(allCandidates, null, 2)}\n\n` +
+  `同義のルールは1件に統合し evidence をまとめ frequency を合算。` +
+  `source=existing-memory 由来の "既出" は統合先の判断材料に使うが、それ自体は新規 cluster にしない。` +
+  `新規性のある運用ルールのみ clusters に残す。`,
+  { label: "cluster", phase: "Cluster", schema: CLUSTER_SCHEMA }
+);
+const clusters = (clustered?.clusters || []).filter(c => c && c.rule);
+log(`🔗 クラスタ ${clusters.length} 件 → adversarial 検証へ`);
+
+// --- Phase 3: Verify (候補ごと adversarial) --------------------------------
+
+phase("Verify");
+const verified = await pipeline(
+  clusters,
+  (c) => agent(
+    `次の運用ルール候補を adversarial に検証してください。\n\n` +
+    `候補: ${c.rule}\n根拠: ${c.evidence}\n観測頻度: ${c.frequency}\n\n` +
+    `判定:\n` +
+    `- is_real: 一度きりの偶発でなく「繰り返す是正」か (疑わしければ false)\n` +
+    `- already_documented: CLAUDE.md / MEMORY.md に既に同趣旨があるか (実際に Grep して確認)\n` +
+    `- recommendation: adopt(新規採用) / merge(既存へ統合) / drop(不採用)\n` +
+    `デフォルトは保守的に。曖昧なら drop。`,
+    { label: `verify:${c.rule.slice(0, 24)}`, phase: "Verify", schema: VERIFY_SCHEMA }
+  ).then(v => v ? { ...c, ...v } : null)
+);
+const survivors = verified.filter(Boolean).filter(v => v.is_real && v.recommendation !== "drop");
+log(`🎯 生存候補 ${survivors.length} 件 (adopt/merge) → 蒸留へ`);
+
+// --- Phase 4: Distill (追記案生成・提案のみ) -------------------------------
+
+phase("Distill");
+const proposals = await agent(
+  `以下の生存ルールを ${target} への追記案として日本語で蒸留してください。**提案のみ。ファイルは編集しないこと。**\n\n` +
+  `${JSON.stringify(survivors, null, 2)}\n\n` +
+  (target === "MEMORY.md"
+    ? `各ルールを memory ファイル形式 (frontmatter: name/description/metadata.type=feedback, 本文に Why/How to apply) の追記案として提示。`
+    : `各ルールを CLAUDE.md の適切な節 (例: 禁止事項 / 行動原則) への追記案として提示。§18 により自動適用はせず人間レビュー前提と明記。`) +
+  `\n各案に「採用/統合(merge 先)/見送り」の推奨と理由を添える。`,
+  { label: "distill", phase: "Distill" }
+);
+
+return {
+  target,
+  counts: { mined: allCandidates.length, clustered: clusters.length, survivors: survivors.length },
+  survivors,
+  proposals,
+  note: "提案のみ。CLAUDE.md/MEMORY.md への反映は人間が判断する (§18)。",
+};

--- a/scripts/lib/TemplateSyncManager.ps1
+++ b/scripts/lib/TemplateSyncManager.ps1
@@ -206,6 +206,15 @@ function Sync-LauncherClaudeGlobalConfig {
         -TargetDir (Join-Path $ProjectDir '.claude\hooks') `
         -Label '.claude/hooks'
 
+    # dynamic workflows (.claude/workflows/*.js) を runtime 有効化。
+    # SOT は Claude\templates\claude\workflows\ (claudeos\ 一括同期 → .claude\claudeos\ とは
+    # 別系統。dynamic workflow は .claude\workflows\ で discovery されるため)。
+    # 注: .github\workflows\ (CI yml) とは別物。
+    Sync-ProjectTemplateDirectory `
+        -TemplateDir (Join-Path $StartupRoot 'Claude\templates\claude\workflows') `
+        -TargetDir (Join-Path $ProjectDir '.claude\workflows') `
+        -Label '.claude/workflows'
+
     # v3.2.53 (F): settings.json は Claude/templates/claude/settings.json に一本化
     $settingsTemplatePath = Join-Path $StartupRoot 'Claude\templates\claude\settings.json'
     Initialize-ProjectTemplate `

--- a/scripts/setup/migrate-workflows-agentteams.js
+++ b/scripts/setup/migrate-workflows-agentteams.js
@@ -5,6 +5,7 @@
 //   1. CLAUDE.md の「公式機能」誤記を修正 → 正しい「Experimental」表記に戻す
 //   2. settings.json に TeammateIdle / TaskCreated / TaskCompleted フックを追加
 //   3. .claude/workflows/ ディレクトリを作成（プロジェクトワークフロー保存場所）
+//   3b. dynamic workflow scripts を SOT (Claude/templates/claude/workflows) から配布
 //   4. フックスクリプトを各プロジェクトにコピー（3ファイル）
 //
 // 根拠:
@@ -21,9 +22,12 @@
 const fs   = require("fs");
 const path = require("path");
 
-const BACKUP_SUFFIX  = ".bak-workflows-agentteams";
-const PROJECTS_BASE  = path.resolve(__dirname, "../../..");
-const TEMPLATE_HOOKS = path.resolve(__dirname, "../../Claude/templates/claudeos/scripts/hooks");
+const BACKUP_SUFFIX      = ".bak-workflows-agentteams";
+const PROJECTS_BASE      = path.resolve(__dirname, "../../..");
+const TEMPLATE_HOOKS     = path.resolve(__dirname, "../../Claude/templates/claudeos/scripts/hooks");
+// dynamic workflow scripts の SOT。.claude/workflows/ で discovery されるため
+// Claude/templates/claudeos/ (一括同期 → .claude/claudeos/) とは別系統に置く。
+const TEMPLATE_WORKFLOWS = path.resolve(__dirname, "../../Claude/templates/claude/workflows");
 
 const args = process.argv.slice(2);
 const DRY_RUN  = args.includes("--dry-run");
@@ -141,6 +145,33 @@ function ensureWorkflowsDir(projectPath) {
   return { changed: true };
 }
 
+// ── 3b. dynamic workflow scripts シード（SOT → .claude/workflows/） ────────────
+// copyHookScripts と同じ copy-if-differ 方式。テンプレートに無い project 固有
+// workflow は対象外（消さない）。テンプレ管理対象のみ最新へ更新する。
+
+function seedWorkflowScripts(projectPath) {
+  if (!fs.existsSync(TEMPLATE_WORKFLOWS)) return { changed: false, reason: "template dir not found", count: 0 };
+
+  const wfDir = path.join(projectPath, ".claude", "workflows");
+  if (APPLY && !fs.existsSync(wfDir)) fs.mkdirSync(wfDir, { recursive: true });
+
+  const files = fs.readdirSync(TEMPLATE_WORKFLOWS).filter(f => f.endsWith(".js"));
+  let copied = 0;
+  for (const fname of files) {
+    const src  = path.join(TEMPLATE_WORKFLOWS, fname);
+    const dest = path.join(wfDir, fname);
+    if (fs.existsSync(dest)) {
+      const srcContent  = fs.readFileSync(src, "utf8");
+      const destContent = fs.readFileSync(dest, "utf8");
+      if (srcContent === destContent) continue; // up-to-date
+    }
+    if (APPLY) fs.copyFileSync(src, dest);
+    copied++;
+    if (VERBOSE) console.log(`  + workflow: ${fname}`);
+  }
+  return { changed: copied > 0, count: copied };
+}
+
 // ── 4. フックスクリプトコピー ─────────────────────────────────────────────────
 
 const HOOK_FILES = ["teammate-idle-gate.js", "task-created-gate.js", "task-completed-gate.js"];
@@ -224,6 +255,13 @@ for (const projectPath of projects) {
     if (r.changed) { console.log(`  ✅ .claude/workflows/ 作成`); }
     else           { console.log(`  ⬛ workflows/: ${r.reason}`); }
   } catch (e) { console.log(`  ❌ workflows/: ${e.message}`); totalErrors++; }
+
+  // dynamic workflow scripts シード（SOT → .claude/workflows/）
+  try {
+    const r = seedWorkflowScripts(projectPath);
+    if (r.changed) { console.log(`  ✅ workflow scripts ${r.count} 件配布`); }
+    else           { console.log(`  ⬛ workflow scripts: ${r.reason || "up-to-date"}`); }
+  } catch (e) { console.log(`  ❌ workflow seed: ${e.message}`); totalErrors++; }
 
   // フックスクリプトコピー
   try {


### PR DESCRIPTION
## 変更内容

dynamic workflows ブログ (Thariq Shihipar & Sid Bidasaria, 2026-06-02 "A harness for every task") の未 codify パターンを取り込み。新規 workflow 4本 + SOT 配布経路を追加。

### 新規 workflow (`.claude/workflows/` + SOT `Claude/templates/claude/workflows/`)

| workflow | ブログパターン | 用途 | 安全既定 |
|---|---|---|---|
| `gate-verification-sweep` | rule-verifier | 検証チェックリスト250項目を1項目=1検証で並列スイープ→終了報告3区分 | 読取のみ |
| `migration-sweep` | Migrations & Refactors | コードベース横断移行を discover→transform→verify | **dry-run** (apply=true で実編集) |
| `rule-distillation` | Memory & Rule Adherence | session/履歴/レビューから運用ルール蒸留 | **提案のみ** (§18 自動適用なし) |
| `issue-triage` | Triage at Scale | open Issue 分類・重複検出・アクション提案 | **dry-run** (apply でラベルのみ) |

### SOT 配布経路

- `Claude/templates/claude/workflows/` を新設 (dynamic workflows 専用 SOT。`.claude/claudeos/` 一括同期や `.github/workflows` CI yml とは別系統)
- `migrate-workflows-agentteams.js`: `seedWorkflowScripts()` 追加 (従来は空 dir 作成のみ → .js 本体を copy-if-differ 配布)
- `TemplateSyncManager.ps1`: `.claude/workflows` マッピングを parity 追加

## テスト結果

| 検証 | 結果 |
|---|---|
| 全4本 構文 (runtime 等価 async ラップ + node --check) | ✅ OK |
| gate-verification-sweep 実 live run (gate-1) | ✅ 113項目/15エージェント/約18分。✅61 ❌7 ⏭17 ⬜28 / 実検証合格率90% |
| migration-sweep ロジック (apply 両経路 mock dry-run) | ✅ planned/verify-skip ↔ transformed/verify-pass |
| migrate-workflows-agentteams.js | ✅ node --check + --dry-run で5プロジェクト配布検出 |
| TemplateSyncManager.ps1 | ✅ PARSE_OK |

**gate-1 live run で実在セキュリティギャップ7件を検出**: CSRF(#72)/CSP(#73)/Security Header(#170)/HTTPS強制(#85)/404画面(#16)/PUT(#113)/リトライ(#194)

## 影響範囲

- 追加が主体 (workflow 7ファイル新規 + 配布スクリプト2本改修)
- 既存挙動への破壊的変更なし。migration-sweep/issue-triage は破壊的操作を既定 OFF
- 実行は token を消費 (CTO 判断: token<70% / 残≥60min 下での起動を想定)

## 残課題 (フォローアップ)

- [ ] 検出セキュリティ7件の本体修正 (別 Issue 推奨)
- [ ] 04-agent-teams.md dynamic workflows § に配布経路の doc 注記 (ドリフト回避のため別途)
- [ ] 全登録プロジェクトへの実配布 (`migrate-workflows-agentteams.js --apply`)

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)