### PR TITLE
fix(workflows): args が JSON 文字列で届くケースを正規化 (#329)

### DIFF
--- a/.claude/workflows/gate-verification-sweep.js
+++ b/.claude/workflows/gate-verification-sweep.js
@@ -104,12 +104,15 @@ const VERIFY_SCHEMA = {
 
 // --- 入力 ------------------------------------------------------------------
 
-const gate          = (args?.gate || "gate-1").toLowerCase();
-const batchSize     = Math.max(1, Number(args?.batchSize) || 10);
-const skipConditions = Array.isArray(args?.skipConditions) ? args.skipConditions : [];
-const changedFiles  = Array.isArray(args?.changedFilesHint) ? args.changedFilesHint : [];
-const appUrl        = args?.appUrl || "";
-const checklistPath = args?.checklistPath || "";
+// args が JSON 文字列で届くケース(自然言語起動など)に備え正規化
+const A = typeof args === "string" ? (() => { try { return JSON.parse(args) || {}; } catch { return {}; } })() : (args || {});
+
+const gate          = (A.gate || "gate-1").toLowerCase();
+const batchSize     = Math.max(1, Number(A.batchSize) || 10);
+const skipConditions = Array.isArray(A.skipConditions) ? A.skipConditions : [];
+const changedFiles  = Array.isArray(A.changedFilesHint) ? A.changedFilesHint : [];
+const appUrl        = A.appUrl || "";
+const checklistPath = A.checklistPath || "";
 
 // gate ごとの選別ルール (Parse エージェントへ渡す自然言語仕様)
 const GATE_RULES = {

--- a/.claude/workflows/issue-triage.js
+++ b/.claude/workflows/issue-triage.js
@@ -70,9 +70,12 @@ const CLASSIFY_SCHEMA = {
   },
 };
 
-const limit     = Math.max(1, Number(args?.limit) || 50);
-const batchSize  = Math.max(1, Number(args?.batchSize) || 8);
-const apply     = args?.apply === true;
+// args が JSON 文字列で届くケース(自然言語起動など)に備え正規化
+const A = typeof args === "string" ? (() => { try { return JSON.parse(args) || {}; } catch { return {}; } })() : (args || {});
+
+const limit     = Math.max(1, Number(A.limit) || 50);
+const batchSize  = Math.max(1, Number(A.batchSize) || 8);
+const apply     = A.apply === true;
 
 log(`📋 issue-triage — ${apply ? "⚡ APPLY (ラベル付けのみ)" : "🔍 DRY-RUN (提案のみ)"} / limit=${limit}`);
 if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);

--- a/.claude/workflows/migration-sweep.js
+++ b/.claude/workflows/migration-sweep.js
@@ -95,11 +95,14 @@ const VERIFY_SCHEMA = {
 
 // --- 入力 ------------------------------------------------------------------
 
-const description = args?.description || "";
-const find        = args?.find || "";
-const globs       = Array.isArray(args?.globs) ? args.globs : [];
-const verifyCmd   = args?.verifyCmd || "";
-const apply       = args?.apply === true;
+// args が JSON 文字列で届くケース(自然言語起動など)に備え正規化
+const A = typeof args === "string" ? (() => { try { return JSON.parse(args) || {}; } catch { return {}; } })() : (args || {});
+
+const description = A.description || "";
+const find        = A.find || "";
+const globs       = Array.isArray(A.globs) ? A.globs : [];
+const verifyCmd   = A.verifyCmd || "";
+const apply       = A.apply === true;
 
 if (!description || !find) {
   log("⚠️ args.description と args.find は必須です。中止します。");

--- a/.claude/workflows/rule-distillation.js
+++ b/.claude/workflows/rule-distillation.js
@@ -60,8 +60,11 @@ const VERIFY_SCHEMA = {
   },
 };
 
-const lookback = Math.max(5, Number(args?.lookback) || 40);
-const target   = args?.target === "CLAUDE.md" ? "CLAUDE.md" : "MEMORY.md";
+// args が JSON 文字列で届くケース(自然言語起動など)に備え正規化
+const A = typeof args === "string" ? (() => { try { return JSON.parse(args) || {}; } catch { return {}; } })() : (args || {});
+
+const lookback = Math.max(5, Number(A.lookback) || 40);
+const target   = A.target === "CLAUDE.md" ? "CLAUDE.md" : "MEMORY.md";
 
 log(`🧬 rule-distillation — 提案のみ (自動適用なし) / target=${target} / lookback=${lookback}コミット`);
 if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);

--- a/Claude/templates/claude/workflows/gate-verification-sweep.js
+++ b/Claude/templates/claude/workflows/gate-verification-sweep.js
@@ -104,12 +104,15 @@ const VERIFY_SCHEMA = {
 
 // --- 入力 ------------------------------------------------------------------
 
-const gate          = (args?.gate || "gate-1").toLowerCase();
-const batchSize     = Math.max(1, Number(args?.batchSize) || 10);
-const skipConditions = Array.isArray(args?.skipConditions) ? args.skipConditions : [];
-const changedFiles  = Array.isArray(args?.changedFilesHint) ? args.changedFilesHint : [];
-const appUrl        = args?.appUrl || "";
-const checklistPath = args?.checklistPath || "";
+// args が JSON 文字列で届くケース(自然言語起動など)に備え正規化
+const A = typeof args === "string" ? (() => { try { return JSON.parse(args) || {}; } catch { return {}; } })() : (args || {});
+
+const gate          = (A.gate || "gate-1").toLowerCase();
+const batchSize     = Math.max(1, Number(A.batchSize) || 10);
+const skipConditions = Array.isArray(A.skipConditions) ? A.skipConditions : [];
+const changedFiles  = Array.isArray(A.changedFilesHint) ? A.changedFilesHint : [];
+const appUrl        = A.appUrl || "";
+const checklistPath = A.checklistPath || "";
 
 // gate ごとの選別ルール (Parse エージェントへ渡す自然言語仕様)
 const GATE_RULES = {

--- a/Claude/templates/claude/workflows/issue-triage.js
+++ b/Claude/templates/claude/workflows/issue-triage.js
@@ -70,9 +70,12 @@ const CLASSIFY_SCHEMA = {
   },
 };
 
-const limit     = Math.max(1, Number(args?.limit) || 50);
-const batchSize  = Math.max(1, Number(args?.batchSize) || 8);
-const apply     = args?.apply === true;
+// args が JSON 文字列で届くケース(自然言語起動など)に備え正規化
+const A = typeof args === "string" ? (() => { try { return JSON.parse(args) || {}; } catch { return {}; } })() : (args || {});
+
+const limit     = Math.max(1, Number(A.limit) || 50);
+const batchSize  = Math.max(1, Number(A.batchSize) || 8);
+const apply     = A.apply === true;
 
 log(`📋 issue-triage — ${apply ? "⚡ APPLY (ラベル付けのみ)" : "🔍 DRY-RUN (提案のみ)"} / limit=${limit}`);
 if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);

--- a/Claude/templates/claude/workflows/migration-sweep.js
+++ b/Claude/templates/claude/workflows/migration-sweep.js
@@ -95,11 +95,14 @@ const VERIFY_SCHEMA = {
 
 // --- 入力 ------------------------------------------------------------------
 
-const description = args?.description || "";
-const find        = args?.find || "";
-const globs       = Array.isArray(args?.globs) ? args.globs : [];
-const verifyCmd   = args?.verifyCmd || "";
-const apply       = args?.apply === true;
+// args が JSON 文字列で届くケース(自然言語起動など)に備え正規化
+const A = typeof args === "string" ? (() => { try { return JSON.parse(args) || {}; } catch { return {}; } })() : (args || {});
+
+const description = A.description || "";
+const find        = A.find || "";
+const globs       = Array.isArray(A.globs) ? A.globs : [];
+const verifyCmd   = A.verifyCmd || "";
+const apply       = A.apply === true;
 
 if (!description || !find) {
   log("⚠️ args.description と args.find は必須です。中止します。");

--- a/Claude/templates/claude/workflows/rule-distillation.js
+++ b/Claude/templates/claude/workflows/rule-distillation.js
@@ -60,8 +60,11 @@ const VERIFY_SCHEMA = {
   },
 };
 
-const lookback = Math.max(5, Number(args?.lookback) || 40);
-const target   = args?.target === "CLAUDE.md" ? "CLAUDE.md" : "MEMORY.md";
+// args が JSON 文字列で届くケース(自然言語起動など)に備え正規化
+const A = typeof args === "string" ? (() => { try { return JSON.parse(args) || {}; } catch { return {}; } })() : (args || {});
+
+const lookback = Math.max(5, Number(A.lookback) || 40);
+const target   = A.target === "CLAUDE.md" ? "CLAUDE.md" : "MEMORY.md";
 
 log(`🧬 rule-distillation — 提案のみ (自動適用なし) / target=${target} / lookback=${lookback}コミット`);
 if (budget?.total) log(`📊 token 予算: 残 ${Math.round(budget.remaining() / 1000)}k`);


### PR DESCRIPTION
## 変更内容

PC-Ops-Orchestrator での **実起動テスト中に検出**した堅牢性バグの修正。自然言語プロンプト (headless `claude -p`) 経由で workflow を起動すると `args` が JSON オブジェクトでなく **JSON 文字列**で届き、`args?.X` が undefined 化して必須引数ガードで空 bail していた。

4 workflow の入力解析冒頭に正規化を追加（`.claude/workflows/` と SOT 両方）:
```js
const A = typeof args === "string" ? (() => { try { return JSON.parse(args) || {}; } catch { return {}; } })() : (args || {});
```

| workflow | 修正 |
|---|---|
| gate-verification-sweep | args→A 正規化 |
| migration-sweep | 同上 |
| rule-distillation | 同上 |
| issue-triage | 同上 |

## テスト結果

- 4本 構文 (runtime 等価 node --check): ✅ OK
- migration-sweep に `args` を JSON 文字列で渡すモックテスト: ✅ 正常解釈 (description/find 認識・discover 到達)
- PC-Ops 実起動テスト: registration ✅ (4本認識) / execution ✅ (migration-sweep dry-run end-to-end)

## 影響範囲

- 既存のオブジェクト渡し (Workflow ツール正規経路) は挙動不変。文字列渡しのみ救済する後方互換な防御的修正。

## 残 (follow-up)

- 既存3本 (bug-investigation/code-review-parallel/feature-development) も同じ `args?.` パターン → 同様の正規化を将来適用推奨。

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)