### PR TITLE
fix(init): STATE_TEMPLATE のパス大文字小文字を claudeos に修正 (Linux対応)

### DIFF
--- a/scripts/setup/init-claudeos-project.js
+++ b/scripts/setup/init-claudeos-project.js
@@ -49,7 +49,7 @@ const MAPPINGS = [
 // 既存プロジェクトの settings.json は permissions/env をカスタムしている場合があり、
 // それらを保護しつつ ClaudeOS の hooks 登録 + 必要 env を *不足分だけ* 補完する。
 const SETTINGS_TEMPLATE = "Claude/templates/claude/settings.json";
-const STATE_TEMPLATE    = "Claude/templates/claude/ClaudeOS/templates/state.json";
+const STATE_TEMPLATE    = "Claude/templates/claude/claudeos/templates/state.json";
 const SKILLS_DIRTY       = ".claude/claudeos/.skills-dirty";
 
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 変更内容

`scripts/setup/init-claudeos-project.js` L52 の `STATE_TEMPLATE` パス文字列を
`Claude/templates/claude/ClaudeOS/templates/state.json` →
`Claude/templates/claude/claudeos/templates/state.json` に修正（`ClaudeOS` → `claudeos`、パス文字列1行のみ）。

### 背景（バグの性質）
- 実体ディレクトリは小文字 `claudeos`。L52 は大文字 `ClaudeOS` をハードコードしていた。
- **Linux (ext4, case-sensitive)** ではテンプレートが解決できず `state.json` が `SOURCE MISSING` となり、
  - 新規プロジェクトの state.json シードが失敗
  - `totals.srcMissing` が汚染され `classify()` が `SRC-MISSING` を返し、誤った "SOURCE MISSING!" ログを出力
- **Windows (NTFS) / macOS (APFS, case-insensitive)** では顕在化していなかったクロスプラットフォーム不具合。

## テスト結果
- `node scripts/setup/init-claudeos-project.js --project Civil-Draw --dry-run`
  - 修正後: `state.json (name=Civil-Draw): +0 new / 1 kept`（テンプレート解決成功、SOURCE MISSING 消失）
  - Summary: `would-create=3  would-merge=0  kept=424`（SRC-MISSING 行なし）
- MAPPINGS のコピーループは state.json シードと独立しているため、本修正は workflows コピー等に影響なし（ログのノイズ除去のみ改善）。

## 影響範囲
- `scripts/setup/init-claudeos-project.js` の1行のみ（パス文字列）。
- L50 のコメント散文中の "ClaudeOS"（製品名言及）は変更なし。
- 既存プロジェクトの state.json は copy-if-missing のため上書きされない（既存は kept）。
- 主に Linux 実行機での新規プロジェクト初期化と SOURCE MISSING ノイズ解消に効果。

## 残課題
- なし（単一行のクロスプラットフォーム修正）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)