### PR TITLE
feat: Claude Code CHANGELOG 第2バッチ (Stop additionalContext / STOP_HOOK_BLOCK_CAP / OpenTelemetry) (#347)

### DIFF
--- a/.claude/claudeos/scripts/hooks/session-end.js
+++ b/.claude/claudeos/scripts/hooks/session-end.js
@@ -44,30 +44,11 @@ function writeJsonAtomic(file, data) {
 }
 
 // --- E (CHANGELOG v2.1.163): Stop hook 継続ゲート -------------------------------
+// 判定ロジックは ./stop-continue-gate.js に分離 (副作用なし・独立テスト可能)。
 // 本セッションで新規追加された actionable な品質 warning がある場合のみ、会話を 1 回だけ
 // 継続させ (hookSpecificOutput.additionalContext)、Claude に停止前の是正を促す。
-// ガード: stop_hook_active(継続ループ中) / 1 セッション 1 回上限 / 環境変数で無効化可能。
-// これにより「未検証のまま静かに停止」を防ぎつつ、暴走 (無限継続) を構造的に排除する。
-// newWarnings = この hook 実行中に push された warning のみ (既存の古い warning は対象外)。
-const STOP_CONTINUE_ACTIONABLE = new Set([
-  "quality_gate_breach", "tdd_required", "verify_subagent_missing", "audit_fail", "ultrareview_blocker",
-]);
-function decideStopContinuation(state, stopHookActive, warnCountBefore) {
-  if (stopHookActive) return { continue: false };                       // 既に継続中 → 確実に停止
-  if (process.env.CLAUDEOS_DISABLE_STOP_CONTINUE) return { continue: false };
-  const exec = state.execution || {};
-  if ((exec.stop_continue_count || 0) >= 1) return { continue: false }; // 1 セッション 1 回上限
-  const all = Array.isArray(state.warnings) ? state.warnings : [];
-  const fresh = all.slice(warnCountBefore).filter(w => w && STOP_CONTINUE_ACTIONABLE.has(w.kind));
-  if (fresh.length === 0) return { continue: false };
-  const kinds = [...new Set(fresh.map(w => w.kind))];
-  const message =
-    `⚠️ ClaudeOS Stop ゲート: 停止前に未解決の品質課題があります — ${kinds.join(" / ")}。\n` +
-    `可能なら本セッション内で是正してください (テスト追加 / lint 修正 / 必須 SubAgent 起動 / ` +
-    `ultrareview blocker 対応 等)。是正不能なら Issue 化し、その旨を要約に記録してから停止してください。\n` +
-    `(この通知は 1 セッション 1 回のみ。次の停止で確定します。)`;
-  return { continue: true, message };
-}
+// ガード: stop_hook_active / 1 セッション 1 回上限 / CLAUDEOS_DISABLE_STOP_CONTINUE。
+const { decideStopContinuation } = require("./stop-continue-gate.js");
 
 let dreamingEnabled = false;
 

--- a/.claude/claudeos/scripts/hooks/session-end.js
+++ b/.claude/claudeos/scripts/hooks/session-end.js
@@ -10,7 +10,22 @@
 const fs = require("fs");
 const path = require("path");
 
+// Hook 規約: 診断ログは stderr へ集約し、stdout は hookSpecificOutput JSON 専用にする。
+// Stop hook の stdout は Claude Code が JSON としてパースするため、ログが混入すると
+// additionalContext (E) が認識されない。本リダイレクトで stdout のクリーン性を保証する。
+console.log = (...args) => console.error(...args);
+
 const STATE_FILE = path.join(process.cwd(), "state.json");
+
+// Stop hook 入力 (stdin JSON)。stop_hook_active=true は既に Stop hook 継続中であることを示す
+// (Claude Code 標準フィールド)。継続中なら二度目の継続はせず、確実に停止させる。
+let STOP_HOOK_ACTIVE = false;
+try {
+  if (!process.stdin.isTTY) {
+    const inp = JSON.parse(fs.readFileSync(0, "utf8") || "{}");
+    STOP_HOOK_ACTIVE = inp && inp.stop_hook_active === true;
+  }
+} catch { /* 入力なし/非JSON時は false (= 通常停止扱い) */ }
 
 function readJson(file) {
   try {
@@ -28,6 +43,32 @@ function writeJsonAtomic(file, data) {
   fs.renameSync(tmp, file);
 }
 
+// --- E (CHANGELOG v2.1.163): Stop hook 継続ゲート -------------------------------
+// 本セッションで新規追加された actionable な品質 warning がある場合のみ、会話を 1 回だけ
+// 継続させ (hookSpecificOutput.additionalContext)、Claude に停止前の是正を促す。
+// ガード: stop_hook_active(継続ループ中) / 1 セッション 1 回上限 / 環境変数で無効化可能。
+// これにより「未検証のまま静かに停止」を防ぎつつ、暴走 (無限継続) を構造的に排除する。
+// newWarnings = この hook 実行中に push された warning のみ (既存の古い warning は対象外)。
+const STOP_CONTINUE_ACTIONABLE = new Set([
+  "quality_gate_breach", "tdd_required", "verify_subagent_missing", "audit_fail", "ultrareview_blocker",
+]);
+function decideStopContinuation(state, stopHookActive, warnCountBefore) {
+  if (stopHookActive) return { continue: false };                       // 既に継続中 → 確実に停止
+  if (process.env.CLAUDEOS_DISABLE_STOP_CONTINUE) return { continue: false };
+  const exec = state.execution || {};
+  if ((exec.stop_continue_count || 0) >= 1) return { continue: false }; // 1 セッション 1 回上限
+  const all = Array.isArray(state.warnings) ? state.warnings : [];
+  const fresh = all.slice(warnCountBefore).filter(w => w && STOP_CONTINUE_ACTIONABLE.has(w.kind));
+  if (fresh.length === 0) return { continue: false };
+  const kinds = [...new Set(fresh.map(w => w.kind))];
+  const message =
+    `⚠️ ClaudeOS Stop ゲート: 停止前に未解決の品質課題があります — ${kinds.join(" / ")}。\n` +
+    `可能なら本セッション内で是正してください (テスト追加 / lint 修正 / 必須 SubAgent 起動 / ` +
+    `ultrareview blocker 対応 等)。是正不能なら Issue 化し、その旨を要約に記録してから停止してください。\n` +
+    `(この通知は 1 セッション 1 回のみ。次の停止で確定します。)`;
+  return { continue: true, message };
+}
+
 let dreamingEnabled = false;
 
 try {
@@ -35,6 +76,9 @@ try {
   if (state) {
     state.execution = state.execution || {};
     state.execution.last_stop_at = new Date().toISOString();
+
+    // E: この hook 実行で新規 push された warning だけを継続判定に使うため、開始時点の件数を記録
+    const _warnCountBefore = Array.isArray(state.warnings) ? state.warnings.length : 0;
 
     // Dreaming フィールド初期化（初回のみ）
     if (!state.dreaming) {
@@ -229,6 +273,27 @@ try {
 
     writeJsonAtomic(STATE_FILE, state);
     console.log("[SessionEnd] state.json updated (last_stop_at + learning recorded)");
+
+    // E: Stop 継続ゲート — actionable な新規 warning があれば 1 回だけ会話を継続させる。
+    // 継続する場合は finalization(Trust Ledger / ReasoningBank / notify / Dreaming) を実行せず、
+    // 最終停止 (次回の Stop, stop_hook_active=true) でまとめて 1 回だけ確定させる (二重計上防止)。
+    {
+      const cont = decideStopContinuation(state, STOP_HOOK_ACTIVE, _warnCountBefore);
+      if (cont.continue) {
+        state.execution.stop_continue_count = (state.execution.stop_continue_count || 0) + 1;
+        writeJsonAtomic(STATE_FILE, state);
+        process.stdout.write(JSON.stringify({
+          hookSpecificOutput: { hookEventName: "Stop", additionalContext: cont.message },
+        }) + "\n");
+        console.error("[SessionEnd] Stop 継続: actionable warning 検出 → additionalContext で是正を促し継続");
+        process.exit(0);  // finalization は最終停止に委ねる
+      }
+      // 最終停止: 継続カウンタをリセットしてから finalization へ進む
+      if (state.execution.stop_continue_count) {
+        state.execution.stop_continue_count = 0;
+        writeJsonAtomic(STATE_FILE, state);
+      }
+    }
 
     // ① Trust Ledger: stable_achievements をセッション終了時に更新（formula 完全版）
     // GitHub Actions の trust-score-update.yml は CI runs のみ追跡するため

--- a/.claude/claudeos/scripts/hooks/stop-continue-gate.js
+++ b/.claude/claudeos/scripts/hooks/stop-continue-gate.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// stop-continue-gate.js — Stop hook 継続ゲートの判定ロジック (CHANGELOG v2.1.163)
+// ---------------------------------------------------------------------------
+// session-end.js から require される。副作用を持たない純粋判定として分離し、
+// scripts/test/test-stop-continue-gate.js から独立してユニットテスト可能にする。
+//
+// 仕様: 本セッションで「新規に」追加された actionable な品質 warning があり、かつ
+//       継続ループ中でなく (stop_hook_active=false)、1 セッション 1 回上限に達して
+//       いない場合のみ continue=true を返し、停止前の是正を促すメッセージを添える。
+// ---------------------------------------------------------------------------
+"use strict";
+
+const STOP_CONTINUE_ACTIONABLE = new Set([
+  "quality_gate_breach", "tdd_required", "verify_subagent_missing", "audit_fail", "ultrareview_blocker",
+]);
+
+/**
+ * @param {object} state            state.json オブジェクト
+ * @param {boolean} stopHookActive  Stop hook 入力の stop_hook_active (継続ループ中フラグ)
+ * @param {number} warnCountBefore  この hook 実行開始時点の state.warnings 件数
+ * @returns {{continue:boolean, message?:string}}
+ */
+function decideStopContinuation(state, stopHookActive, warnCountBefore) {
+  if (stopHookActive) return { continue: false };                       // 既に継続中 → 確実に停止
+  if (process.env.CLAUDEOS_DISABLE_STOP_CONTINUE) return { continue: false }; // 脱出弁
+  const exec = (state && state.execution) || {};
+  if ((exec.stop_continue_count || 0) >= 1) return { continue: false }; // 1 セッション 1 回上限
+  const all = Array.isArray(state && state.warnings) ? state.warnings : [];
+  const fresh = all.slice(warnCountBefore || 0).filter(w => w && STOP_CONTINUE_ACTIONABLE.has(w.kind));
+  if (fresh.length === 0) return { continue: false };
+  const kinds = [...new Set(fresh.map(w => w.kind))];
+  const message =
+    `⚠️ ClaudeOS Stop ゲート: 停止前に未解決の品質課題があります — ${kinds.join(" / ")}。\n` +
+    `可能なら本セッション内で是正してください (テスト追加 / lint 修正 / 必須 SubAgent 起動 / ` +
+    `ultrareview blocker 対応 等)。是正不能なら Issue 化し、その旨を要約に記録してから停止してください。\n` +
+    `(この通知は 1 セッション 1 回のみ。次の停止で確定します。)`;
+  return { continue: true, message };
+}
+
+module.exports = { decideStopContinuation, STOP_CONTINUE_ACTIONABLE };

--- a/.claude/claudeos/system/loop-guard.md
+++ b/.claude/claudeos/system/loop-guard.md
@@ -29,3 +29,18 @@
 
 ## Priority
 Loop Guard > 全システム（CTO・Architect・Developerの判断より優先）
+
+## Stop hook 継続ゲート (E) と block cap (F) — CHANGELOG v2.1.163 / v2.1.143
+Stop hook (`session-end.js`) は、本セッションで新規検出した actionable な品質 warning
+(`quality_gate_breach` / `tdd_required` / `verify_subagent_missing` / `audit_fail` /
+`ultrareview_blocker`) がある場合に **1 回だけ** `hookSpecificOutput.additionalContext` を返して
+会話を継続させ、停止前の是正を促す。「未検証のまま静かに停止」を防ぐ。
+
+暴走させない多重ガード:
+1. **1 セッション 1 回上限**: `state.execution.stop_continue_count` で 2 回目以降を抑止。
+2. **`stop_hook_active`**: 継続ループ中フラグ。true の Stop では継続しない。
+3. **`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`** (既定 8): Claude Code 組込の最終バックストップ（`settings.json` env で明示）。
+4. **`CLAUDEOS_DISABLE_STOP_CONTINUE`**: 継続ゲートを完全無効化する脱出弁。
+
+継続は Auto Repair (修復 3 回) とは別レイヤーで最大 1 回。是正不能なら Issue 化して停止。
+finalization (Trust Ledger / learning / Dreaming) は継続パスでは実行せず最終停止で 1 回だけ確定（二重計上防止）。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,8 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
     "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": "true",
-    "ENABLE_PROMPT_CACHING_1H": "1"
+    "ENABLE_PROMPT_CACHING_1H": "1",
+    "CLAUDE_CODE_STOP_HOOK_BLOCK_CAP": "8"
   },
   "includeCoAuthoredBy": true,
   "outputStyle": "Explanatory",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,3 +287,4 @@ jobs:
           node scripts/validate-state-example.js
           node scripts/check-doc-versions.js
           node scripts/test/test-supervisor-smoke.js
+          node scripts/test/test-stop-continue-gate.js

--- a/Claude/templates/claude/settings.json
+++ b/Claude/templates/claude/settings.json
@@ -5,7 +5,8 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
     "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": "true",
-    "ENABLE_PROMPT_CACHING_1H": "1"
+    "ENABLE_PROMPT_CACHING_1H": "1",
+    "CLAUDE_CODE_STOP_HOOK_BLOCK_CAP": "8"
   },
   "includeCoAuthoredBy": true,
   "outputStyle": "Explanatory",

--- a/Claude/templates/claudeos/scripts/hooks/session-end.js
+++ b/Claude/templates/claudeos/scripts/hooks/session-end.js
@@ -10,7 +10,22 @@
 const fs = require("fs");
 const path = require("path");
 
+// Hook 規約: 診断ログは stderr へ集約し、stdout は hookSpecificOutput JSON 専用にする。
+// Stop hook の stdout は Claude Code が JSON としてパースするため、ログが混入すると
+// additionalContext (E) が認識されない。本リダイレクトで stdout のクリーン性を保証する。
+console.log = (...args) => console.error(...args);
+
 const STATE_FILE = path.join(process.cwd(), "state.json");
+
+// Stop hook 入力 (stdin JSON)。stop_hook_active=true は既に Stop hook 継続中であることを示す
+// (Claude Code 標準フィールド)。継続中なら二度目の継続はせず、確実に停止させる。
+let STOP_HOOK_ACTIVE = false;
+try {
+  if (!process.stdin.isTTY) {
+    const inp = JSON.parse(fs.readFileSync(0, "utf8") || "{}");
+    STOP_HOOK_ACTIVE = inp && inp.stop_hook_active === true;
+  }
+} catch { /* 入力なし/非JSON時は false (= 通常停止扱い) */ }
 
 function readJson(file) {
   try {
@@ -28,6 +43,32 @@ function writeJsonAtomic(file, data) {
   fs.renameSync(tmp, file);
 }
 
+// --- E (CHANGELOG v2.1.163): Stop hook 継続ゲート -------------------------------
+// 本セッションで新規追加された actionable な品質 warning がある場合のみ、会話を 1 回だけ
+// 継続させ (hookSpecificOutput.additionalContext)、Claude に停止前の是正を促す。
+// ガード: stop_hook_active(継続ループ中) / 1 セッション 1 回上限 / 環境変数で無効化可能。
+// これにより「未検証のまま静かに停止」を防ぎつつ、暴走 (無限継続) を構造的に排除する。
+// newWarnings = この hook 実行中に push された warning のみ (既存の古い warning は対象外)。
+const STOP_CONTINUE_ACTIONABLE = new Set([
+  "quality_gate_breach", "tdd_required", "verify_subagent_missing", "audit_fail", "ultrareview_blocker",
+]);
+function decideStopContinuation(state, stopHookActive, warnCountBefore) {
+  if (stopHookActive) return { continue: false };                       // 既に継続中 → 確実に停止
+  if (process.env.CLAUDEOS_DISABLE_STOP_CONTINUE) return { continue: false };
+  const exec = state.execution || {};
+  if ((exec.stop_continue_count || 0) >= 1) return { continue: false }; // 1 セッション 1 回上限
+  const all = Array.isArray(state.warnings) ? state.warnings : [];
+  const fresh = all.slice(warnCountBefore).filter(w => w && STOP_CONTINUE_ACTIONABLE.has(w.kind));
+  if (fresh.length === 0) return { continue: false };
+  const kinds = [...new Set(fresh.map(w => w.kind))];
+  const message =
+    `⚠️ ClaudeOS Stop ゲート: 停止前に未解決の品質課題があります — ${kinds.join(" / ")}。\n` +
+    `可能なら本セッション内で是正してください (テスト追加 / lint 修正 / 必須 SubAgent 起動 / ` +
+    `ultrareview blocker 対応 等)。是正不能なら Issue 化し、その旨を要約に記録してから停止してください。\n` +
+    `(この通知は 1 セッション 1 回のみ。次の停止で確定します。)`;
+  return { continue: true, message };
+}
+
 let dreamingEnabled = false;
 
 try {
@@ -35,6 +76,9 @@ try {
   if (state) {
     state.execution = state.execution || {};
     state.execution.last_stop_at = new Date().toISOString();
+
+    // E: この hook 実行で新規 push された warning だけを継続判定に使うため、開始時点の件数を記録
+    const _warnCountBefore = Array.isArray(state.warnings) ? state.warnings.length : 0;
 
     // Dreaming フィールド初期化（初回のみ）
     if (!state.dreaming) {
@@ -157,6 +201,26 @@ try {
 
     writeJsonAtomic(STATE_FILE, state);
     console.log("[SessionEnd] state.json updated (last_stop_at + learning recorded)");
+
+    // E: Stop 継続ゲート — actionable な新規 warning があれば 1 回だけ会話を継続させる。
+    // 継続する場合は finalization(Webhook / notify / Dreaming) を実行せず、最終停止
+    // (次回の Stop, stop_hook_active=true) でまとめて 1 回だけ確定させる (二重実行防止)。
+    {
+      const cont = decideStopContinuation(state, STOP_HOOK_ACTIVE, _warnCountBefore);
+      if (cont.continue) {
+        state.execution.stop_continue_count = (state.execution.stop_continue_count || 0) + 1;
+        writeJsonAtomic(STATE_FILE, state);
+        process.stdout.write(JSON.stringify({
+          hookSpecificOutput: { hookEventName: "Stop", additionalContext: cont.message },
+        }) + "\n");
+        console.error("[SessionEnd] Stop 継続: actionable warning 検出 → additionalContext で是正を促し継続");
+        process.exit(0);  // finalization は最終停止に委ねる
+      }
+      if (state.execution.stop_continue_count) {
+        state.execution.stop_continue_count = 0;
+        writeJsonAtomic(STATE_FILE, state);
+      }
+    }
 
     // Webhook: session_end イベントを外部へ通知（detached spawn）
     try {

--- a/Claude/templates/claudeos/scripts/hooks/session-end.js
+++ b/Claude/templates/claudeos/scripts/hooks/session-end.js
@@ -44,30 +44,11 @@ function writeJsonAtomic(file, data) {
 }
 
 // --- E (CHANGELOG v2.1.163): Stop hook 継続ゲート -------------------------------
+// 判定ロジックは ./stop-continue-gate.js に分離 (副作用なし・独立テスト可能)。
 // 本セッションで新規追加された actionable な品質 warning がある場合のみ、会話を 1 回だけ
 // 継続させ (hookSpecificOutput.additionalContext)、Claude に停止前の是正を促す。
-// ガード: stop_hook_active(継続ループ中) / 1 セッション 1 回上限 / 環境変数で無効化可能。
-// これにより「未検証のまま静かに停止」を防ぎつつ、暴走 (無限継続) を構造的に排除する。
-// newWarnings = この hook 実行中に push された warning のみ (既存の古い warning は対象外)。
-const STOP_CONTINUE_ACTIONABLE = new Set([
-  "quality_gate_breach", "tdd_required", "verify_subagent_missing", "audit_fail", "ultrareview_blocker",
-]);
-function decideStopContinuation(state, stopHookActive, warnCountBefore) {
-  if (stopHookActive) return { continue: false };                       // 既に継続中 → 確実に停止
-  if (process.env.CLAUDEOS_DISABLE_STOP_CONTINUE) return { continue: false };
-  const exec = state.execution || {};
-  if ((exec.stop_continue_count || 0) >= 1) return { continue: false }; // 1 セッション 1 回上限
-  const all = Array.isArray(state.warnings) ? state.warnings : [];
-  const fresh = all.slice(warnCountBefore).filter(w => w && STOP_CONTINUE_ACTIONABLE.has(w.kind));
-  if (fresh.length === 0) return { continue: false };
-  const kinds = [...new Set(fresh.map(w => w.kind))];
-  const message =
-    `⚠️ ClaudeOS Stop ゲート: 停止前に未解決の品質課題があります — ${kinds.join(" / ")}。\n` +
-    `可能なら本セッション内で是正してください (テスト追加 / lint 修正 / 必須 SubAgent 起動 / ` +
-    `ultrareview blocker 対応 等)。是正不能なら Issue 化し、その旨を要約に記録してから停止してください。\n` +
-    `(この通知は 1 セッション 1 回のみ。次の停止で確定します。)`;
-  return { continue: true, message };
-}
+// ガード: stop_hook_active / 1 セッション 1 回上限 / CLAUDEOS_DISABLE_STOP_CONTINUE。
+const { decideStopContinuation } = require("./stop-continue-gate.js");
 
 let dreamingEnabled = false;
 

--- a/Claude/templates/claudeos/scripts/hooks/stop-continue-gate.js
+++ b/Claude/templates/claudeos/scripts/hooks/stop-continue-gate.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// stop-continue-gate.js — Stop hook 継続ゲートの判定ロジック (CHANGELOG v2.1.163)
+// ---------------------------------------------------------------------------
+// session-end.js から require される。副作用を持たない純粋判定として分離し、
+// scripts/test/test-stop-continue-gate.js から独立してユニットテスト可能にする。
+//
+// 仕様: 本セッションで「新規に」追加された actionable な品質 warning があり、かつ
+//       継続ループ中でなく (stop_hook_active=false)、1 セッション 1 回上限に達して
+//       いない場合のみ continue=true を返し、停止前の是正を促すメッセージを添える。
+// ---------------------------------------------------------------------------
+"use strict";
+
+const STOP_CONTINUE_ACTIONABLE = new Set([
+  "quality_gate_breach", "tdd_required", "verify_subagent_missing", "audit_fail", "ultrareview_blocker",
+]);
+
+/**
+ * @param {object} state            state.json オブジェクト
+ * @param {boolean} stopHookActive  Stop hook 入力の stop_hook_active (継続ループ中フラグ)
+ * @param {number} warnCountBefore  この hook 実行開始時点の state.warnings 件数
+ * @returns {{continue:boolean, message?:string}}
+ */
+function decideStopContinuation(state, stopHookActive, warnCountBefore) {
+  if (stopHookActive) return { continue: false };                       // 既に継続中 → 確実に停止
+  if (process.env.CLAUDEOS_DISABLE_STOP_CONTINUE) return { continue: false }; // 脱出弁
+  const exec = (state && state.execution) || {};
+  if ((exec.stop_continue_count || 0) >= 1) return { continue: false }; // 1 セッション 1 回上限
+  const all = Array.isArray(state && state.warnings) ? state.warnings : [];
+  const fresh = all.slice(warnCountBefore || 0).filter(w => w && STOP_CONTINUE_ACTIONABLE.has(w.kind));
+  if (fresh.length === 0) return { continue: false };
+  const kinds = [...new Set(fresh.map(w => w.kind))];
+  const message =
+    `⚠️ ClaudeOS Stop ゲート: 停止前に未解決の品質課題があります — ${kinds.join(" / ")}。\n` +
+    `可能なら本セッション内で是正してください (テスト追加 / lint 修正 / 必須 SubAgent 起動 / ` +
+    `ultrareview blocker 対応 等)。是正不能なら Issue 化し、その旨を要約に記録してから停止してください。\n` +
+    `(この通知は 1 セッション 1 回のみ。次の停止で確定します。)`;
+  return { continue: true, message };
+}
+
+module.exports = { decideStopContinuation, STOP_CONTINUE_ACTIONABLE };

--- a/Claude/templates/claudeos/system/loop-guard.md
+++ b/Claude/templates/claudeos/system/loop-guard.md
@@ -14,3 +14,25 @@
 ## 重要
 
 ループ判定は時間ではなく主作業内容で行う。
+
+## Stop hook 継続ゲート (E) と block cap (F) — CHANGELOG v2.1.163 / v2.1.143
+
+Stop hook (`session-end.js`) は、本セッションで新規検出した actionable な品質 warning
+(`quality_gate_breach` / `tdd_required` / `verify_subagent_missing` / `audit_fail` /
+`ultrareview_blocker`) がある場合に **1 回だけ** `hookSpecificOutput.additionalContext` を返して
+会話を継続させ、停止前の是正を促す。「未検証のまま静かに停止」を防ぐ。
+
+### 暴走させない多重ガード
+
+1. **1 セッション 1 回上限**: `state.execution.stop_continue_count` で 2 回目以降の継続を抑止。
+2. **`stop_hook_active`**: Claude Code が継続ループ中に渡す標準フラグ。true の Stop では継続しない。
+3. **`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`** (既定 8): Claude Code 組込の最終バックストップ。
+   Stop hook の連続継続がこの回数に達すると強制停止する (`settings.json` の `env` で明示・調整可)。
+4. **`CLAUDEOS_DISABLE_STOP_CONTINUE`**: 設定すると継続ゲートを完全に無効化する脱出弁。
+
+### §12 / 本ガードとの関係
+
+- 継続は Auto Repair (修復 3 回) とは別レイヤー。継続は**最大 1 回**なので無限ループにならない。
+- 是正不能なら Issue 化して停止する。
+- finalization (Trust Ledger 加算 / learning / Dreaming spawn) は継続パスでは実行せず、最終停止で
+  1 回だけ確定する (二重計上防止)。

--- a/Claude/templates/observability/README.md
+++ b/Claude/templates/observability/README.md
@@ -1,0 +1,42 @@
+# 📈 ClaudeOS Observability — Claude Code OpenTelemetry 連携 (readiness)
+
+Claude Code は実行メトリクス/ログを **OpenTelemetry (OTLP)** で外部にエクスポートできます。
+ClaudeOS の Analyst エージェント / Mission Control の KPI パネルに、**ログのパースではなく
+実テレメトリ**を供給するための土台です。
+
+> ⚠️ **本ディレクトリは「準備 (readiness)」**です。env テンプレと配線手順を提供しますが、
+> ライブの OTLP collector + dashboard 取り込みは別途構築が必要（本バッチでは未構築）。
+> collector を立てずに有効化しても export 先が無く無意味なので、collector 準備後に有効化すること。
+
+## 🎯 ClaudeOS が活用したい主なメトリクス/イベント
+
+| シグナル | 何がわかるか | ClaudeOS での用途 |
+|---|---|---|
+| `claude_code.skill_activated` (`invocation_trigger`) | どの skill が auto-trigger / 手動起動されたか | skills 二層構造の実効性検証（[[skills-two-layer]] の実測） |
+| `claude_code.pull_request.count` | 作成された PR/MR 数 | KPI（生産性）・Trust Ledger 補助 |
+| `claude_code.active_time.total` | 実作業時間 | セッション効率・5時間枠の実消費 |
+| `tool_decision` (`tool_parameters`) | ツール使用判断の内訳 | 自律判断の監査・Audit-Agent |
+| `claude_code.at_mention` | @メンション解決 | — |
+
+## 🚀 有効化手順（概要）
+
+1. **OTLP collector を起動**（例: `otelcol-contrib` / Grafana Alloy / lightweight OTLP receiver）。
+   - grpc:4317 または http/protobuf:4318 で受信。
+2. **env を取り込む**: `otel-env.sh.example` を編集（endpoint を collector に合わせる）し、
+   `~/.env-claudeos` に追記するか cron/シェルで `source` してから `claude` を起動。
+   - cron 経由の自律セッションに効かせる場合は `cron-launcher.sh` が読む env ファイルに入れる。
+3. **dashboard 取り込み**（follow-up）: collector の出力（Prometheus / OTLP→JSON 等）を
+   `serve-dashboard.js` の新エンドポイントで読み、Mission Control の KPI/Analyst パネルに表示。
+
+## 📋 注意
+
+- `CLAUDE_CODE_ENABLE_TELEMETRY=1` を settings.json の `env` に直書きしない（collector 不在環境で
+  全プロジェクトが無駄な export を試みるため）。**opt-in の env テンプレ**として配布する設計。
+- API キー認証時はテレメトリ周りの一部機能が無効化される点に注意（CHANGELOG 参照）。
+- 3P プロバイダ（Bedrock/Vertex/Foundry）でも OTLP export 自体は可能。
+
+## 関連
+
+- env テンプレ: [`otel-env.sh.example`](./otel-env.sh.example)
+- 出典: Claude Code CHANGELOG v2.1.145 / 152 / 157 / 161、公式 OpenTelemetry / monitoring ドキュメント
+- follow-up: dashboard 取り込み（collector → `/api/otel-*` → Mission Control KPI パネル）

--- a/Claude/templates/observability/otel-env.sh.example
+++ b/Claude/templates/observability/otel-env.sh.example
@@ -1,0 +1,27 @@
+# ClaudeOS — Claude Code OpenTelemetry 有効化 env テンプレート (opt-in)
+# ------------------------------------------------------------------------------
+# 使い方: OTLP collector を起動した上で、本ファイルを ~/.env-claudeos 等に取り込むか
+#         cron/シェルで source してから claude を起動する。collector 不在のまま有効化すると
+#         export 先が無く無意味（軽微なエラーログ）になるため、collector 準備後に有効化すること。
+#
+# 出典: Claude Code CHANGELOG v2.1.145/152/157/161 (skill_activated / pull_request.count /
+#       active_time / OTEL_RESOURCE_ATTRIBUTES / OTEL_METRICS_INCLUDE_ENTRYPOINT / OTEL_LOG_TOOL_DETAILS)
+# ------------------------------------------------------------------------------
+
+# テレメトリ有効化
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+
+# エクスポータ (OTLP)。collector のプロトコルに合わせる (grpc=4317 / http/protobuf=4318)
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+# ClaudeOS 用のカスタム次元 (プロジェクト別に集計するためのラベル)
+# 例: project / phase をラベル化して Analyst が切り分けられるようにする
+export OTEL_RESOURCE_ATTRIBUTES="service.namespace=claudeos,deployment.environment=cron"
+export OTEL_METRICS_INCLUDE_ENTRYPOINT=true   # app.entrypoint 属性 (cron/手動の区別)
+export OTEL_LOG_TOOL_DETAILS=1                 # tool_decision に tool_parameters を含める
+
+# 任意: エクスポート間隔 (ms)。無人 cron では長めでよい
+export OTEL_METRIC_EXPORT_INTERVAL=60000

--- a/scripts/test/test-stop-continue-gate.js
+++ b/scripts/test/test-stop-continue-gate.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// test-stop-continue-gate.js — E (Stop hook 継続ゲート) 判定ロジックの回帰テスト。
+// CI の「Node validations」ステップから `node scripts/test/test-stop-continue-gate.js` で実行。
+// 失敗時は exit 1。CHANGELOG v2.1.163 取り込み (#347) の安全性ガードを検証する。
+"use strict";
+
+const path = require("path");
+const GATE = path.join(__dirname, "..", "..", ".claude", "claudeos", "scripts", "hooks", "stop-continue-gate.js");
+const { decideStopContinuation, STOP_CONTINUE_ACTIONABLE } = require(GATE);
+
+// テスト中は脱出弁 env を確実に未設定にする
+delete process.env.CLAUDEOS_DISABLE_STOP_CONTINUE;
+
+let failed = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  ✅ ${name}`); }
+  else { console.error(`  ❌ ${name}`); failed++; }
+}
+
+const freshWarn = (kind) => ({ kind, at: new Date().toISOString(), message: "x" });
+
+console.log("🧪 stop-continue-gate 判定ロジック");
+
+// 1. 新規 actionable warning + 継続中でない + 上限未満 → 継続する
+{
+  const state = { execution: { stop_continue_count: 0 }, warnings: [freshWarn("tdd_required")] };
+  const r = decideStopContinuation(state, false, 0);
+  check("新規 tdd_required で継続する", r.continue === true);
+  check("継続メッセージに kind を含む", typeof r.message === "string" && r.message.includes("tdd_required"));
+}
+
+// 2. stop_hook_active=true → 継続しない (継続ループ防止)
+{
+  const state = { execution: { stop_continue_count: 0 }, warnings: [freshWarn("tdd_required")] };
+  check("stop_hook_active=true で継続しない", decideStopContinuation(state, true, 0).continue === false);
+}
+
+// 3. 既に 1 回継続済み (count>=1) → 継続しない (1 セッション 1 回上限)
+{
+  const state = { execution: { stop_continue_count: 1 }, warnings: [freshWarn("audit_fail")] };
+  check("count>=1 で継続しない", decideStopContinuation(state, false, 0).continue === false);
+}
+
+// 4. actionable warning なし → 継続しない
+{
+  const state = { execution: {}, warnings: [] };
+  check("warning 無しで継続しない", decideStopContinuation(state, false, 0).continue === false);
+}
+
+// 5. actionable でない kind の warning → 継続しない
+{
+  const state = { execution: {}, warnings: [freshWarn("some_info")] };
+  check("非 actionable kind で継続しない", decideStopContinuation(state, false, 0).continue === false);
+}
+
+// 6. warnCountBefore より前の (既存) warning は対象外 — 新規が非 actionable なら継続しない
+{
+  const state = { execution: {}, warnings: [freshWarn("tdd_required"), freshWarn("some_info")] };
+  // index 0 は既存(=warnCountBefore=1 で除外)、index 1 が新規(非actionable) → 継続しない
+  check("warnCountBefore で既存 warning を除外する", decideStopContinuation(state, false, 1).continue === false);
+}
+
+// 7. CLAUDEOS_DISABLE_STOP_CONTINUE 設定時 → 継続しない (脱出弁)
+{
+  process.env.CLAUDEOS_DISABLE_STOP_CONTINUE = "1";
+  const state = { execution: { stop_continue_count: 0 }, warnings: [freshWarn("verify_subagent_missing")] };
+  check("DISABLE env で継続しない", decideStopContinuation(state, false, 0).continue === false);
+  delete process.env.CLAUDEOS_DISABLE_STOP_CONTINUE;
+}
+
+// 8. actionable kind 集合の健全性
+check("actionable 集合に主要 kind を含む",
+  ["quality_gate_breach", "tdd_required", "verify_subagent_missing", "audit_fail", "ultrareview_blocker"]
+    .every(k => STOP_CONTINUE_ACTIONABLE.has(k)));
+
+if (failed) { console.error(`\n❌ ${failed} 件失敗`); process.exit(1); }
+console.log("\n✅ stop-continue-gate: 全テスト通過");


### PR DESCRIPTION
## 変更内容

Claude Code 公式 CHANGELOG **第2バッチ**（#344 の続き）。Stop hook の自己是正フィードバック・ブロック上限・OpenTelemetry を取り込む。

| # | 機能 (version) | 変更 |
|---|---|---|
| **E** | Stop `additionalContext` (2.1.163) | `session-end.js`(runtime+SOT) が actionable な**新規**品質 warning 検出時に **1 回だけ** `hookSpecificOutput.additionalContext` を返して継続し、停止前の是正を促す |
| **F** | `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (2.1.143) | 既定 8 を settings.json env に明示 + `loop-guard.md`(両所在) に文書化 |
| **G** | OpenTelemetry readiness (2.1.145/152/157/161) | `Claude/templates/observability/`（`otel-env.sh.example` + README）新設。opt-in |

## 暴走防止（E の多重ガード）

1. **1 セッション 1 回上限** — `state.execution.stop_continue_count`
2. **`stop_hook_active`** — Claude Code 標準の継続ループ検知フラグ。true なら継続しない
3. **`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`（F・既定8）** — 組込の最終バックストップ
4. **`CLAUDEOS_DISABLE_STOP_CONTINUE`** — 完全無効化の脱出弁
5. **finalization 二重計上防止** — Trust Ledger 加算 / learning / Dreaming spawn は継続パスでスキップ、最終停止で 1 回だけ確定
6. **stdout クリーン化** — `console.log → console.error` リダイレクトで stdout を JSON 専用化（ログ混入で additionalContext が無視されるのを防止）

## テスト結果

- ✅ `node --check`: runtime / SOT 両 session-end.js
- ✅ settings.json × 2: JSON 妥当 / `bash -n` otel-env.sh.example
- ✅ **継続パス実機検証**: 一時 state(phase=Verify・必須 subagent 未起動) + stdin `{}` で実行 → stdout が**単独で valid JSON・`additionalContext` あり**（ログ混入なし）を確認、`stop_continue_count` 加算も確認
- ✅ no-continue パス: `console.log→stderr` により stdout 空＝通常停止（構造的に保証）。負側ガードは早期 return（`stop_hook_active` / count≥1 / 新規 warning 無 / DISABLE）

## 影響範囲

session-end.js（runtime+SOT）・settings.json×2・loop-guard.md×2・observability テンプレ新設。Stop hook は最大 1 回の継続のみで**無限ループ不可**。既存 finalization は no-continue 時に従来どおり実行（挙動不変）。

## 残課題

- **G の実効化**: OTLP collector + dashboard 取り込みは follow-up（本 PR は readiness テンプレ+手順のみ）。
- session-end.js は runtime が SOT より進んでいる既存ドリフト（CMDB/Audit/Projects 等）あり。E 編集は両方に適用済みだが、ドリフト統合は別 Issue。

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)
