### PR TITLE
feat: Claude Code CHANGELOG 第1バッチ取り込み (fallbackModel/agents-json/skillOverrides訂正/requiredMinimumVersion) (#344)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,7 @@
   "alwaysThinkingEnabled": true,
   "promptSuggestionEnabled": true,
   "autoUpdatesChannel": "latest",
+  "fallbackModel": "claude-opus-4-7,claude-sonnet-4-6",
   "prefersReducedMotion": false,
   "terminal": {
     "mode": "auto"

--- a/Claude/templates/claude/CLAUDE.md
+++ b/Claude/templates/claude/CLAUDE.md
@@ -775,7 +775,11 @@ Agent Teams で並列に動き、Agent View で監視する。
   "worktree": {
     "baseRef": "head"
   },
-  "skillOverrides": "user-invocable-only",
+  "fallbackModel": "claude-opus-4-7,claude-sonnet-4-6",
+  "skillOverrides": {
+    "django-patterns": "name-only",
+    "investor-materials": "off"
+  },
   "parentSettingsBehavior": "first-wins"
 }
 ```
@@ -784,9 +788,12 @@ Agent Teams で並列に動き、Agent View で監視する。
 |---|---|---|
 | `worktree.baseRef` | `"head"` / `"fresh"` | worktree 分岐元。`head`=現 HEAD、`fresh`=origin デフォルトブランチ |
 | `worktree.bgIsolation` | `"none"` | BG セッションで直接編集（worktree 不使用） |
-| `skillOverrides` | `"user-invocable-only"` | スキル起動制限（`off`/`user-invocable-only`/`name-only`） |
+| `fallbackModel` | `"id1,id2"` (CSV) | primary モデル不可時に左から順に試行（最大3個）。cron 耐障害性。例: `claude-opus-4-7,claude-sonnet-4-6` |
+| `skillOverrides` | **per-skill オブジェクト** | スキルごとの可視性。値: `on`(既定) / `name-only`(説明非表示・auto-trigger可) / `user-invocable-only`(自動起動禁止・`/`手動のみ) / `off`(完全非表示)。**グローバル文字列は不可（スキーマ違反）**。無関係ドメイン skill を `off`/`name-only` にして listing budget を削減 |
 | `sandbox.bwrapPath` | `/usr/bin/bwrap` | Linux sandboxing パス（Linux/WSL 環境で有効） |
 | `parentSettingsBehavior` | `"first-wins"` | 親設定のマージ方式 |
+
+> ⚙️ **managed settings 専用キー（`.claude/settings.json` 不可）**: `requiredMinimumVersion` / `requiredMaximumVersion`（CC バージョン下限/上限を semver で強制）。配置は Linux `/etc/claude-code/managed-settings.json` / Windows レジストリ `HKLM\SOFTWARE\Policies\ClaudeCode`。テンプレと手順は [`Claude/templates/managed-settings/`](../managed-settings/) を参照。
 
 ### 🔗 フック拡張（v2.1.159+）
 

--- a/Claude/templates/claude/settings.json
+++ b/Claude/templates/claude/settings.json
@@ -14,6 +14,7 @@
   "alwaysThinkingEnabled": true,
   "promptSuggestionEnabled": true,
   "autoUpdatesChannel": "latest",
+  "fallbackModel": "claude-opus-4-7,claude-sonnet-4-6",
   "prefersReducedMotion": false,
   "terminal": {
     "mode": "auto"

--- a/Claude/templates/managed-settings/README.md
+++ b/Claude/templates/managed-settings/README.md
@@ -1,0 +1,45 @@
+# 🔒 Claude Code managed settings — バージョン下限の強制
+
+ClaudeOS は Claude Code の特定バージョン以降の機能に依存します（例: `/goal` 2.1.139+、dynamic workflows 2.1.154+、reloadSkills/sessionTitle 2.1.152+）。古い Claude Code で起動すると**機能がサイレントに欠落**し、自律開発が静かに劣化します。
+
+`requiredMinimumVersion` / `requiredMaximumVersion` は **managed settings 専用キー**（通常の `.claude/settings.json` では効きません）で、範囲外バージョンでの起動を**起動時に拒否**します（`claude update` / `claude install` / `claude doctor` は範囲外でも動くので復旧可能）。
+
+## 📌 推奨値
+
+| キー | 推奨 | 根拠 |
+|---|---|---|
+| `requiredMinimumVersion` | `"2.1.154"` | ClaudeOS が依存する最新機能 floor（dynamic workflows）。/goal・Agent Teams・skills・reloadSkills を全て内包 |
+| `requiredMaximumVersion` | 未設定（任意） | 上限を固定したい場合のみ。`autoUpdatesChannel: latest` 運用なら通常不要 |
+
+`managed-settings.json` をそのまま使うか、floor を運用方針に合わせて調整してください。
+
+## 🚀 配置場所（OS 別）
+
+| OS | 配置場所 |
+|---|---|
+| 🐧 **Linux**（実行機 192.168.0.185） | `/etc/claude-code/managed-settings.json`（または `/etc/claude-code/managed-settings.d/*.json` をアルファベット順マージ） |
+| 🪟 **Windows**（開発機） | レジストリ `HKLM\SOFTWARE\Policies\ClaudeCode`（Group Policy） |
+| 🍎 macOS | MDM plist `com.anthropic.claudecode` |
+
+> ⚠️ managed settings は**システム/管理者権限**が必要です（`/etc` 書込・レジストリ）。リポジトリ内の `.claude/` には置けません。本テンプレは「正本」であり、実配置は人手（または構成管理）で行います。
+
+## 🐧 Linux 実行機への適用手順（例）
+
+```bash
+# 192.168.0.185 上で（sudo 必要）
+sudo mkdir -p /etc/claude-code
+sudo cp Claude/templates/managed-settings/managed-settings.json /etc/claude-code/managed-settings.json
+# 検証: 範囲外バージョンだと起動拒否される
+claude doctor
+```
+
+## ✅ 適用後の確認
+
+- `claude doctor` で managed settings が認識されているか確認。
+- floor 未満の Claude Code で `claude` を起動 → 起動拒否＋承認バージョン案内が出れば成功。
+- cron（`cron-launcher.sh`）経由の自律セッションにも自動適用される（同一 OS 上の managed settings は全 claude 起動に効く）。
+
+## 関連
+
+- 設定キー一覧: `Claude/templates/claude/CLAUDE.md` §「新設定キー」
+- 出典: Claude Code CHANGELOG v2.1.163 / 公式 settings ドキュメント（managed settings）

--- a/Claude/templates/managed-settings/managed-settings.json
+++ b/Claude/templates/managed-settings/managed-settings.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Claude Code managed settings テンプレート (組織/IT 管理者が配置)。requiredMinimumVersion は通常の .claude/settings.json では効かない managed 専用キー。詳細は同ディレクトリの README.md。",
+  "requiredMinimumVersion": "2.1.154"
+}

--- a/scripts/dashboards/mission-control.html
+++ b/scripts/dashboards/mission-control.html
@@ -1018,6 +1018,26 @@ const AgentsPanel = ({ state, liveData, agentTeamsActivity }) => {
           </span>
         )}
       </div>
+      {/* Live Sessions — `claude agents --json` (v2.1.145+) 由来のライブセッション */}
+      <div style={{ gridColumn:"1 / -1", background:MC.bgPanel, border:`1px solid ${MC.border}`, borderRadius:8, padding:"10px 14px", display:"flex", alignItems:"center", gap:12, flexWrap:"wrap" }}>
+        <span style={{ fontSize:11, color:MC.textDim, fontWeight:600 }}>🛰️ Live Sessions (claude agents)</span>
+        {(liveData && liveData.agentsLive && liveData.agentsLive.length) ? (
+          liveData.agentsLive.map((s, i) => (
+            <span key={s.sessionId || i} style={{ fontSize:11, fontFamily:MC.mono, color:MC.textMuted, display:"inline-flex", alignItems:"center", gap:6, border:`1px solid ${MC.border}`, borderRadius:4, padding:"2px 8px" }}>
+              <b style={{ color: s.status==="working" ? MC.green : s.status==="completed" ? MC.accent : MC.textMuted }}>
+                {s.status==="working" ? "✽" : s.status==="waiting" ? "✻" : s.status==="completed" ? "✔" : "•"}
+              </b>
+              {s.name || s.sessionId || "(no name)"}
+              {(s.done!=null && s.total!=null) ? <span style={{ color:MC.textDim }}>{s.done}/{s.total}</span> : null}
+              {s.waitingFor ? <span style={{ color:MC.accent }}>⏳{s.waitingFor}</span> : null}
+            </span>
+          ))
+        ) : (
+          <span style={{ fontSize:11, color:MC.textMuted }}>
+            ライブセッションなし（claude agents --json が空 / 未起動）
+          </span>
+        )}
+      </div>
       <Panel title="エージェント一覧" icon="👥" noPad>
         <div style={{ display:"grid", gridTemplateColumns:"repeat(auto-fill, minmax(220px, 1fr))", gap:1, background:MC.border }}>
           {agents.map(agent => (

--- a/scripts/dashboards/serve-dashboard.js
+++ b/scripts/dashboards/serve-dashboard.js
@@ -906,6 +906,39 @@ function getAgentTeamsActivity() {
   }
 }
 
+/**
+ * Live Claude Code sessions via `claude agents --json` (v2.1.145+).
+ * トップレベルは配列。ライブセッション無し時は []。claude 不在/タイムアウト時も [] を返す。
+ * 15秒キャッシュで /api/mc-data ポーリングのブロッキングを抑制する。
+ */
+let _agentsLiveCache = { at: 0, data: [] };
+function getLiveAgentSessions() {
+  const now = Date.now();
+  if (now - _agentsLiveCache.at < 15000) return _agentsLiveCache.data;
+  let sessions = [];
+  try {
+    const raw = execSync('claude agents --json', {
+      encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    const parsed = raw ? JSON.parse(raw) : [];
+    if (Array.isArray(parsed)) {
+      sessions = parsed.map(s => ({
+        sessionId:  s.sessionId || null,
+        name:       s.name || null,
+        status:     s.status || 'unknown',
+        waitingFor: s.waitingFor || null,
+        done:       typeof s.done  === 'number' ? s.done  : null,
+        total:      typeof s.total === 'number' ? s.total : null,
+        kind:       s.kind || null,
+        cwd:        s.cwd  || null,
+        startedAt:  s.startedAt || null,
+      }));
+    }
+  } catch { /* claude agents 不在/タイムアウト/非JSON時は空配列 */ }
+  _agentsLiveCache = { at: now, data: sessions };
+  return sessions;
+}
+
 /** Trust Score: trust-score.json を読み込んで返す（/health エンドポイント共用） */
 function readTrustScore() {
   try {
@@ -1121,6 +1154,7 @@ async function handleMcData(res) {
     const { agentTeams, eventLog } = getAgentAndEventData();
 
     const currentProjectInfo = getCurrentProjectInfo();
+    const agentsLive = getLiveAgentSessions();  // `claude agents --json` 由来のライブセッション
     const data = {
       currentProjectInfo,
       cronSchedules,
@@ -1129,6 +1163,7 @@ async function handleMcData(res) {
       openIssues:   ghData.openIssues,
       bootSteps,
       agentTeams,
+      agentsLive,
       eventLog,
       generated: new Date().toISOString(),
     };


### PR DESCRIPTION
## 変更内容

Claude Code 公式 CHANGELOG (v2.1.122→2.1.167) を精査し、ClaudeOS 未採用かつ自律 cron 組織に高価値な **4機能を第1バッチ**として取り込む。全スキーマを公式 docs / schemastore / 実機で検証済み。

| # | 機能 (version) | 変更 |
|---|---|---|
| **A** | `fallbackModel` (2.1.166) | `.claude/settings.json` + SOT に `"claude-opus-4-7,claude-sonnet-4-6"`。primary 不可時に順次 fallback＝**cron 耐障害性** |
| **B** | `claude agents --json` (2.1.145/162) | `serve-dashboard.js` に `getLiveAgentSessions()` を `/api/mc-data` 相乗り、`mission-control.html` AgentsPanel に「🛰️ Live Sessions」行 |
| **C** | `skillOverrides` 訂正 (2.1.129) | テンプレ CLAUDE.md の**スキーマ違反**（グローバル文字列）を正しい per-skill オブジェクトへ訂正 |
| **D** | `requiredMinimumVersion` (2.1.163) | managed-settings 専用のためテンプレ＋OS別デプロイ手順を新設（`Claude/templates/managed-settings/`） |

## 検証

- ✅ `node -e JSON.parse`: `.claude/settings.json` / テンプレ settings.json / managed-settings.json すべて妥当
- ✅ `claude doctor`: `fallbackModel` に異常警告なし
- ✅ `node --check scripts/dashboards/serve-dashboard.js` OK
- ✅ **実起動スモーク**: 代替ポートで dashboard 起動 → `/api/mc-data` が `agentsLive` 配列を返すことを確認
- ✅ スキーマ確定: schemastore で `skillOverrides` = object（enum: on/name-only/user-invocable-only/off）、公式 docs で `requiredMinimumVersion` = managed 専用・semver と確認

## スキーマ検証で判明した重要点

- **C**: 旧テンプレの `"skillOverrides": "user-invocable-only"`（グローバル文字列）は schemastore 上**スキーマ違反**。さらにグローバル適用は先日有効化した auto-trigger を壊すため、per-skill オブジェクトへ訂正した。
- **D**: `requiredMinimumVersion` は `.claude/settings.json` では効かない managed-settings 専用キー。Linux `/etc/claude-code/managed-settings.json` 等へ人手配置する前提でテンプレ化。

## 影響範囲

settings 2件 + dashboard 2件 + テンプレ docs/managed-settings 3件。既存動作への破壊なし（fallbackModel は primary 不可時のみ発火、agentsLive は claude 不在時 `[]` フォールバック）。

## 残課題

- D は managed-settings 専用のため、実効化には Linux 実行機での人手配置が必要（手順は README に記載）。
- 第2バッチ候補（Stop/SubagentStop additionalContext・STOP_HOOK_BLOCK_CAP・OpenTelemetry）は別 PR。

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)
