### PR TITLE
docs: リポジトリと実行マシンの対応を明記 (同一リポジトリの2チェックアウト) (#336)

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,13 @@ scripts/                Mission Control(Web) / 各種ツール / Pester テス�
 ~/.claudeos/            実行時データ（logs / sessions / supervisor / locks / cron-launcher.sh）
 ```
 
+> **📍 リポジトリは 1 つ・実行マシンは 2 つ（同一リポジトリの 2 チェックアウト）**
+> GitHub 上のリポジトリは `ClaudeCode-StartUpTools-New` **ただ 1 つ**です。「Windows 版」「Linux 版」という別リポジトリはありません。
+> - 💻 **Windows `D:\ClaudeCode-StartUpTools-New`** = 開発機（編集・push）
+> - 🐧 **Linux `<linuxBase>/ClaudeCode-StartUpTools-New`** = 実行機（cron 自律実行・goals/hooks 供給元）
+>
+> 同一リポジトリを 2 台に clone した「2 チェックアウト」です（リネーム / 分割はしない方針）。詳細は [`docs/common/18_ARCHITECTURE.md`](./docs/common/18_ARCHITECTURE.md) §3 を参照。
+
 ---
 
 ## 🔐 設定の要点

--- a/docs/common/18_ARCHITECTURE.md
+++ b/docs/common/18_ARCHITECTURE.md
@@ -69,7 +69,52 @@ PowerShell スクリプトの依存は **一方向** に固定します。逆方
 多くのディレクトリでは直下の `README.md` で目的を確認できます（`Claude/`, `reports/` 等）。
 `.codex/` のように `README.md` を置かず設定ファイル（`config.toml`）で役割を表現する例外もあります。
 
-## 3. 用語集
+## 3. リポジトリと実行マシンの対応（同一リポジトリの 2 チェックアウト）
+
+**最重要**: GitHub 上のリポジトリは
+[`ClaudeCode-StartUpTools-New`](https://github.com/Kensan196948G/ClaudeCode-StartUpTools-New)
+**ただ 1 つ**です。「Windows 版」「Linux 版」という別リポジトリは存在しません。
+**同一リポジトリを 2 台のマシンに clone した「2 チェックアウト」** として運用します。
+
+| マシン | パス（例） | 役割 | このマシンで起きること |
+|---|---|---|---|
+| 💻 **Windows 開発機** | `D:\ClaudeCode-StartUpTools-New` | 開発ワークステーション | Claude Code がコード編集・テスト・commit・push。SOT (`Claude/templates/`) の編集はここで行う |
+| 🐧 **Linux 実行機** | `<linuxBase>/ClaudeCode-StartUpTools-New`（例: `192.168.0.185`） | 自律実行ランタイム | crontab が `cron-launcher.sh` 経由で自律セッションを起動。全登録プロジェクトの goals/hooks 供給元 |
+
+```text
+        ┌──────────────────────────────────────────────┐
+        │  GitHub: ClaudeCode-StartUpTools-New  (1 つ)  │
+        └──────────────────────────────────────────────┘
+             ▲  push                       │ pull / clone
+             │ (開発成果)                  ▼ (デプロイ)
+   ┌────────────────────┐        ┌────────────────────┐
+   │ 💻 Windows  D:\     │        │ 🐧 Linux  185       │
+   │    開発機 (編集)    │        │    実行機 (cron)    │
+   └────────────────────┘        └────────────────────┘
+```
+
+開発フローは **「Windows `D:\` で編集 → GitHub に push → Linux 実行機で pull して実機検証」** です。
+
+### なぜ 1 リポジトリのままにするか（リネーム / 分割しない理由）
+
+`feat/linux-migration` のゴールは **「SSH/SMB 廃止・ローカル一本化」** です。リポジトリを
+Windows 版 / Linux 版に分割（fork）すると、この一本化と逆方向になり二重メンテが発生します。
+
+また **GitHub のリポジトリ名とローカルディレクトリ名は独立** です。GitHub をリネームしても
+ローカルフォルダ名は変わらず、逆にローカルフォルダ名を変えると次の **ローカルパス依存箇所が破断**
+します（特に Linux cron 基盤がサイレント劣化する）:
+
+| 破断する箇所 | 依存内容 |
+|---|---|
+| `Claude/templates/linux/cron-launcher.sh` | `CLAUDEOS_GOALS_DIR` / `_CANONICAL_HOOKS`（全プロジェクトの goals/hooks 供給元） |
+| `scripts/lib/TemplateSyncManager.ps1` | canonical hooks 修復元のパス |
+| `scripts/setup/migrate-*.js` | SOT 自身を配布対象から除外するフィルタ（`e.name !== "ClaudeCode-StartUpTools-New"`） |
+
+したがって**呼称の混乱は「リネーム」ではなく「本ドキュメントでの役割明記」で解消**する方針です
+（2026-06-06 決定）。リポジトリ名を変更したい場合は、上表のローカルパス依存箇所を
+環境変数化（`PROJECTS_BASE` 起点の SOT 名を単一定数化）してから行うこと。
+
+## 4. 用語集
 
 本プロジェクト固有の用語と、一般用語から意味が拡張されているものを列挙します。
 
@@ -88,8 +133,9 @@ PowerShell スクリプトの依存は **一方向** に固定します。逆方
 | **Issue Factory** | KPI 未達 / CI 失敗時に自動で Issue を生成する機構 | CLAUDE.md §7 |
 | **WorkTree** | 1 Issue = 1 WorkTree の並列開発単位。main への直 push 禁止 | CLAUDE.md §10 |
 | **hookify** | PreToolUse hook による CTO 委任違反などの自動検知機構 | `docs/common/17_hookify-CTO-guard.md` |
+| **2 チェックアウト構成** | GitHub 上の単一リポジトリを Windows 開発機（編集）と Linux 実行機（cron）の 2 台に clone して運用する形態。別リポジトリではない | 本書 §3 |
 
-## 4. 関連ドキュメント
+## 5. 関連ドキュメント
 
 | 目的 | ドキュメント |
 |---|---|


### PR DESCRIPTION
## 変更内容

リポジトリの呼称混乱（「Windows 版 / Linux 版が同名」）を、**リネームではなくドキュメントでの役割明記**で解消する。GitHub 上のリポジトリは `ClaudeCode-StartUpTools-New` 1 つのみで、Windows 開発機 (`D:\`) と Linux 実行機 (cron) の 2 台に clone した「2 チェックアウト」構成であることを単一の真実として文書化した。

- `docs/common/18_ARCHITECTURE.md`: §3「リポジトリと実行マシンの対応（同一リポジトリの 2 チェックアウト）」を新設。マシン対応表 + 構成図 + 「リネーム / 分割しない理由」（破断するローカルパス依存箇所一覧）を記載。用語集 → §4 / 関連ドキュメント → §5 に繰り下げ、用語集に「2 チェックアウト構成」を追加。
- `README.md`: ディレクトリ構成セクション直後に簡潔な誘導ボックスを追加。

## 背景（方針決定）

| 選択肢 | 判断 |
|---|---|
| 単一リポジトリを -Linux へ改名 | 見送り |
| 2 リポジトリに分割 (fork) | 見送り（一本化ゴールと逆方向） |
| **GitHub 名は維持・呼称を docs で整理** | **採用（リスクゼロ）** |

リネームの本当のリスクは GitHub URL（自動リダイレクトで安全）ではなく、ローカルディレクトリ名に依存する cron 基盤（`cron-launcher.sh` の goals/hooks 供給元）等のサイレント破断にある。混乱の根因は「名前」ではなく「2 チェックアウト構造が未文書化だったこと」のため、docs で固定する。

## テスト結果

docs のみの変更。コード・スクリプト・動作への影響なし。Markdown 構文・節番号の整合（§3 新設 → §4/§5 繰り下げ）を確認済み。

## 影響範囲

- `docs/common/18_ARCHITECTURE.md`、`README.md` の 2 ファイルのみ（+55 / -2 行）
- 実行ロジック・CI・配布スクリプトへの影響なし

## 残課題

なし。

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)
