### PR TITLE
fix(cron): cron をサブスク認証へ切替 — API 上限で自律実行が止まる問題 (#331)

### DIFF
--- a/Claude/templates/linux/cron-launcher.sh
+++ b/Claude/templates/linux/cron-launcher.sh
@@ -309,6 +309,13 @@ printf '%s' "$PROMPT_ARG" > "$PROMPT_FILE"
 cat > "$CLAUDE_WRAPPER" <<'WRAPPER_EOF'
 #!/usr/bin/env bash
 claude_exit=0
+# サブスク認証(利用クレジット)を優先する。ANTHROPIC_API_KEY が環境に残っていると
+# claude はそれ(=API org・spend cap 対象)で認証し、上限到達時にサブスクの利用クレジットで
+# 救済されない。OAuth 認証情報がある場合のみ API キーを外し、サブスク認証へ倒す。
+# OAuth 不在時はフォールバックとして API キーを維持し cron を壊さない。
+if [ -f "$HOME/.claude/.credentials.json" ]; then
+  unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+fi
 _prompt_file="${_CLAUDEOS_PROMPT_FILE:-}"
 if [[ -f "$_prompt_file" ]] && [[ -s "$_prompt_file" ]]; then
   _prompt_content="$(cat "$_prompt_file")"


### PR DESCRIPTION
## 変更内容

環境変数 `ANTHROPIC_API_KEY`（API org・spend cap 到達／回復 2026-07-01）があると `claude` はそれで認証し、サブスクの「利用クレジット」では救済されず cron が全停止する。`Claude/templates/linux/cron-launcher.sh` の claude 起動 wrapper で、**OAuth 認証情報がある場合のみ** API キーを外してサブスク認証へ倒す。

```bash
# claude 起動 wrapper 冒頭
if [ -f "$HOME/.claude/.credentials.json" ]; then
  unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
fi
```

- wrapper は claude の**直接の親**（tmux/非tmux 両分岐で実行）のため最確実な箇所。
- **OAuth 不在時は API キーを維持**（フォールバック）し cron を壊さない。

## テスト結果

- `bash -n` 構文 OK。
- `autonomy.bats` 等はモック launcher を使用するため実 wrapper 変更の影響なし（CI bats で再確認）。
- 先行検証: 本マシンで `env -u ANTHROPIC_API_KEY claude -p` がサブスク認証（クレジット有効）で成功することを実証済み。

## ⚠️ デプロイ前提（重要）

1. **Linux runner (192.168.0.185) に有効な OAuth 認証情報 (`~/.claude/.credentials.json`) が必要**。無い場合は runner で `claude` を一度対話起動して OAuth ログインすること（無い間は API キーにフォールバックするため即停止はしない）。
2. OAuth トークンは期限切れ得るため、無人運用では定期的な再ログイン/更新の担保が必要（API キー無期限とのトレードオフ）。
3. runner がこの cron-launcher.sh を pull/デプロイする必要あり。
4. サブスク側の「利用クレジット」を ON のままにしておくこと（上限超過分の救済）。

## 影響範囲

- cron 起動経路のみ。手動起動 (`bin/start-claude.sh`) は対象外（必要なら follow-up）。

Closes #331