### PR TITLE
feat(skills): Skills 自動発見の復活 + Gotchas + 計測hook + marketplace修正 (Anthropic blog 活用)

### DIFF
--- a/.claude/claudeos/.claude-plugin/marketplace.json
+++ b/.claude/claudeos/.claude-plugin/marketplace.json
@@ -6,10 +6,7 @@
   "plugins": [
     {
       "name": "everything-claude-code",
-      "source": {
-        "source": "local",
-        "path": "./everything-claude-code"
-      },
+      "source": "./",
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"

--- a/.claude/claudeos/marketplace.json
+++ b/.claude/claudeos/marketplace.json
@@ -6,10 +6,7 @@
   "plugins": [
     {
       "name": "everything-claude-code",
-      "source": {
-        "source": "local",
-        "path": "./everything-claude-code"
-      },
+      "source": "./",
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"

--- a/.claude/claudeos/skills/api-design/SKILL.md
+++ b/.claude/claudeos/skills/api-design/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: api-design
+description: "REST API の契約、ページネーション、互換性、エラー応答を設計するときに使う。"
+---
+
 # api-design
 
 ## 概要

--- a/.claude/claudeos/skills/article-writing/SKILL.md
+++ b/.claude/claudeos/skills/article-writing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: article-writing
+description: "自然で読みやすい長文記事、技術解説、社内ナレッジ文書を作成するときに使う。"
+---
+
 # article-writing
 
 ## 概要

--- a/.claude/claudeos/skills/autonomous-loops/SKILL.md
+++ b/.claude/claudeos/skills/autonomous-loops/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: autonomous-loops
+description: "逐次ループ、PR ループ、DAG 型オーケストレーションを設計するときに使う。"
+---
+
 # autonomous-loops
 
 ## 概要

--- a/.claude/claudeos/skills/backend-patterns/SKILL.md
+++ b/.claude/claudeos/skills/backend-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: backend-patterns
+description: "API、DB、キャッシュ、非同期処理、認証認可を含むバックエンド設計の標準を示すときに使う。"
+---
+
 # backend-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/clickhouse-io/SKILL.md
+++ b/.claude/claudeos/skills/clickhouse-io/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: clickhouse-io
+description: "ClickHouse のテーブル設計、分析クエリ、集計基盤、データエンジニアリングを支援するときに使う。"
+---
+
 # clickhouse-io
 
 ## 概要

--- a/.claude/claudeos/skills/clickhouse-io/SKILL.md
+++ b/.claude/claudeos/skills/clickhouse-io/SKILL.md
@@ -56,7 +56,7 @@ description: "ClickHouse のテーブル設計、分析クエリ、集計基盤�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - 列指向なのに `SELECT *` で全列読込し I/O を浪費する
 - 行単位 INSERT を多発させ part 爆発 → merge 過負荷 (バッチ INSERT 必須)

--- a/.claude/claudeos/skills/clickhouse-io/SKILL.md
+++ b/.claude/claudeos/skills/clickhouse-io/SKILL.md
@@ -56,6 +56,16 @@ description: "ClickHouse のテーブル設計、分析クエリ、集計基盤�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- 列指向なのに `SELECT *` で全列読込し I/O を浪費する
+- 行単位 INSERT を多発させ part 爆発 → merge 過負荷 (バッチ INSERT 必須)
+- `FINAL` 常用で性能劣化 / ReplacingMergeTree の重複解消を即時と誤解する
+- sorting key(`ORDER BY`)設計ミスで primary index が効かず full scan
+- 高カーディナリティの partition key で part 数が爆発する
+- `ALTER UPDATE/DELETE`(mutation) を OLTP 的に使う (非同期・高コスト)
+- `Nullable` 乱用でストレージと性能を劣化させる
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/.claude/claudeos/skills/coding-standards/SKILL.md
+++ b/.claude/claudeos/skills/coding-standards/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: coding-standards
+description: "言語共通のコーディング規約、責務分離、命名、コメント、可読性を整えるときに使う。"
+---
+
 # coding-standards
 
 ## 概要

--- a/.claude/claudeos/skills/configure-ecc/SKILL.md
+++ b/.claude/claudeos/skills/configure-ecc/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: configure-ecc
+description: "everything-claude-code の初期導入と設定整備を支援するときに使う。"
+---
+
 # configure-ecc
 
 ## 概要

--- a/.claude/claudeos/skills/content-engine/SKILL.md
+++ b/.claude/claudeos/skills/content-engine/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: content-engine
+description: "1 つの原稿から複数媒体向けの投稿や配信用コンテンツへ再構成するときに使う。"
+---
+
 # content-engine
 
 ## 概要

--- a/.claude/claudeos/skills/content-hash-cache-pattern/SKILL.md
+++ b/.claude/claudeos/skills/content-hash-cache-pattern/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: content-hash-cache-pattern
+description: "コンテンツハッシュを使って再処理を避けるキャッシュ戦略を整えるときに使う。"
+---
+
 # content-hash-cache-pattern
 
 ## 概要

--- a/.claude/claudeos/skills/continuous-learning-v2/SKILL.md
+++ b/.claude/claudeos/skills/continuous-learning-v2/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: continuous-learning-v2
+description: "学びを信頼度付きで記録し、採用候補と保留候補を分けて管理するときに使う。"
+---
+
 # continuous-learning-v2
 
 ## 概要

--- a/.claude/claudeos/skills/continuous-learning/SKILL.md
+++ b/.claude/claudeos/skills/continuous-learning/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: continuous-learning
+description: "セッションから学びを抽出して再利用可能な知見へまとめるときに使う。"
+---
+
 # continuous-learning
 
 ## 概要

--- a/.claude/claudeos/skills/cost-aware-llm-pipeline/SKILL.md
+++ b/.claude/claudeos/skills/cost-aware-llm-pipeline/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: cost-aware-llm-pipeline
+description: "モデル選択、ルーティング、トークン費用、予算上限を意識した LLM パイプラインを構成するときに使う。"
+---
+
 # cost-aware-llm-pipeline
 
 ## 概要

--- a/.claude/claudeos/skills/cpp-coding-standards/SKILL.md
+++ b/.claude/claudeos/skills/cpp-coding-standards/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: cpp-coding-standards
+description: "C++ Core Guidelines を踏まえた安全な設計と実装を支援するときに使う。"
+---
+
 # cpp-coding-standards
 
 ## 概要

--- a/.claude/claudeos/skills/cpp-testing/SKILL.md
+++ b/.claude/claudeos/skills/cpp-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: cpp-testing
+description: "GoogleTest、CMake、CTest を使った C++ テスト戦略を整えるときに使う。"
+---
+
 # cpp-testing
 
 ## 概要

--- a/.claude/claudeos/skills/database-migrations/SKILL.md
+++ b/.claude/claudeos/skills/database-migrations/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: database-migrations
+description: "各種 ORM やフレームワークにおける安全な migration 運用を整理するときに使う。"
+---
+
 # database-migrations
 
 ## 概要

--- a/.claude/claudeos/skills/database-migrations/SKILL.md
+++ b/.claude/claudeos/skills/database-migrations/SKILL.md
@@ -56,7 +56,7 @@ description: "各種 ORM やフレームワークにおける安全な migration
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - rename/drop を deploy と同時実行し旧コードが落ちる (expand→contract の2段階に)
 - 後方互換を壊す変更を 1 migration に詰め込む

--- a/.claude/claudeos/skills/database-migrations/SKILL.md
+++ b/.claude/claudeos/skills/database-migrations/SKILL.md
@@ -56,6 +56,15 @@ description: "各種 ORM やフレームワークにおける安全な migration
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- rename/drop を deploy と同時実行し旧コードが落ちる (expand→contract の2段階に)
+- 後方互換を壊す変更を 1 migration に詰め込む
+- 大テーブルの DDL で長時間 lock (オンライン DDL / batched backfill)
+- down migration(rollback)を未検証のまま出す
+- data migration を schema migration に混在させる
+- 本番でしか出ない順序依存・seed 依存を見逃す
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/.claude/claudeos/skills/deployment-patterns/SKILL.md
+++ b/.claude/claudeos/skills/deployment-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "CI/CD、環境差異、ヘルスチェック、ロールバック�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - readiness と liveness を混同し、起動中に traffic を流す
 - rollback 手順未整備 / DB migration が rollback 不能

--- a/.claude/claudeos/skills/deployment-patterns/SKILL.md
+++ b/.claude/claudeos/skills/deployment-patterns/SKILL.md
@@ -56,6 +56,15 @@ description: "CI/CD、環境差異、ヘルスチェック、ロールバック�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- readiness と liveness を混同し、起動中に traffic を流す
+- rollback 手順未整備 / DB migration が rollback 不能
+- ビルド時 env と実行時 env を混同する (12-factor 違反)
+- secret を image / CI ログに露出する
+- zero-downtime 前提なのに in-place restart で瞬断する
+- canary/blue-green で新旧スキーマ非互換 (expand/contract で吸収する)
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/.claude/claudeos/skills/deployment-patterns/SKILL.md
+++ b/.claude/claudeos/skills/deployment-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: deployment-patterns
+description: "CI/CD、環境差異、ヘルスチェック、ロールバックを設計するときに使う。"
+---
+
 # deployment-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/django-patterns/SKILL.md
+++ b/.claude/claudeos/skills/django-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Django の models、views、service 層、管理画面設計を整
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `select_related` / `prefetch_related` 不足で N+1 クエリ
 - QuerySet の遅延評価を理解せずループ内でクエリを発行する

--- a/.claude/claudeos/skills/django-patterns/SKILL.md
+++ b/.claude/claudeos/skills/django-patterns/SKILL.md
@@ -56,6 +56,15 @@ description: "Django の models、views、service 層、管理画面設計を整
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `select_related` / `prefetch_related` 不足で N+1 クエリ
+- QuerySet の遅延評価を理解せずループ内でクエリを発行する
+- fat views / fat models で service 層の責務分離が崩れる
+- model 変更後の `makemigrations` 忘れで schema と乖離する
+- signals 多用で副作用の追跡が不能になる
+- settings を環境分離せず単一 `settings.py` に `if` 分岐を詰め込む
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/.claude/claudeos/skills/django-patterns/SKILL.md
+++ b/.claude/claudeos/skills/django-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: django-patterns
+description: "Django の models、views、service 層、管理画面設計を整理するときに使う。"
+---
+
 # django-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/django-security/SKILL.md
+++ b/.claude/claudeos/skills/django-security/SKILL.md
@@ -56,7 +56,7 @@ description: "Django の CSRF、認証認可、ORM 安全性、設定不備を�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - 本番 `DEBUG=True` 残置で例外画面に settings と secret が露出する
 - `ALLOWED_HOSTS` 未設定 / `["*"]` で Host ヘッダ injection を許す

--- a/.claude/claudeos/skills/django-security/SKILL.md
+++ b/.claude/claudeos/skills/django-security/SKILL.md
@@ -56,6 +56,17 @@ description: "Django の CSRF、認証認可、ORM 安全性、設定不備を�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- 本番 `DEBUG=True` 残置で例外画面に settings と secret が露出する
+- `ALLOWED_HOSTS` 未設定 / `["*"]` で Host ヘッダ injection を許す
+- `SECRET_KEY` をコード/リポジトリにハードコードする
+- `.raw()` / `.extra()` / 文字列連結 SQL で ORM の injection 防御を迂回する
+- `mark_safe` / `|safe` / `format_html` 誤用で XSS を作る
+- `@csrf_exempt` の無自覚付与、SessionAuth の API で CSRF が抜ける
+- `get_object_or_404` だけで所有者チェックを省き IDOR を作る
+- session/CSRF cookie の `SECURE` / `HttpOnly` / `SameSite` 未設定
+
 ## 相性のよい command
 
 `/code-review`, `/verify`

--- a/.claude/claudeos/skills/django-security/SKILL.md
+++ b/.claude/claudeos/skills/django-security/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: django-security
+description: "Django の CSRF、認証認可、ORM 安全性、設定不備を点検するときに使う。"
+---
+
 # django-security
 
 ## 概要

--- a/.claude/claudeos/skills/django-tdd/SKILL.md
+++ b/.claude/claudeos/skills/django-tdd/SKILL.md
@@ -56,7 +56,7 @@ description: "Django をテスト先行で安全に実装するときに使う�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `TestCase`(トランザクション) と `TransactionTestCase` の差異を無視し flaky 化
 - 実 DB/外部 API に依存したテストで遅く不安定になる

--- a/.claude/claudeos/skills/django-tdd/SKILL.md
+++ b/.claude/claudeos/skills/django-tdd/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: django-tdd
+description: "Django をテスト先行で安全に実装するときに使う。"
+---
+
 # django-tdd
 
 ## 概要

--- a/.claude/claudeos/skills/django-tdd/SKILL.md
+++ b/.claude/claudeos/skills/django-tdd/SKILL.md
@@ -56,6 +56,14 @@ description: "Django をテスト先行で安全に実装するときに使う�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `TestCase`(トランザクション) と `TransactionTestCase` の差異を無視し flaky 化
+- 実 DB/外部 API に依存したテストで遅く不安定になる
+- fixtures 肥大で意図が読めない。factory(`factory_boy`) で必要分だけ作る
+- `setUp` の重い処理を毎テスト実行して遅くする (`setUpTestData` を使う)
+- freeze せず `timezone.now()` 依存テストを書き時間で壊れる
+
 ## 相性のよい command
 
 `/tdd`

--- a/.claude/claudeos/skills/django-verification/SKILL.md
+++ b/.claude/claudeos/skills/django-verification/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: django-verification
+description: "Django の migration、permission、API、画面の検証を回すときに使う。"
+---
+
 # django-verification
 
 ## 概要

--- a/.claude/claudeos/skills/django-verification/SKILL.md
+++ b/.claude/claudeos/skills/django-verification/SKILL.md
@@ -56,6 +56,13 @@ description: "Django の migration、permission、API、画面の検証を回す
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- migration の前進だけ確認し rollback(逆 migration) を検証しない
+- permission/所有者チェックの検証を正常系だけで済ませる
+- `makemigrations --check --dry-run` を CI に入れず未生成 migration を見逃す
+- 本番相当データ量での性能/タイムアウトを確認しない
+
 ## 相性のよい command
 
 `/verify`

--- a/.claude/claudeos/skills/django-verification/SKILL.md
+++ b/.claude/claudeos/skills/django-verification/SKILL.md
@@ -56,7 +56,7 @@ description: "Django の migration、permission、API、画面の検証を回す
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - migration の前進だけ確認し rollback(逆 migration) を検証しない
 - permission/所有者チェックの検証を正常系だけで済ませる

--- a/.claude/claudeos/skills/docker-patterns/SKILL.md
+++ b/.claude/claudeos/skills/docker-patterns/SKILL.md
@@ -56,6 +56,16 @@ description: "Docker Compose、ネットワーク、ボリューム、コンテ�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `latest` タグ依存で再現性が壊れる。digest 固定か明示バージョンタグを使う
+- `.dockerignore` 未整備で `COPY . .` が `.git`/`node_modules`/secret を image へ焼き込む
+- root 実行のまま放置。`USER` 指定と read-only rootfs を検討する
+- `depends_on` は起動順を保証するが起動完了は保証しない。healthcheck + `condition: service_healthy` が要る
+- マルチステージビルド未使用で build ツールチェーンを本番 image に残し肥大化させる
+- secret を `build-arg` や ENV に渡すと image layer / `docker inspect` から漏れる
+- Linux の bind mount は host uid/gid 差異でコンテナ内書込みが失敗する
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/.claude/claudeos/skills/docker-patterns/SKILL.md
+++ b/.claude/claudeos/skills/docker-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Docker Compose、ネットワーク、ボリューム、コンテ�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `latest` タグ依存で再現性が壊れる。digest 固定か明示バージョンタグを使う
 - `.dockerignore` 未整備で `COPY . .` が `.git`/`node_modules`/secret を image へ焼き込む

--- a/.claude/claudeos/skills/docker-patterns/SKILL.md
+++ b/.claude/claudeos/skills/docker-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: docker-patterns
+description: "Docker Compose、ネットワーク、ボリューム、コンテナセキュリティを扱うときに使う。"
+---
+
 # docker-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/e2e-testing/SKILL.md
+++ b/.claude/claudeos/skills/e2e-testing/SKILL.md
@@ -56,6 +56,15 @@ description: "Playwright の E2E テスト、Page Object Model、待機戦略を
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- 固定 `sleep`/`waitForTimeout` で flaky 化 (web-first assertion / auto-wait を使う)
+- 脆い CSS セレクタ依存。role/label/test-id ベースにする
+- テスト間で DB/seed のリセットを怠り状態が漏れる
+- 認証を毎テスト UI 経由にする (storageState を使い回す)
+- 並列実行時のデータ競合を考慮しない
+- `networkidle` 待ちを過信して不安定化させる
+
 ## 相性のよい command
 
 `/e2e`, `/verify`

--- a/.claude/claudeos/skills/e2e-testing/SKILL.md
+++ b/.claude/claudeos/skills/e2e-testing/SKILL.md
@@ -56,7 +56,7 @@ description: "Playwright の E2E テスト、Page Object Model、待機戦略を
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - 固定 `sleep`/`waitForTimeout` で flaky 化 (web-first assertion / auto-wait を使う)
 - 脆い CSS セレクタ依存。role/label/test-id ベースにする

--- a/.claude/claudeos/skills/e2e-testing/SKILL.md
+++ b/.claude/claudeos/skills/e2e-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: e2e-testing
+description: "Playwright の E2E テスト、Page Object Model、待機戦略を扱うときに使う。"
+---
+
 # e2e-testing
 
 ## 概要

--- a/.claude/claudeos/skills/eval-harness/SKILL.md
+++ b/.claude/claudeos/skills/eval-harness/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: eval-harness
+description: "評価ハーネス、採点基準、実験条件、再現可能な検証を整備するときに使う。"
+---
+
 # eval-harness
 
 ## 概要

--- a/.claude/claudeos/skills/foundation-models-on-device/SKILL.md
+++ b/.claude/claudeos/skills/foundation-models-on-device/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: foundation-models-on-device
+description: "Apple のオンデバイス Foundation Models 活用設計を支援するときに使う。"
+---
+
 # foundation-models-on-device
 
 ## 概要

--- a/.claude/claudeos/skills/frontend-patterns/SKILL.md
+++ b/.claude/claudeos/skills/frontend-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: frontend-patterns
+description: "React と Next.js を中心に画面設計、状態管理、UI 分割、アクセシビリティを整理するときに使う。"
+---
+
 # frontend-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/frontend-slides/SKILL.md
+++ b/.claude/claudeos/skills/frontend-slides/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: frontend-slides
+description: "HTML スライド、プレゼン資料、PPTX 代替の Web ベース資料作成を支援するときに使う。"
+---
+
 # frontend-slides
 
 ## 概要

--- a/.claude/claudeos/skills/golang-patterns/SKILL.md
+++ b/.claude/claudeos/skills/golang-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: golang-patterns
+description: "Go の idiom、context、エラー処理、パッケージ分割を整えるときに使う。"
+---
+
 # golang-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/golang-patterns/SKILL.md
+++ b/.claude/claudeos/skills/golang-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Go の idiom、context、エラー処理、パッケージ分割�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `err` を `_` で握りつぶす / wrap せず原因を失う (`fmt.Errorf("...: %w", err)`)
 - goroutine leak。context cancel / channel close 漏れを残す

--- a/.claude/claudeos/skills/golang-patterns/SKILL.md
+++ b/.claude/claudeos/skills/golang-patterns/SKILL.md
@@ -56,6 +56,15 @@ description: "Go の idiom、context、エラー処理、パッケージ分割�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `err` を `_` で握りつぶす / wrap せず原因を失う (`fmt.Errorf("...: %w", err)`)
+- goroutine leak。context cancel / channel close 漏れを残す
+- Go 1.22 未満の loop 変数キャプチャを goroutine/closure が共有する
+- 共有 map への並行書込みで data race (`-race` で検出する)
+- nil map への書込み panic / nil interface 比較の落とし穴
+- ループ内 `defer` の多用でリソース解放が関数末尾まで遅延する
+
 ## 相性のよい command
 
 `/go-review`, `/go-test`

--- a/.claude/claudeos/skills/golang-testing/SKILL.md
+++ b/.claude/claudeos/skills/golang-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: golang-testing
+description: "Go の unit test、table-driven test、benchmark、TDD を支援するときに使う。"
+---
+
 # golang-testing
 
 ## 概要

--- a/.claude/claudeos/skills/investor-materials/SKILL.md
+++ b/.claude/claudeos/skills/investor-materials/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: investor-materials
+description: "ピッチ資料、1 ページ要約、投資家向け説明資料を構成するときに使う。"
+---
+
 # investor-materials
 
 ## 概要

--- a/.claude/claudeos/skills/investor-outreach/SKILL.md
+++ b/.claude/claudeos/skills/investor-outreach/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: investor-outreach
+description: "投資家や候補先への個別連絡文、フォローアップ文面を整えるときに使う。"
+---
+
 # investor-outreach
 
 ## 概要

--- a/.claude/claudeos/skills/iterative-retrieval/SKILL.md
+++ b/.claude/claudeos/skills/iterative-retrieval/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: iterative-retrieval
+description: "必要な文脈だけを段階的に掘り下げ、過剰読込を防ぐときに使う。"
+---
+
 # iterative-retrieval
 
 ## 概要

--- a/.claude/claudeos/skills/java-coding-standards/SKILL.md
+++ b/.claude/claudeos/skills/java-coding-standards/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: java-coding-standards
+description: "Java の命名、例外、レイヤ分離、読みやすい実装基準を揃えるときに使う。"
+---
+
 # java-coding-standards
 
 ## 概要

--- a/.claude/claudeos/skills/jpa-patterns/SKILL.md
+++ b/.claude/claudeos/skills/jpa-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: jpa-patterns
+description: "JPA と Hibernate の entity、fetch、transaction、query 設計を整理するときに使う。"
+---
+
 # jpa-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/jpa-patterns/SKILL.md
+++ b/.claude/claudeos/skills/jpa-patterns/SKILL.md
@@ -56,6 +56,15 @@ description: "JPA と Hibernate の entity、fetch、transaction、query 設計�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- N+1。`FetchType.EAGER` 乱用 or lazy + ループ (fetch join / `@EntityGraph`)
+- session 外アクセスで `LazyInitializationException`
+- `equals`/`hashCode` を生成 ID で実装する (永続化前は null)
+- 更新で `save()` を多用する (dirty checking で不要)
+- cascade の過剰設定で意図しない delete が伝播する
+- `@Transactional` 境界外での lazy load を前提にする
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/.claude/claudeos/skills/jpa-patterns/SKILL.md
+++ b/.claude/claudeos/skills/jpa-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "JPA と Hibernate の entity、fetch、transaction、query 設計�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - N+1。`FetchType.EAGER` 乱用 or lazy + ループ (fetch join / `@EntityGraph`)
 - session 外アクセスで `LazyInitializationException`

--- a/.claude/claudeos/skills/laravel-patterns/SKILL.md
+++ b/.claude/claudeos/skills/laravel-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: laravel-patterns
+description: "Laravel の controller、service、job、policy、Eloquent 設計を整えるときに使う。"
+---
+
 # laravel-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/laravel-patterns/SKILL.md
+++ b/.claude/claudeos/skills/laravel-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Laravel の controller、service、job、policy、Eloquent 設計�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - Eloquent の N+1。`with()` eager loading 不足 (Telescope/Debugbar で検出)
 - controller に業務ロジック集中。service/action クラスへ分離する

--- a/.claude/claudeos/skills/laravel-patterns/SKILL.md
+++ b/.claude/claudeos/skills/laravel-patterns/SKILL.md
@@ -56,6 +56,14 @@ description: "Laravel の controller、service、job、policy、Eloquent 設計�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- Eloquent の N+1。`with()` eager loading 不足 (Telescope/Debugbar で検出)
+- controller に業務ロジック集中。service/action クラスへ分離する
+- `Model::all()` を大量データに使いメモリ枯渇 (`chunk`/`cursor` を使う)
+- queue job の冪等性欠如で再試行が二重実行になる
+- 実行時に `env()` を直接呼ぶと config cache で null になる。`config()` 経由にする
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/.claude/claudeos/skills/laravel-security/SKILL.md
+++ b/.claude/claudeos/skills/laravel-security/SKILL.md
@@ -56,7 +56,7 @@ description: "Laravel の認可、バリデーション、mass assignment、秘�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `$fillable` 未定義 + `$guarded=[]` で mass assignment (is_admin 等を更新される)
 - `{!! !!}` の raw 出力で XSS。既定は `{{ }}` を使う

--- a/.claude/claudeos/skills/laravel-security/SKILL.md
+++ b/.claude/claudeos/skills/laravel-security/SKILL.md
@@ -56,6 +56,16 @@ description: "Laravel の認可、バリデーション、mass assignment、秘�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `$fillable` 未定義 + `$guarded=[]` で mass assignment (is_admin 等を更新される)
+- `{!! !!}` の raw 出力で XSS。既定は `{{ }}` を使う
+- `DB::raw()` / `whereRaw()` に未バインドのユーザー入力を渡す
+- 本番 `APP_DEBUG=true` 残置で Ignition がスタック/設定を露出する
+- route に policy/`authorize` を付け忘れて IDOR を作る
+- public disk 誤設定で非公開ファイルを `Storage::url` 経由で露出する
+- `VerifyCsrfToken::$except` へ安易に追加して CSRF を抜く
+
 ## 相性のよい command
 
 `/code-review`, `/verify`

--- a/.claude/claudeos/skills/laravel-security/SKILL.md
+++ b/.claude/claudeos/skills/laravel-security/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: laravel-security
+description: "Laravel の認可、バリデーション、mass assignment、秘密情報管理を扱うときに使う。"
+---
+
 # laravel-security
 
 ## 概要

--- a/.claude/claudeos/skills/laravel-tdd/SKILL.md
+++ b/.claude/claudeos/skills/laravel-tdd/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: laravel-tdd
+description: "Laravel の feature test と unit test を軸に TDD を進めるときに使う。"
+---
+
 # laravel-tdd
 
 ## 概要

--- a/.claude/claudeos/skills/laravel-tdd/SKILL.md
+++ b/.claude/claudeos/skills/laravel-tdd/SKILL.md
@@ -56,7 +56,7 @@ description: "Laravel の feature test と unit test を軸に TDD を進める�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - Feature test で `RefreshDatabase` を付け忘れテスト間が汚染される
 - 実メール/実決済を mock せず外部に到達させる (`Mail::fake()` 等)

--- a/.claude/claudeos/skills/laravel-tdd/SKILL.md
+++ b/.claude/claudeos/skills/laravel-tdd/SKILL.md
@@ -56,6 +56,13 @@ description: "Laravel の feature test と unit test を軸に TDD を進める�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- Feature test で `RefreshDatabase` を付け忘れテスト間が汚染される
+- 実メール/実決済を mock せず外部に到達させる (`Mail::fake()` 等)
+- factory の states を使わず重複したセットアップを量産する
+- `assertDatabaseHas` だけで副作用(event/job)の検証を怠る
+
 ## 相性のよい command
 
 `/tdd`

--- a/.claude/claudeos/skills/laravel-verification/SKILL.md
+++ b/.claude/claudeos/skills/laravel-verification/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: laravel-verification
+description: "Laravel の route、policy、queue、DB 更新を検証するときに使う。"
+---
+
 # laravel-verification
 
 ## 概要

--- a/.claude/claudeos/skills/laravel-verification/SKILL.md
+++ b/.claude/claudeos/skills/laravel-verification/SKILL.md
@@ -56,7 +56,7 @@ description: "Laravel の route、policy、queue、DB 更新を検証すると�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - route/policy/queue/DB 更新のうち queue の非同期挙動を検証しない
 - `php artisan route:list` で認可ミドルウェアの付与漏れを確認しない

--- a/.claude/claudeos/skills/laravel-verification/SKILL.md
+++ b/.claude/claudeos/skills/laravel-verification/SKILL.md
@@ -56,6 +56,13 @@ description: "Laravel の route、policy、queue、DB 更新を検証すると�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- route/policy/queue/DB 更新のうち queue の非同期挙動を検証しない
+- `php artisan route:list` で認可ミドルウェアの付与漏れを確認しない
+- migration の rollback を本番相当データで検証しない
+- config cache(`config:cache`) 後に挙動が変わる箇所を確認しない
+
 ## 相性のよい command
 
 `/verify`

--- a/.claude/claudeos/skills/liquid-glass-design/SKILL.md
+++ b/.claude/claudeos/skills/liquid-glass-design/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: liquid-glass-design
+description: "Liquid Glass 系の UI 指針に沿って画面設計を整えるときに使う。"
+---
+
 # liquid-glass-design
 
 ## 概要

--- a/.claude/claudeos/skills/market-research/SKILL.md
+++ b/.claude/claudeos/skills/market-research/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: market-research
+description: "市場調査、競合比較、一次情報に基づく外部環境分析を行うときに使う。"
+---
+
 # market-research
 
 ## 概要

--- a/.claude/claudeos/skills/nutrient-document-processing/SKILL.md
+++ b/.claude/claudeos/skills/nutrient-document-processing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: nutrient-document-processing
+description: "Nutrient API を使った文書抽出、変換、構造化を支援するときに使う。"
+---
+
 # nutrient-document-processing
 
 ## 概要

--- a/.claude/claudeos/skills/performance-review/SKILL.md
+++ b/.claude/claudeos/skills/performance-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: performance-review
+description: "差分や既存コードを性能観点でレビューし、ホットスポット・計算量・I/O 回数・並列性・メモリ・DB クエリのリグレッションを検出するときに使う。"
+---
+
 # performance-review
 
 ## 概要

--- a/.claude/claudeos/skills/perl-patterns/SKILL.md
+++ b/.claude/claudeos/skills/perl-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: perl-patterns
+description: "Modern Perl の責務分離、モジュール設計、読みやすい実装を扱うときに使う。"
+---
+
 # perl-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/perl-security/SKILL.md
+++ b/.claude/claudeos/skills/perl-security/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: perl-security
+description: "Perl の taint mode、安全な I/O、外部入力の取り扱いを整理するときに使う。"
+---
+
 # perl-security
 
 ## 概要

--- a/.claude/claudeos/skills/perl-testing/SKILL.md
+++ b/.claude/claudeos/skills/perl-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: perl-testing
+description: "Perl の Test2::V0、prove、カバレッジ計測を支援するときに使う。"
+---
+
 # perl-testing
 
 ## 概要

--- a/.claude/claudeos/skills/plankton-code-quality/SKILL.md
+++ b/.claude/claudeos/skills/plankton-code-quality/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: plankton-code-quality
+description: "保存時や実装時に品質を前倒し確保するフック連携を整えるときに使う。"
+---
+
 # plankton-code-quality
 
 ## 概要

--- a/.claude/claudeos/skills/postgres-patterns/SKILL.md
+++ b/.claude/claudeos/skills/postgres-patterns/SKILL.md
@@ -56,6 +56,16 @@ description: "PostgreSQL のクエリ最適化、インデックス、ロック�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `WHERE lower(col)=...` 等の関数適用で index が無効化する (式 index が要る)
+- 長時間トランザクションで VACUUM を阻害し bloat を招く
+- `CREATE INDEX` を `CONCURRENTLY` 無しで実行し write lock を取る
+- 旧版で `ADD COLUMN ... DEFAULT` が full table rewrite + lock を引き起こす
+- 接続プール(pgbouncer 等)無しで接続枯渇する
+- `SELECT *` + N+1 で過剰取得する
+- `SERIALIZABLE` の競合 retry を実装しない
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/.claude/claudeos/skills/postgres-patterns/SKILL.md
+++ b/.claude/claudeos/skills/postgres-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: postgres-patterns
+description: "PostgreSQL のクエリ最適化、インデックス、ロック、移行運用を扱うときに使う。"
+---
+
 # postgres-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/postgres-patterns/SKILL.md
+++ b/.claude/claudeos/skills/postgres-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "PostgreSQL のクエリ最適化、インデックス、ロック�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `WHERE lower(col)=...` 等の関数適用で index が無効化する (式 index が要る)
 - 長時間トランザクションで VACUUM を阻害し bloat を招く

--- a/.claude/claudeos/skills/project-guidelines-example/SKILL.md
+++ b/.claude/claudeos/skills/project-guidelines-example/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: project-guidelines-example
+description: "プロジェクト固有の skill を設計するための見本とテンプレートを示すときに使う。"
+---
+
 # project-guidelines-example
 
 ## 概要

--- a/.claude/claudeos/skills/python-patterns/SKILL.md
+++ b/.claude/claudeos/skills/python-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Python の型、例外、責務分割、保守しやすい構成�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - mutable default 引数 (`def f(x=[])`) で状態が共有される
 - bare `except:` で例外を握りつぶす / 原因を失う

--- a/.claude/claudeos/skills/python-patterns/SKILL.md
+++ b/.claude/claudeos/skills/python-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: python-patterns
+description: "Python の型、例外、責務分割、保守しやすい構成を整理するときに使う。"
+---
+
 # python-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/python-patterns/SKILL.md
+++ b/.claude/claudeos/skills/python-patterns/SKILL.md
@@ -56,6 +56,15 @@ description: "Python の型、例外、責務分割、保守しやすい構成�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- mutable default 引数 (`def f(x=[])`) で状態が共有される
+- bare `except:` で例外を握りつぶす / 原因を失う
+- `None` 比較に `==` を使う (`is None` が正)
+- モジュールレベル副作用 / 循環 import で読込順に依存する
+- CPU bound を thread で並列化して GIL に阻まれる (process/別実装へ)
+- ログを f-string で先評価し遅延評価の利点を失う
+
 ## 相性のよい command
 
 `/python-review`, `/verify`

--- a/.claude/claudeos/skills/python-testing/SKILL.md
+++ b/.claude/claudeos/skills/python-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: python-testing
+description: "pytest による fixture、parametrize、integration test を支援するときに使う。"
+---
+
 # python-testing
 
 ## 概要

--- a/.claude/claudeos/skills/regex-vs-llm-structured-text/SKILL.md
+++ b/.claude/claudeos/skills/regex-vs-llm-structured-text/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: regex-vs-llm-structured-text
+description: "正規表現と LLM のどちらで構造化テキスト処理すべきか判断するときに使う。"
+---
+
 # regex-vs-llm-structured-text
 
 ## 概要

--- a/.claude/claudeos/skills/requirements-extractor/SKILL.md
+++ b/.claude/claudeos/skills/requirements-extractor/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: requirements-extractor
+description: "議事録・要件メモ・メール・Slack ログなどの非構造化テキストから実行可能タスクと受け入れ基準を抽出し Issue 化するときに使う。"
+---
+
 # requirements-extractor
 
 ## 概要

--- a/.claude/claudeos/skills/search-first/SKILL.md
+++ b/.claude/claudeos/skills/search-first/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: search-first
+description: "実装前に既存コード、仕様、外部資料を優先的に調べるときに使う。"
+---
+
 # search-first
 
 ## 概要

--- a/.claude/claudeos/skills/security-review/SKILL.md
+++ b/.claude/claudeos/skills/security-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: security-review
+description: "認証、認可、入力検証、秘密情報、監査ログの観点からセキュリティを点検するときに使う。"
+---
+
 # security-review
 
 ## 概要

--- a/.claude/claudeos/skills/security-scan/SKILL.md
+++ b/.claude/claudeos/skills/security-scan/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: security-scan
+description: "静的解析、依存監査、設定監査をまとめて実行するときに使う。"
+---
+
 # security-scan
 
 ## 概要

--- a/.claude/claudeos/skills/skill-stocktake/SKILL.md
+++ b/.claude/claudeos/skills/skill-stocktake/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: skill-stocktake
+description: "既存 skills と commands の重複、不足、品質差を棚卸しするときに使う。"
+---
+
 # skill-stocktake
 
 ## 概要

--- a/.claude/claudeos/skills/springboot-patterns/SKILL.md
+++ b/.claude/claudeos/skills/springboot-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Spring Boot の層構造、DI、設定管理、トランザクシ�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `@Transactional` が self-invocation / private メソッドで無効になる
 - field injection でテスト困難化。constructor injection にする

--- a/.claude/claudeos/skills/springboot-patterns/SKILL.md
+++ b/.claude/claudeos/skills/springboot-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: springboot-patterns
+description: "Spring Boot の層構造、DI、設定管理、トランザクションを整理するときに使う。"
+---
+
 # springboot-patterns
 
 ## 概要

--- a/.claude/claudeos/skills/springboot-patterns/SKILL.md
+++ b/.claude/claudeos/skills/springboot-patterns/SKILL.md
@@ -56,6 +56,14 @@ description: "Spring Boot の層構造、DI、設定管理、トランザクシ�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `@Transactional` が self-invocation / private メソッドで無効になる
+- field injection でテスト困難化。constructor injection にする
+- `application.properties` に secret 直書き (profile/vault 分離する)
+- JPA entity を controller から直接返し lazy 例外・過剰公開を招く (DTO 化)
+- 読取専用処理に `@Transactional(readOnly=true)` を付けず不要 dirty checking が走る
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/.claude/claudeos/skills/springboot-security/SKILL.md
+++ b/.claude/claudeos/skills/springboot-security/SKILL.md
@@ -56,7 +56,7 @@ description: "Spring Security、認可、シークレット、設定分離を点
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `.anyRequest().permitAll()` の取り残しで全公開になる
 - REST 化で CSRF を全 disable するが cookie ベース認証が残り脆弱になる

--- a/.claude/claudeos/skills/springboot-security/SKILL.md
+++ b/.claude/claudeos/skills/springboot-security/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: springboot-security
+description: "Spring Security、認可、シークレット、設定分離を点検するときに使う。"
+---
+
 # springboot-security
 
 ## 概要

--- a/.claude/claudeos/skills/springboot-security/SKILL.md
+++ b/.claude/claudeos/skills/springboot-security/SKILL.md
@@ -56,6 +56,16 @@ description: "Spring Security、認可、シークレット、設定分離を点
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `.anyRequest().permitAll()` の取り残しで全公開になる
+- REST 化で CSRF を全 disable するが cookie ベース認証が残り脆弱になる
+- `@PreAuthorize` が self-invocation(同クラス内呼び出し)で効かない
+- actuator(`/env`,`/heapdump`)を無認証で露出する
+- `NoOpPasswordEncoder` / 平文でパスワードを保存する
+- JWT で `alg=none` を受理 / secret が短小で総当たり可能
+- CORS `allowedOrigins("*")` と credentials を併用する
+
 ## 相性のよい command
 
 `/code-review`, `/verify`

--- a/.claude/claudeos/skills/springboot-tdd/SKILL.md
+++ b/.claude/claudeos/skills/springboot-tdd/SKILL.md
@@ -56,6 +56,13 @@ description: "Spring Boot を controller から service まで段階的に TDD �
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `@SpringBootContext` 全起動を多用しテストが遅くなる (slice test を使う)
+- `@MockBean` 乱用で実結線の不具合を検出できなくなる
+- `@DataJpaTest` の組込 DB と本番 DB の方言差で漏れる
+- test 用 `application.properties` の profile 分離漏れで本番設定を読む
+
 ## 相性のよい command
 
 `/tdd`

--- a/.claude/claudeos/skills/springboot-tdd/SKILL.md
+++ b/.claude/claudeos/skills/springboot-tdd/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: springboot-tdd
+description: "Spring Boot を controller から service まで段階的に TDD するときに使う。"
+---
+
 # springboot-tdd
 
 ## 概要

--- a/.claude/claudeos/skills/springboot-tdd/SKILL.md
+++ b/.claude/claudeos/skills/springboot-tdd/SKILL.md
@@ -56,7 +56,7 @@ description: "Spring Boot を controller から service まで段階的に TDD �
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `@SpringBootContext` 全起動を多用しテストが遅くなる (slice test を使う)
 - `@MockBean` 乱用で実結線の不具合を検出できなくなる

--- a/.claude/claudeos/skills/springboot-verification/SKILL.md
+++ b/.claude/claudeos/skills/springboot-verification/SKILL.md
@@ -56,7 +56,7 @@ description: "Spring Boot の起動、統合試験、DB 接続、主要 API の�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - 起動・統合・DB 接続のうち lazy 関連の境界外アクセスを検証しない
 - actuator/health endpoint の応答だけで実依存(DB/MQ)の死活を判断する

--- a/.claude/claudeos/skills/springboot-verification/SKILL.md
+++ b/.claude/claudeos/skills/springboot-verification/SKILL.md
@@ -56,6 +56,13 @@ description: "Spring Boot の起動、統合試験、DB 接続、主要 API の�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- 起動・統合・DB 接続のうち lazy 関連の境界外アクセスを検証しない
+- actuator/health endpoint の応答だけで実依存(DB/MQ)の死活を判断する
+- flyway/liquibase の migration 適用順を本番相当で確認しない
+- 主要 API の異常系(401/403/409)の検証を省く
+
 ## 相性のよい command
 
 `/verify`

--- a/.claude/claudeos/skills/springboot-verification/SKILL.md
+++ b/.claude/claudeos/skills/springboot-verification/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: springboot-verification
+description: "Spring Boot の起動、統合試験、DB 接続、主要 API の検証を行うときに使う。"
+---
+
 # springboot-verification
 
 ## 概要

--- a/.claude/claudeos/skills/strategic-compact/SKILL.md
+++ b/.claude/claudeos/skills/strategic-compact/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: strategic-compact
+description: "長い文脈を圧縮する前に何を残し何を捨てるかを判断するときに使う。"
+---
+
 # strategic-compact
 
 ## 概要

--- a/.claude/claudeos/skills/swift-actor-persistence/SKILL.md
+++ b/.claude/claudeos/skills/swift-actor-persistence/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: swift-actor-persistence
+description: "Swift actor を用いた安全な永続化と競合回避を扱うときに使う。"
+---
+
 # swift-actor-persistence
 
 ## 概要

--- a/.claude/claudeos/skills/swift-concurrency-6-2/SKILL.md
+++ b/.claude/claudeos/skills/swift-concurrency-6-2/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: swift-concurrency-6-2
+description: "Swift 6.2 の concurrency を安全かつ段階的に導入するときに使う。"
+---
+
 # swift-concurrency-6-2
 
 ## 概要

--- a/.claude/claudeos/skills/swift-protocol-di-testing/SKILL.md
+++ b/.claude/claudeos/skills/swift-protocol-di-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: swift-protocol-di-testing
+description: "Swift の protocol ベース DI とテスト容易性向上を支援するときに使う。"
+---
+
 # swift-protocol-di-testing
 
 ## 概要

--- a/.claude/claudeos/skills/tdd-workflow/SKILL.md
+++ b/.claude/claudeos/skills/tdd-workflow/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: tdd-workflow
+description: "Red、Green、Refactor の流れで安全に実装を進めるときに使う。"
+---
+
 # tdd-workflow
 
 ## 概要

--- a/.claude/claudeos/skills/verification-loop/SKILL.md
+++ b/.claude/claudeos/skills/verification-loop/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: verification-loop
+description: "変更近傍から全体へ広げる継続的検証ループを運用するときに使う。"
+---
+
 # verification-loop
 
 ## 概要

--- a/.claude/claudeos/skills/videodb/SKILL.md
+++ b/.claude/claudeos/skills/videodb/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: videodb
+description: "動画、音声、字幕、検索、編集、生成のワークフローを扱うときに使う。"
+---
+
 # videodb
 
 ## 概要

--- a/Claude/templates/claudeos/.claude-plugin/marketplace.json
+++ b/Claude/templates/claudeos/.claude-plugin/marketplace.json
@@ -6,10 +6,7 @@
   "plugins": [
     {
       "name": "everything-claude-code",
-      "source": {
-        "source": "local",
-        "path": "./everything-claude-code"
-      },
+      "source": "./",
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"

--- a/Claude/templates/claudeos/skills/api-design/SKILL.md
+++ b/Claude/templates/claudeos/skills/api-design/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: api-design
+description: "REST API の契約、ページネーション、互換性、エラー応答を設計するときに使う。"
+---
+
 # api-design
 
 ## 概要

--- a/Claude/templates/claudeos/skills/article-writing/SKILL.md
+++ b/Claude/templates/claudeos/skills/article-writing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: article-writing
+description: "自然で読みやすい長文記事、技術解説、社内ナレッジ文書を作成するときに使う。"
+---
+
 # article-writing
 
 ## 概要

--- a/Claude/templates/claudeos/skills/autonomous-loops/SKILL.md
+++ b/Claude/templates/claudeos/skills/autonomous-loops/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: autonomous-loops
+description: "逐次ループ、PR ループ、DAG 型オーケストレーションを設計するときに使う。"
+---
+
 # autonomous-loops
 
 ## 概要

--- a/Claude/templates/claudeos/skills/backend-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/backend-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: backend-patterns
+description: "API、DB、キャッシュ、非同期処理、認証認可を含むバックエンド設計の標準を示すときに使う。"
+---
+
 # backend-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/clickhouse-io/SKILL.md
+++ b/Claude/templates/claudeos/skills/clickhouse-io/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: clickhouse-io
+description: "ClickHouse のテーブル設計、分析クエリ、集計基盤、データエンジニアリングを支援するときに使う。"
+---
+
 # clickhouse-io
 
 ## 概要

--- a/Claude/templates/claudeos/skills/clickhouse-io/SKILL.md
+++ b/Claude/templates/claudeos/skills/clickhouse-io/SKILL.md
@@ -56,7 +56,7 @@ description: "ClickHouse のテーブル設計、分析クエリ、集計基盤�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - 列指向なのに `SELECT *` で全列読込し I/O を浪費する
 - 行単位 INSERT を多発させ part 爆発 → merge 過負荷 (バッチ INSERT 必須)

--- a/Claude/templates/claudeos/skills/clickhouse-io/SKILL.md
+++ b/Claude/templates/claudeos/skills/clickhouse-io/SKILL.md
@@ -56,6 +56,16 @@ description: "ClickHouse のテーブル設計、分析クエリ、集計基盤�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- 列指向なのに `SELECT *` で全列読込し I/O を浪費する
+- 行単位 INSERT を多発させ part 爆発 → merge 過負荷 (バッチ INSERT 必須)
+- `FINAL` 常用で性能劣化 / ReplacingMergeTree の重複解消を即時と誤解する
+- sorting key(`ORDER BY`)設計ミスで primary index が効かず full scan
+- 高カーディナリティの partition key で part 数が爆発する
+- `ALTER UPDATE/DELETE`(mutation) を OLTP 的に使う (非同期・高コスト)
+- `Nullable` 乱用でストレージと性能を劣化させる
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/Claude/templates/claudeos/skills/coding-standards/SKILL.md
+++ b/Claude/templates/claudeos/skills/coding-standards/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: coding-standards
+description: "言語共通のコーディング規約、責務分離、命名、コメント、可読性を整えるときに使う。"
+---
+
 # coding-standards
 
 ## 概要

--- a/Claude/templates/claudeos/skills/configure-ecc/SKILL.md
+++ b/Claude/templates/claudeos/skills/configure-ecc/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: configure-ecc
+description: "everything-claude-code の初期導入と設定整備を支援するときに使う。"
+---
+
 # configure-ecc
 
 ## 概要

--- a/Claude/templates/claudeos/skills/content-engine/SKILL.md
+++ b/Claude/templates/claudeos/skills/content-engine/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: content-engine
+description: "1 つの原稿から複数媒体向けの投稿や配信用コンテンツへ再構成するときに使う。"
+---
+
 # content-engine
 
 ## 概要

--- a/Claude/templates/claudeos/skills/content-hash-cache-pattern/SKILL.md
+++ b/Claude/templates/claudeos/skills/content-hash-cache-pattern/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: content-hash-cache-pattern
+description: "コンテンツハッシュを使って再処理を避けるキャッシュ戦略を整えるときに使う。"
+---
+
 # content-hash-cache-pattern
 
 ## 概要

--- a/Claude/templates/claudeos/skills/continuous-learning-v2/SKILL.md
+++ b/Claude/templates/claudeos/skills/continuous-learning-v2/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: continuous-learning-v2
+description: "学びを信頼度付きで記録し、採用候補と保留候補を分けて管理するときに使う。"
+---
+
 # continuous-learning-v2
 
 ## 概要

--- a/Claude/templates/claudeos/skills/continuous-learning/SKILL.md
+++ b/Claude/templates/claudeos/skills/continuous-learning/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: continuous-learning
+description: "セッションから学びを抽出して再利用可能な知見へまとめるときに使う。"
+---
+
 # continuous-learning
 
 ## 概要

--- a/Claude/templates/claudeos/skills/cost-aware-llm-pipeline/SKILL.md
+++ b/Claude/templates/claudeos/skills/cost-aware-llm-pipeline/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: cost-aware-llm-pipeline
+description: "モデル選択、ルーティング、トークン費用、予算上限を意識した LLM パイプラインを構成するときに使う。"
+---
+
 # cost-aware-llm-pipeline
 
 ## 概要

--- a/Claude/templates/claudeos/skills/cpp-coding-standards/SKILL.md
+++ b/Claude/templates/claudeos/skills/cpp-coding-standards/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: cpp-coding-standards
+description: "C++ Core Guidelines を踏まえた安全な設計と実装を支援するときに使う。"
+---
+
 # cpp-coding-standards
 
 ## 概要

--- a/Claude/templates/claudeos/skills/cpp-testing/SKILL.md
+++ b/Claude/templates/claudeos/skills/cpp-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: cpp-testing
+description: "GoogleTest、CMake、CTest を使った C++ テスト戦略を整えるときに使う。"
+---
+
 # cpp-testing
 
 ## 概要

--- a/Claude/templates/claudeos/skills/database-migrations/SKILL.md
+++ b/Claude/templates/claudeos/skills/database-migrations/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: database-migrations
+description: "各種 ORM やフレームワークにおける安全な migration 運用を整理するときに使う。"
+---
+
 # database-migrations
 
 ## 概要

--- a/Claude/templates/claudeos/skills/database-migrations/SKILL.md
+++ b/Claude/templates/claudeos/skills/database-migrations/SKILL.md
@@ -56,7 +56,7 @@ description: "各種 ORM やフレームワークにおける安全な migration
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - rename/drop を deploy と同時実行し旧コードが落ちる (expand→contract の2段階に)
 - 後方互換を壊す変更を 1 migration に詰め込む

--- a/Claude/templates/claudeos/skills/database-migrations/SKILL.md
+++ b/Claude/templates/claudeos/skills/database-migrations/SKILL.md
@@ -56,6 +56,15 @@ description: "各種 ORM やフレームワークにおける安全な migration
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- rename/drop を deploy と同時実行し旧コードが落ちる (expand→contract の2段階に)
+- 後方互換を壊す変更を 1 migration に詰め込む
+- 大テーブルの DDL で長時間 lock (オンライン DDL / batched backfill)
+- down migration(rollback)を未検証のまま出す
+- data migration を schema migration に混在させる
+- 本番でしか出ない順序依存・seed 依存を見逃す
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/Claude/templates/claudeos/skills/deployment-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/deployment-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "CI/CD、環境差異、ヘルスチェック、ロールバック�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - readiness と liveness を混同し、起動中に traffic を流す
 - rollback 手順未整備 / DB migration が rollback 不能

--- a/Claude/templates/claudeos/skills/deployment-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/deployment-patterns/SKILL.md
@@ -56,6 +56,15 @@ description: "CI/CD、環境差異、ヘルスチェック、ロールバック�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- readiness と liveness を混同し、起動中に traffic を流す
+- rollback 手順未整備 / DB migration が rollback 不能
+- ビルド時 env と実行時 env を混同する (12-factor 違反)
+- secret を image / CI ログに露出する
+- zero-downtime 前提なのに in-place restart で瞬断する
+- canary/blue-green で新旧スキーマ非互換 (expand/contract で吸収する)
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/Claude/templates/claudeos/skills/deployment-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/deployment-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: deployment-patterns
+description: "CI/CD、環境差異、ヘルスチェック、ロールバックを設計するときに使う。"
+---
+
 # deployment-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/django-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Django の models、views、service 層、管理画面設計を整
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `select_related` / `prefetch_related` 不足で N+1 クエリ
 - QuerySet の遅延評価を理解せずループ内でクエリを発行する

--- a/Claude/templates/claudeos/skills/django-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-patterns/SKILL.md
@@ -56,6 +56,15 @@ description: "Django の models、views、service 層、管理画面設計を整
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `select_related` / `prefetch_related` 不足で N+1 クエリ
+- QuerySet の遅延評価を理解せずループ内でクエリを発行する
+- fat views / fat models で service 層の責務分離が崩れる
+- model 変更後の `makemigrations` 忘れで schema と乖離する
+- signals 多用で副作用の追跡が不能になる
+- settings を環境分離せず単一 `settings.py` に `if` 分岐を詰め込む
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/Claude/templates/claudeos/skills/django-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: django-patterns
+description: "Django の models、views、service 層、管理画面設計を整理するときに使う。"
+---
+
 # django-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/django-security/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-security/SKILL.md
@@ -56,7 +56,7 @@ description: "Django の CSRF、認証認可、ORM 安全性、設定不備を�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - 本番 `DEBUG=True` 残置で例外画面に settings と secret が露出する
 - `ALLOWED_HOSTS` 未設定 / `["*"]` で Host ヘッダ injection を許す

--- a/Claude/templates/claudeos/skills/django-security/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-security/SKILL.md
@@ -56,6 +56,17 @@ description: "Django の CSRF、認証認可、ORM 安全性、設定不備を�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- 本番 `DEBUG=True` 残置で例外画面に settings と secret が露出する
+- `ALLOWED_HOSTS` 未設定 / `["*"]` で Host ヘッダ injection を許す
+- `SECRET_KEY` をコード/リポジトリにハードコードする
+- `.raw()` / `.extra()` / 文字列連結 SQL で ORM の injection 防御を迂回する
+- `mark_safe` / `|safe` / `format_html` 誤用で XSS を作る
+- `@csrf_exempt` の無自覚付与、SessionAuth の API で CSRF が抜ける
+- `get_object_or_404` だけで所有者チェックを省き IDOR を作る
+- session/CSRF cookie の `SECURE` / `HttpOnly` / `SameSite` 未設定
+
 ## 相性のよい command
 
 `/code-review`, `/verify`

--- a/Claude/templates/claudeos/skills/django-security/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-security/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: django-security
+description: "Django の CSRF、認証認可、ORM 安全性、設定不備を点検するときに使う。"
+---
+
 # django-security
 
 ## 概要

--- a/Claude/templates/claudeos/skills/django-tdd/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-tdd/SKILL.md
@@ -56,7 +56,7 @@ description: "Django をテスト先行で安全に実装するときに使う�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `TestCase`(トランザクション) と `TransactionTestCase` の差異を無視し flaky 化
 - 実 DB/外部 API に依存したテストで遅く不安定になる

--- a/Claude/templates/claudeos/skills/django-tdd/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-tdd/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: django-tdd
+description: "Django をテスト先行で安全に実装するときに使う。"
+---
+
 # django-tdd
 
 ## 概要

--- a/Claude/templates/claudeos/skills/django-tdd/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-tdd/SKILL.md
@@ -56,6 +56,14 @@ description: "Django をテスト先行で安全に実装するときに使う�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `TestCase`(トランザクション) と `TransactionTestCase` の差異を無視し flaky 化
+- 実 DB/外部 API に依存したテストで遅く不安定になる
+- fixtures 肥大で意図が読めない。factory(`factory_boy`) で必要分だけ作る
+- `setUp` の重い処理を毎テスト実行して遅くする (`setUpTestData` を使う)
+- freeze せず `timezone.now()` 依存テストを書き時間で壊れる
+
 ## 相性のよい command
 
 `/tdd`

--- a/Claude/templates/claudeos/skills/django-verification/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-verification/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: django-verification
+description: "Django の migration、permission、API、画面の検証を回すときに使う。"
+---
+
 # django-verification
 
 ## 概要

--- a/Claude/templates/claudeos/skills/django-verification/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-verification/SKILL.md
@@ -56,6 +56,13 @@ description: "Django の migration、permission、API、画面の検証を回す
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- migration の前進だけ確認し rollback(逆 migration) を検証しない
+- permission/所有者チェックの検証を正常系だけで済ませる
+- `makemigrations --check --dry-run` を CI に入れず未生成 migration を見逃す
+- 本番相当データ量での性能/タイムアウトを確認しない
+
 ## 相性のよい command
 
 `/verify`

--- a/Claude/templates/claudeos/skills/django-verification/SKILL.md
+++ b/Claude/templates/claudeos/skills/django-verification/SKILL.md
@@ -56,7 +56,7 @@ description: "Django の migration、permission、API、画面の検証を回す
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - migration の前進だけ確認し rollback(逆 migration) を検証しない
 - permission/所有者チェックの検証を正常系だけで済ませる

--- a/Claude/templates/claudeos/skills/docker-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/docker-patterns/SKILL.md
@@ -56,6 +56,16 @@ description: "Docker Compose、ネットワーク、ボリューム、コンテ�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `latest` タグ依存で再現性が壊れる。digest 固定か明示バージョンタグを使う
+- `.dockerignore` 未整備で `COPY . .` が `.git`/`node_modules`/secret を image へ焼き込む
+- root 実行のまま放置。`USER` 指定と read-only rootfs を検討する
+- `depends_on` は起動順を保証するが起動完了は保証しない。healthcheck + `condition: service_healthy` が要る
+- マルチステージビルド未使用で build ツールチェーンを本番 image に残し肥大化させる
+- secret を `build-arg` や ENV に渡すと image layer / `docker inspect` から漏れる
+- Linux の bind mount は host uid/gid 差異でコンテナ内書込みが失敗する
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/Claude/templates/claudeos/skills/docker-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/docker-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Docker Compose、ネットワーク、ボリューム、コンテ�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `latest` タグ依存で再現性が壊れる。digest 固定か明示バージョンタグを使う
 - `.dockerignore` 未整備で `COPY . .` が `.git`/`node_modules`/secret を image へ焼き込む

--- a/Claude/templates/claudeos/skills/docker-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/docker-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: docker-patterns
+description: "Docker Compose、ネットワーク、ボリューム、コンテナセキュリティを扱うときに使う。"
+---
+
 # docker-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/e2e-testing/SKILL.md
+++ b/Claude/templates/claudeos/skills/e2e-testing/SKILL.md
@@ -56,6 +56,15 @@ description: "Playwright の E2E テスト、Page Object Model、待機戦略を
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- 固定 `sleep`/`waitForTimeout` で flaky 化 (web-first assertion / auto-wait を使う)
+- 脆い CSS セレクタ依存。role/label/test-id ベースにする
+- テスト間で DB/seed のリセットを怠り状態が漏れる
+- 認証を毎テスト UI 経由にする (storageState を使い回す)
+- 並列実行時のデータ競合を考慮しない
+- `networkidle` 待ちを過信して不安定化させる
+
 ## 相性のよい command
 
 `/e2e`, `/verify`

--- a/Claude/templates/claudeos/skills/e2e-testing/SKILL.md
+++ b/Claude/templates/claudeos/skills/e2e-testing/SKILL.md
@@ -56,7 +56,7 @@ description: "Playwright の E2E テスト、Page Object Model、待機戦略を
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - 固定 `sleep`/`waitForTimeout` で flaky 化 (web-first assertion / auto-wait を使う)
 - 脆い CSS セレクタ依存。role/label/test-id ベースにする

--- a/Claude/templates/claudeos/skills/e2e-testing/SKILL.md
+++ b/Claude/templates/claudeos/skills/e2e-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: e2e-testing
+description: "Playwright の E2E テスト、Page Object Model、待機戦略を扱うときに使う。"
+---
+
 # e2e-testing
 
 ## 概要

--- a/Claude/templates/claudeos/skills/eval-harness/SKILL.md
+++ b/Claude/templates/claudeos/skills/eval-harness/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: eval-harness
+description: "評価ハーネス、採点基準、実験条件、再現可能な検証を整備するときに使う。"
+---
+
 # eval-harness
 
 ## 概要

--- a/Claude/templates/claudeos/skills/foundation-models-on-device/SKILL.md
+++ b/Claude/templates/claudeos/skills/foundation-models-on-device/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: foundation-models-on-device
+description: "Apple のオンデバイス Foundation Models 活用設計を支援するときに使う。"
+---
+
 # foundation-models-on-device
 
 ## 概要

--- a/Claude/templates/claudeos/skills/frontend-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/frontend-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: frontend-patterns
+description: "React と Next.js を中心に画面設計、状態管理、UI 分割、アクセシビリティを整理するときに使う。"
+---
+
 # frontend-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/frontend-slides/SKILL.md
+++ b/Claude/templates/claudeos/skills/frontend-slides/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: frontend-slides
+description: "HTML スライド、プレゼン資料、PPTX 代替の Web ベース資料作成を支援するときに使う。"
+---
+
 # frontend-slides
 
 ## 概要

--- a/Claude/templates/claudeos/skills/golang-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/golang-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: golang-patterns
+description: "Go の idiom、context、エラー処理、パッケージ分割を整えるときに使う。"
+---
+
 # golang-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/golang-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/golang-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Go の idiom、context、エラー処理、パッケージ分割�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `err` を `_` で握りつぶす / wrap せず原因を失う (`fmt.Errorf("...: %w", err)`)
 - goroutine leak。context cancel / channel close 漏れを残す

--- a/Claude/templates/claudeos/skills/golang-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/golang-patterns/SKILL.md
@@ -56,6 +56,15 @@ description: "Go の idiom、context、エラー処理、パッケージ分割�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `err` を `_` で握りつぶす / wrap せず原因を失う (`fmt.Errorf("...: %w", err)`)
+- goroutine leak。context cancel / channel close 漏れを残す
+- Go 1.22 未満の loop 変数キャプチャを goroutine/closure が共有する
+- 共有 map への並行書込みで data race (`-race` で検出する)
+- nil map への書込み panic / nil interface 比較の落とし穴
+- ループ内 `defer` の多用でリソース解放が関数末尾まで遅延する
+
 ## 相性のよい command
 
 `/go-review`, `/go-test`

--- a/Claude/templates/claudeos/skills/golang-testing/SKILL.md
+++ b/Claude/templates/claudeos/skills/golang-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: golang-testing
+description: "Go の unit test、table-driven test、benchmark、TDD を支援するときに使う。"
+---
+
 # golang-testing
 
 ## 概要

--- a/Claude/templates/claudeos/skills/investor-materials/SKILL.md
+++ b/Claude/templates/claudeos/skills/investor-materials/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: investor-materials
+description: "ピッチ資料、1 ページ要約、投資家向け説明資料を構成するときに使う。"
+---
+
 # investor-materials
 
 ## 概要

--- a/Claude/templates/claudeos/skills/investor-outreach/SKILL.md
+++ b/Claude/templates/claudeos/skills/investor-outreach/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: investor-outreach
+description: "投資家や候補先への個別連絡文、フォローアップ文面を整えるときに使う。"
+---
+
 # investor-outreach
 
 ## 概要

--- a/Claude/templates/claudeos/skills/iterative-retrieval/SKILL.md
+++ b/Claude/templates/claudeos/skills/iterative-retrieval/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: iterative-retrieval
+description: "必要な文脈だけを段階的に掘り下げ、過剰読込を防ぐときに使う。"
+---
+
 # iterative-retrieval
 
 ## 概要

--- a/Claude/templates/claudeos/skills/java-coding-standards/SKILL.md
+++ b/Claude/templates/claudeos/skills/java-coding-standards/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: java-coding-standards
+description: "Java の命名、例外、レイヤ分離、読みやすい実装基準を揃えるときに使う。"
+---
+
 # java-coding-standards
 
 ## 概要

--- a/Claude/templates/claudeos/skills/jpa-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/jpa-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: jpa-patterns
+description: "JPA と Hibernate の entity、fetch、transaction、query 設計を整理するときに使う。"
+---
+
 # jpa-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/jpa-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/jpa-patterns/SKILL.md
@@ -56,6 +56,15 @@ description: "JPA と Hibernate の entity、fetch、transaction、query 設計�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- N+1。`FetchType.EAGER` 乱用 or lazy + ループ (fetch join / `@EntityGraph`)
+- session 外アクセスで `LazyInitializationException`
+- `equals`/`hashCode` を生成 ID で実装する (永続化前は null)
+- 更新で `save()` を多用する (dirty checking で不要)
+- cascade の過剰設定で意図しない delete が伝播する
+- `@Transactional` 境界外での lazy load を前提にする
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/Claude/templates/claudeos/skills/jpa-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/jpa-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "JPA と Hibernate の entity、fetch、transaction、query 設計�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - N+1。`FetchType.EAGER` 乱用 or lazy + ループ (fetch join / `@EntityGraph`)
 - session 外アクセスで `LazyInitializationException`

--- a/Claude/templates/claudeos/skills/laravel-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: laravel-patterns
+description: "Laravel の controller、service、job、policy、Eloquent 設計を整えるときに使う。"
+---
+
 # laravel-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/laravel-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Laravel の controller、service、job、policy、Eloquent 設計�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - Eloquent の N+1。`with()` eager loading 不足 (Telescope/Debugbar で検出)
 - controller に業務ロジック集中。service/action クラスへ分離する

--- a/Claude/templates/claudeos/skills/laravel-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-patterns/SKILL.md
@@ -56,6 +56,14 @@ description: "Laravel の controller、service、job、policy、Eloquent 設計�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- Eloquent の N+1。`with()` eager loading 不足 (Telescope/Debugbar で検出)
+- controller に業務ロジック集中。service/action クラスへ分離する
+- `Model::all()` を大量データに使いメモリ枯渇 (`chunk`/`cursor` を使う)
+- queue job の冪等性欠如で再試行が二重実行になる
+- 実行時に `env()` を直接呼ぶと config cache で null になる。`config()` 経由にする
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/Claude/templates/claudeos/skills/laravel-security/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-security/SKILL.md
@@ -56,7 +56,7 @@ description: "Laravel の認可、バリデーション、mass assignment、秘�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `$fillable` 未定義 + `$guarded=[]` で mass assignment (is_admin 等を更新される)
 - `{!! !!}` の raw 出力で XSS。既定は `{{ }}` を使う

--- a/Claude/templates/claudeos/skills/laravel-security/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-security/SKILL.md
@@ -56,6 +56,16 @@ description: "Laravel の認可、バリデーション、mass assignment、秘�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `$fillable` 未定義 + `$guarded=[]` で mass assignment (is_admin 等を更新される)
+- `{!! !!}` の raw 出力で XSS。既定は `{{ }}` を使う
+- `DB::raw()` / `whereRaw()` に未バインドのユーザー入力を渡す
+- 本番 `APP_DEBUG=true` 残置で Ignition がスタック/設定を露出する
+- route に policy/`authorize` を付け忘れて IDOR を作る
+- public disk 誤設定で非公開ファイルを `Storage::url` 経由で露出する
+- `VerifyCsrfToken::$except` へ安易に追加して CSRF を抜く
+
 ## 相性のよい command
 
 `/code-review`, `/verify`

--- a/Claude/templates/claudeos/skills/laravel-security/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-security/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: laravel-security
+description: "Laravel の認可、バリデーション、mass assignment、秘密情報管理を扱うときに使う。"
+---
+
 # laravel-security
 
 ## 概要

--- a/Claude/templates/claudeos/skills/laravel-tdd/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-tdd/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: laravel-tdd
+description: "Laravel の feature test と unit test を軸に TDD を進めるときに使う。"
+---
+
 # laravel-tdd
 
 ## 概要

--- a/Claude/templates/claudeos/skills/laravel-tdd/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-tdd/SKILL.md
@@ -56,7 +56,7 @@ description: "Laravel の feature test と unit test を軸に TDD を進める�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - Feature test で `RefreshDatabase` を付け忘れテスト間が汚染される
 - 実メール/実決済を mock せず外部に到達させる (`Mail::fake()` 等)

--- a/Claude/templates/claudeos/skills/laravel-tdd/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-tdd/SKILL.md
@@ -56,6 +56,13 @@ description: "Laravel の feature test と unit test を軸に TDD を進める�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- Feature test で `RefreshDatabase` を付け忘れテスト間が汚染される
+- 実メール/実決済を mock せず外部に到達させる (`Mail::fake()` 等)
+- factory の states を使わず重複したセットアップを量産する
+- `assertDatabaseHas` だけで副作用(event/job)の検証を怠る
+
 ## 相性のよい command
 
 `/tdd`

--- a/Claude/templates/claudeos/skills/laravel-verification/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-verification/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: laravel-verification
+description: "Laravel の route、policy、queue、DB 更新を検証するときに使う。"
+---
+
 # laravel-verification
 
 ## 概要

--- a/Claude/templates/claudeos/skills/laravel-verification/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-verification/SKILL.md
@@ -56,7 +56,7 @@ description: "Laravel の route、policy、queue、DB 更新を検証すると�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - route/policy/queue/DB 更新のうち queue の非同期挙動を検証しない
 - `php artisan route:list` で認可ミドルウェアの付与漏れを確認しない

--- a/Claude/templates/claudeos/skills/laravel-verification/SKILL.md
+++ b/Claude/templates/claudeos/skills/laravel-verification/SKILL.md
@@ -56,6 +56,13 @@ description: "Laravel の route、policy、queue、DB 更新を検証すると�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- route/policy/queue/DB 更新のうち queue の非同期挙動を検証しない
+- `php artisan route:list` で認可ミドルウェアの付与漏れを確認しない
+- migration の rollback を本番相当データで検証しない
+- config cache(`config:cache`) 後に挙動が変わる箇所を確認しない
+
 ## 相性のよい command
 
 `/verify`

--- a/Claude/templates/claudeos/skills/liquid-glass-design/SKILL.md
+++ b/Claude/templates/claudeos/skills/liquid-glass-design/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: liquid-glass-design
+description: "Liquid Glass 系の UI 指針に沿って画面設計を整えるときに使う。"
+---
+
 # liquid-glass-design
 
 ## 概要

--- a/Claude/templates/claudeos/skills/market-research/SKILL.md
+++ b/Claude/templates/claudeos/skills/market-research/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: market-research
+description: "市場調査、競合比較、一次情報に基づく外部環境分析を行うときに使う。"
+---
+
 # market-research
 
 ## 概要

--- a/Claude/templates/claudeos/skills/nutrient-document-processing/SKILL.md
+++ b/Claude/templates/claudeos/skills/nutrient-document-processing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: nutrient-document-processing
+description: "Nutrient API を使った文書抽出、変換、構造化を支援するときに使う。"
+---
+
 # nutrient-document-processing
 
 ## 概要

--- a/Claude/templates/claudeos/skills/performance-review/SKILL.md
+++ b/Claude/templates/claudeos/skills/performance-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: performance-review
+description: "差分や既存コードを性能観点でレビューし、ホットスポット・計算量・I/O 回数・並列性・メモリ・DB クエリのリグレッションを検出するときに使う。"
+---
+
 # performance-review
 
 ## 概要

--- a/Claude/templates/claudeos/skills/perl-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/perl-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: perl-patterns
+description: "Modern Perl の責務分離、モジュール設計、読みやすい実装を扱うときに使う。"
+---
+
 # perl-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/perl-security/SKILL.md
+++ b/Claude/templates/claudeos/skills/perl-security/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: perl-security
+description: "Perl の taint mode、安全な I/O、外部入力の取り扱いを整理するときに使う。"
+---
+
 # perl-security
 
 ## 概要

--- a/Claude/templates/claudeos/skills/perl-testing/SKILL.md
+++ b/Claude/templates/claudeos/skills/perl-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: perl-testing
+description: "Perl の Test2::V0、prove、カバレッジ計測を支援するときに使う。"
+---
+
 # perl-testing
 
 ## 概要

--- a/Claude/templates/claudeos/skills/plankton-code-quality/SKILL.md
+++ b/Claude/templates/claudeos/skills/plankton-code-quality/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: plankton-code-quality
+description: "保存時や実装時に品質を前倒し確保するフック連携を整えるときに使う。"
+---
+
 # plankton-code-quality
 
 ## 概要

--- a/Claude/templates/claudeos/skills/postgres-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/postgres-patterns/SKILL.md
@@ -56,6 +56,16 @@ description: "PostgreSQL のクエリ最適化、インデックス、ロック�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `WHERE lower(col)=...` 等の関数適用で index が無効化する (式 index が要る)
+- 長時間トランザクションで VACUUM を阻害し bloat を招く
+- `CREATE INDEX` を `CONCURRENTLY` 無しで実行し write lock を取る
+- 旧版で `ADD COLUMN ... DEFAULT` が full table rewrite + lock を引き起こす
+- 接続プール(pgbouncer 等)無しで接続枯渇する
+- `SELECT *` + N+1 で過剰取得する
+- `SERIALIZABLE` の競合 retry を実装しない
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/Claude/templates/claudeos/skills/postgres-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/postgres-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: postgres-patterns
+description: "PostgreSQL のクエリ最適化、インデックス、ロック、移行運用を扱うときに使う。"
+---
+
 # postgres-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/postgres-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/postgres-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "PostgreSQL のクエリ最適化、インデックス、ロック�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `WHERE lower(col)=...` 等の関数適用で index が無効化する (式 index が要る)
 - 長時間トランザクションで VACUUM を阻害し bloat を招く

--- a/Claude/templates/claudeos/skills/project-guidelines-example/SKILL.md
+++ b/Claude/templates/claudeos/skills/project-guidelines-example/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: project-guidelines-example
+description: "プロジェクト固有の skill を設計するための見本とテンプレートを示すときに使う。"
+---
+
 # project-guidelines-example
 
 ## 概要

--- a/Claude/templates/claudeos/skills/python-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/python-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Python の型、例外、責務分割、保守しやすい構成�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - mutable default 引数 (`def f(x=[])`) で状態が共有される
 - bare `except:` で例外を握りつぶす / 原因を失う

--- a/Claude/templates/claudeos/skills/python-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/python-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: python-patterns
+description: "Python の型、例外、責務分割、保守しやすい構成を整理するときに使う。"
+---
+
 # python-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/python-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/python-patterns/SKILL.md
@@ -56,6 +56,15 @@ description: "Python の型、例外、責務分割、保守しやすい構成�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- mutable default 引数 (`def f(x=[])`) で状態が共有される
+- bare `except:` で例外を握りつぶす / 原因を失う
+- `None` 比較に `==` を使う (`is None` が正)
+- モジュールレベル副作用 / 循環 import で読込順に依存する
+- CPU bound を thread で並列化して GIL に阻まれる (process/別実装へ)
+- ログを f-string で先評価し遅延評価の利点を失う
+
 ## 相性のよい command
 
 `/python-review`, `/verify`

--- a/Claude/templates/claudeos/skills/python-testing/SKILL.md
+++ b/Claude/templates/claudeos/skills/python-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: python-testing
+description: "pytest による fixture、parametrize、integration test を支援するときに使う。"
+---
+
 # python-testing
 
 ## 概要

--- a/Claude/templates/claudeos/skills/regex-vs-llm-structured-text/SKILL.md
+++ b/Claude/templates/claudeos/skills/regex-vs-llm-structured-text/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: regex-vs-llm-structured-text
+description: "正規表現と LLM のどちらで構造化テキスト処理すべきか判断するときに使う。"
+---
+
 # regex-vs-llm-structured-text
 
 ## 概要

--- a/Claude/templates/claudeos/skills/requirements-extractor/SKILL.md
+++ b/Claude/templates/claudeos/skills/requirements-extractor/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: requirements-extractor
+description: "議事録・要件メモ・メール・Slack ログなどの非構造化テキストから実行可能タスクと受け入れ基準を抽出し Issue 化するときに使う。"
+---
+
 # requirements-extractor
 
 ## 概要

--- a/Claude/templates/claudeos/skills/search-first/SKILL.md
+++ b/Claude/templates/claudeos/skills/search-first/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: search-first
+description: "実装前に既存コード、仕様、外部資料を優先的に調べるときに使う。"
+---
+
 # search-first
 
 ## 概要

--- a/Claude/templates/claudeos/skills/security-review/SKILL.md
+++ b/Claude/templates/claudeos/skills/security-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: security-review
+description: "認証、認可、入力検証、秘密情報、監査ログの観点からセキュリティを点検するときに使う。"
+---
+
 # security-review
 
 ## 概要

--- a/Claude/templates/claudeos/skills/security-scan/SKILL.md
+++ b/Claude/templates/claudeos/skills/security-scan/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: security-scan
+description: "静的解析、依存監査、設定監査をまとめて実行するときに使う。"
+---
+
 # security-scan
 
 ## 概要

--- a/Claude/templates/claudeos/skills/skill-stocktake/SKILL.md
+++ b/Claude/templates/claudeos/skills/skill-stocktake/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: skill-stocktake
+description: "既存 skills と commands の重複、不足、品質差を棚卸しするときに使う。"
+---
+
 # skill-stocktake
 
 ## 概要

--- a/Claude/templates/claudeos/skills/springboot-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-patterns/SKILL.md
@@ -56,7 +56,7 @@ description: "Spring Boot の層構造、DI、設定管理、トランザクシ�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `@Transactional` が self-invocation / private メソッドで無効になる
 - field injection でテスト困難化。constructor injection にする

--- a/Claude/templates/claudeos/skills/springboot-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-patterns/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: springboot-patterns
+description: "Spring Boot の層構造、DI、設定管理、トランザクションを整理するときに使う。"
+---
+
 # springboot-patterns
 
 ## 概要

--- a/Claude/templates/claudeos/skills/springboot-patterns/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-patterns/SKILL.md
@@ -56,6 +56,14 @@ description: "Spring Boot の層構造、DI、設定管理、トランザクシ�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `@Transactional` が self-invocation / private メソッドで無効になる
+- field injection でテスト困難化。constructor injection にする
+- `application.properties` に secret 直書き (profile/vault 分離する)
+- JPA entity を controller から直接返し lazy 例外・過剰公開を招く (DTO 化)
+- 読取専用処理に `@Transactional(readOnly=true)` を付けず不要 dirty checking が走る
+
 ## 相性のよい command
 
 `/plan`, `/verify`

--- a/Claude/templates/claudeos/skills/springboot-security/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-security/SKILL.md
@@ -56,7 +56,7 @@ description: "Spring Security、認可、シークレット、設定分離を点
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `.anyRequest().permitAll()` の取り残しで全公開になる
 - REST 化で CSRF を全 disable するが cookie ベース認証が残り脆弱になる

--- a/Claude/templates/claudeos/skills/springboot-security/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-security/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: springboot-security
+description: "Spring Security、認可、シークレット、設定分離を点検するときに使う。"
+---
+
 # springboot-security
 
 ## 概要

--- a/Claude/templates/claudeos/skills/springboot-security/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-security/SKILL.md
@@ -56,6 +56,16 @@ description: "Spring Security、認可、シークレット、設定分離を点
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `.anyRequest().permitAll()` の取り残しで全公開になる
+- REST 化で CSRF を全 disable するが cookie ベース認証が残り脆弱になる
+- `@PreAuthorize` が self-invocation(同クラス内呼び出し)で効かない
+- actuator(`/env`,`/heapdump`)を無認証で露出する
+- `NoOpPasswordEncoder` / 平文でパスワードを保存する
+- JWT で `alg=none` を受理 / secret が短小で総当たり可能
+- CORS `allowedOrigins("*")` と credentials を併用する
+
 ## 相性のよい command
 
 `/code-review`, `/verify`

--- a/Claude/templates/claudeos/skills/springboot-tdd/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-tdd/SKILL.md
@@ -56,6 +56,13 @@ description: "Spring Boot を controller から service まで段階的に TDD �
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- `@SpringBootContext` 全起動を多用しテストが遅くなる (slice test を使う)
+- `@MockBean` 乱用で実結線の不具合を検出できなくなる
+- `@DataJpaTest` の組込 DB と本番 DB の方言差で漏れる
+- test 用 `application.properties` の profile 分離漏れで本番設定を読む
+
 ## 相性のよい command
 
 `/tdd`

--- a/Claude/templates/claudeos/skills/springboot-tdd/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-tdd/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: springboot-tdd
+description: "Spring Boot を controller から service まで段階的に TDD するときに使う。"
+---
+
 # springboot-tdd
 
 ## 概要

--- a/Claude/templates/claudeos/skills/springboot-tdd/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-tdd/SKILL.md
@@ -56,7 +56,7 @@ description: "Spring Boot を controller から service まで段階的に TDD �
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - `@SpringBootContext` 全起動を多用しテストが遅くなる (slice test を使う)
 - `@MockBean` 乱用で実結線の不具合を検出できなくなる

--- a/Claude/templates/claudeos/skills/springboot-verification/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-verification/SKILL.md
@@ -56,7 +56,7 @@ description: "Spring Boot の起動、統合試験、DB 接続、主要 API の�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
-## Gotchas（陥りやすい失敗）
+## ⚠️ Gotchas（陥りやすい失敗）
 
 - 起動・統合・DB 接続のうち lazy 関連の境界外アクセスを検証しない
 - actuator/health endpoint の応答だけで実依存(DB/MQ)の死活を判断する

--- a/Claude/templates/claudeos/skills/springboot-verification/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-verification/SKILL.md
@@ -56,6 +56,13 @@ description: "Spring Boot の起動、統合試験、DB 接続、主要 API の�
 - 主要フローに回帰がないか
 - ドキュメントと実装にズレがないか
 
+## Gotchas（陥りやすい失敗）
+
+- 起動・統合・DB 接続のうち lazy 関連の境界外アクセスを検証しない
+- actuator/health endpoint の応答だけで実依存(DB/MQ)の死活を判断する
+- flyway/liquibase の migration 適用順を本番相当で確認しない
+- 主要 API の異常系(401/403/409)の検証を省く
+
 ## 相性のよい command
 
 `/verify`

--- a/Claude/templates/claudeos/skills/springboot-verification/SKILL.md
+++ b/Claude/templates/claudeos/skills/springboot-verification/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: springboot-verification
+description: "Spring Boot の起動、統合試験、DB 接続、主要 API の検証を行うときに使う。"
+---
+
 # springboot-verification
 
 ## 概要

--- a/Claude/templates/claudeos/skills/strategic-compact/SKILL.md
+++ b/Claude/templates/claudeos/skills/strategic-compact/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: strategic-compact
+description: "長い文脈を圧縮する前に何を残し何を捨てるかを判断するときに使う。"
+---
+
 # strategic-compact
 
 ## 概要

--- a/Claude/templates/claudeos/skills/swift-actor-persistence/SKILL.md
+++ b/Claude/templates/claudeos/skills/swift-actor-persistence/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: swift-actor-persistence
+description: "Swift actor を用いた安全な永続化と競合回避を扱うときに使う。"
+---
+
 # swift-actor-persistence
 
 ## 概要

--- a/Claude/templates/claudeos/skills/swift-concurrency-6-2/SKILL.md
+++ b/Claude/templates/claudeos/skills/swift-concurrency-6-2/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: swift-concurrency-6-2
+description: "Swift 6.2 の concurrency を安全かつ段階的に導入するときに使う。"
+---
+
 # swift-concurrency-6-2
 
 ## 概要

--- a/Claude/templates/claudeos/skills/swift-protocol-di-testing/SKILL.md
+++ b/Claude/templates/claudeos/skills/swift-protocol-di-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: swift-protocol-di-testing
+description: "Swift の protocol ベース DI とテスト容易性向上を支援するときに使う。"
+---
+
 # swift-protocol-di-testing
 
 ## 概要

--- a/Claude/templates/claudeos/skills/tdd-workflow/SKILL.md
+++ b/Claude/templates/claudeos/skills/tdd-workflow/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: tdd-workflow
+description: "Red、Green、Refactor の流れで安全に実装を進めるときに使う。"
+---
+
 # tdd-workflow
 
 ## 概要

--- a/Claude/templates/claudeos/skills/verification-loop/SKILL.md
+++ b/Claude/templates/claudeos/skills/verification-loop/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: verification-loop
+description: "変更近傍から全体へ広げる継続的検証ループを運用するときに使う。"
+---
+
 # verification-loop
 
 ## 概要

--- a/Claude/templates/claudeos/skills/videodb/SKILL.md
+++ b/Claude/templates/claudeos/skills/videodb/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: videodb
+description: "動画、音声、字幕、検索、編集、生成のワークフローを扱うときに使う。"
+---
+
 # videodb
 
 ## 概要

--- a/scripts/setup/add-skill-frontmatter.js
+++ b/scripts/setup/add-skill-frontmatter.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * add-skill-frontmatter.js
+ *
+ * 全 SKILL.md に `name` / `description` frontmatter を付与する保守スクリプト。
+ *
+ * 背景:
+ *   Claude Code は SKILL.md frontmatter の `description` を読んで skill の
+ *   自動発火 / 自動選択を判断する。frontmatter が無い skill は名前による
+ *   明示呼び出ししか効かず「休眠状態」になる (Anthropic blog: Model-Focused
+ *   Descriptions)。本スクリプトで配布元テンプレと local copy の両方を回復する。
+ *
+ * 抽出ロジック:
+ *   - name        : skill フォルダ名
+ *   - description : `## 概要` の scaffold 文 `この skill は <X> ための実務向け
+ *                   ガイドです。` から X を抽出し `<X>ときに使う。` へ整形。
+ *                   scaffold に一致しない手書き skill は EXCEPTIONS で補う。
+ *
+ * 冪等性:
+ *   先頭が `---` の SKILL.md は frontmatter 既存と見なしてスキップする。
+ *
+ * 使い方:
+ *   node scripts/setup/add-skill-frontmatter.js --dry-run   # 変更プレビュー
+ *   node scripts/setup/add-skill-frontmatter.js             # 適用
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+// 配布元 (source-of-truth) と local runtime copy の両方を処理する。
+const SKILL_DIRS = [
+  path.join(REPO_ROOT, "Claude", "templates", "claudeos", "skills"),
+  path.join(REPO_ROOT, ".claude", "claudeos", "skills"),
+];
+
+// scaffold に一致しない手書き skill の description (フォルダ名 -> description)。
+const EXCEPTIONS = {
+  "performance-review":
+    "差分や既存コードを性能観点でレビューし、ホットスポット・計算量・I/O 回数・並列性・メモリ・DB クエリのリグレッションを検出するときに使う。",
+  "requirements-extractor":
+    "議事録・要件メモ・メール・Slack ログなどの非構造化テキストから実行可能タスクと受け入れ基準を抽出し Issue 化するときに使う。",
+};
+
+// `## 概要` 直後の scaffold 文から X を取り出す正規表現。
+const SCAFFOLD_RE = /この skill は\s*(.+?)\s*ための実務向けガイドです。/;
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+/** YAML double-quoted scalar として安全な文字列にする。 */
+function yamlQuote(value) {
+  return '"' + String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+}
+
+/** SKILL.md 本文から description を決定する。決められなければ null。 */
+function deriveDescription(folderName, body) {
+  if (EXCEPTIONS[folderName]) return EXCEPTIONS[folderName];
+  const m = body.match(SCAFFOLD_RE);
+  if (m) {
+    const x = m[1].trim();
+    return `${x}ときに使う。`;
+  }
+  return null;
+}
+
+function processSkillFile(skillMdPath, folderName) {
+  const original = fs.readFileSync(skillMdPath, "utf8");
+
+  if (original.startsWith("---")) {
+    return { status: "skip", reason: "frontmatter 既存" };
+  }
+
+  const description = deriveDescription(folderName, original);
+  if (!description) {
+    return { status: "error", reason: "description を抽出できず (scaffold 不一致 & 例外未定義)" };
+  }
+
+  const frontmatter =
+    "---\n" +
+    `name: ${folderName}\n` +
+    `description: ${yamlQuote(description)}\n` +
+    "---\n\n";
+
+  if (DRY_RUN) {
+    return { status: "would-write", description };
+  }
+
+  fs.writeFileSync(skillMdPath, frontmatter + original, "utf8");
+  return { status: "written", description };
+}
+
+function main() {
+  let totals = { written: 0, skip: 0, error: 0, wouldWrite: 0, missing: 0 };
+  const errors = [];
+
+  for (const dir of SKILL_DIRS) {
+    if (!fs.existsSync(dir)) {
+      console.log(`⚠️  ディレクトリ無し: ${path.relative(REPO_ROOT, dir)}`);
+      continue;
+    }
+    console.log(`\n📁 ${path.relative(REPO_ROOT, dir)}`);
+
+    const folders = fs
+      .readdirSync(dir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+
+    for (const folderName of folders) {
+      const skillMdPath = path.join(dir, folderName, "SKILL.md");
+      if (!fs.existsSync(skillMdPath)) {
+        totals.missing++;
+        console.log(`   ❓ ${folderName}: SKILL.md 無し`);
+        continue;
+      }
+      const result = processSkillFile(skillMdPath, folderName);
+      switch (result.status) {
+        case "written":
+          totals.written++;
+          console.log(`   ✅ ${folderName} → ${result.description}`);
+          break;
+        case "would-write":
+          totals.wouldWrite++;
+          console.log(`   📝 ${folderName} → ${result.description}`);
+          break;
+        case "skip":
+          totals.skip++;
+          console.log(`   ⏭️  ${folderName} (${result.reason})`);
+          break;
+        case "error":
+          totals.error++;
+          errors.push(`${folderName}: ${result.reason}`);
+          console.log(`   ❌ ${folderName} (${result.reason})`);
+          break;
+      }
+    }
+  }
+
+  console.log("\n📊 サマリ");
+  if (DRY_RUN) {
+    console.log(`   付与予定: ${totals.wouldWrite}`);
+  } else {
+    console.log(`   付与: ${totals.written}`);
+  }
+  console.log(`   スキップ(既存): ${totals.skip}`);
+  console.log(`   SKILL.md 欠落: ${totals.missing}`);
+  console.log(`   エラー: ${totals.error}`);
+
+  if (errors.length > 0) {
+    console.log("\n❌ エラー詳細:");
+    errors.forEach((e) => console.log(`   - ${e}`));
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/setup/add-skill-gotchas.js
+++ b/scripts/setup/add-skill-gotchas.js
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+/**
+ * add-skill-gotchas.js
+ *
+ * 主要 skill にドメイン固有の `## Gotchas（陥りやすい失敗）` セクションを挿入する
+ * 保守スクリプト (Tier2)。
+ *
+ * 背景:
+ *   全 SKILL.md は scaffold 生成で 概要〜注意点 まで汎用ボイラープレートのみ。
+ *   Anthropic blog "Lessons from building Claude Code: How we use Skills" は
+ *   最も信号価値が高いのは「Gotchas (よくある失敗点)」だと述べる。
+ *   ここに各ドメインで実際に人を刺す失敗モードを集約し、skill の実効性を上げる。
+ *
+ * 設計:
+ *   - GOTCHAS: フォルダ名 -> 箇条書き配列 (単一の真実)。
+ *   - 挿入位置: `## 相性のよい command` の直前。無ければ `## 注意点` の直前。
+ *   - 配布元テンプレと local copy の両方を処理する。
+ *
+ * 冪等性:
+ *   既に `## Gotchas` を含む SKILL.md はスキップする。
+ *
+ * 使い方:
+ *   node scripts/setup/add-skill-gotchas.js --dry-run
+ *   node scripts/setup/add-skill-gotchas.js
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+const SKILL_DIRS = [
+  path.join(REPO_ROOT, "Claude", "templates", "claudeos", "skills"),
+  path.join(REPO_ROOT, ".claude", "claudeos", "skills"),
+];
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const SECTION_HEADING = "## Gotchas（陥りやすい失敗）";
+
+// フォルダ名 -> ドメイン固有の失敗モード (実際に人を刺すものだけ)。
+const GOTCHAS = {
+  "docker-patterns": [
+    "`latest` タグ依存で再現性が壊れる。digest 固定か明示バージョンタグを使う",
+    "`.dockerignore` 未整備で `COPY . .` が `.git`/`node_modules`/secret を image へ焼き込む",
+    "root 実行のまま放置。`USER` 指定と read-only rootfs を検討する",
+    "`depends_on` は起動順を保証するが起動完了は保証しない。healthcheck + `condition: service_healthy` が要る",
+    "マルチステージビルド未使用で build ツールチェーンを本番 image に残し肥大化させる",
+    "secret を `build-arg` や ENV に渡すと image layer / `docker inspect` から漏れる",
+    "Linux の bind mount は host uid/gid 差異でコンテナ内書込みが失敗する",
+  ],
+  "django-security": [
+    "本番 `DEBUG=True` 残置で例外画面に settings と secret が露出する",
+    "`ALLOWED_HOSTS` 未設定 / `[\"*\"]` で Host ヘッダ injection を許す",
+    "`SECRET_KEY` をコード/リポジトリにハードコードする",
+    "`.raw()` / `.extra()` / 文字列連結 SQL で ORM の injection 防御を迂回する",
+    "`mark_safe` / `|safe` / `format_html` 誤用で XSS を作る",
+    "`@csrf_exempt` の無自覚付与、SessionAuth の API で CSRF が抜ける",
+    "`get_object_or_404` だけで所有者チェックを省き IDOR を作る",
+    "session/CSRF cookie の `SECURE` / `HttpOnly` / `SameSite` 未設定",
+  ],
+  "django-patterns": [
+    "`select_related` / `prefetch_related` 不足で N+1 クエリ",
+    "QuerySet の遅延評価を理解せずループ内でクエリを発行する",
+    "fat views / fat models で service 層の責務分離が崩れる",
+    "model 変更後の `makemigrations` 忘れで schema と乖離する",
+    "signals 多用で副作用の追跡が不能になる",
+    "settings を環境分離せず単一 `settings.py` に `if` 分岐を詰め込む",
+  ],
+  "django-tdd": [
+    "`TestCase`(トランザクション) と `TransactionTestCase` の差異を無視し flaky 化",
+    "実 DB/外部 API に依存したテストで遅く不安定になる",
+    "fixtures 肥大で意図が読めない。factory(`factory_boy`) で必要分だけ作る",
+    "`setUp` の重い処理を毎テスト実行して遅くする (`setUpTestData` を使う)",
+    "freeze せず `timezone.now()` 依存テストを書き時間で壊れる",
+  ],
+  "django-verification": [
+    "migration の前進だけ確認し rollback(逆 migration) を検証しない",
+    "permission/所有者チェックの検証を正常系だけで済ませる",
+    "`makemigrations --check --dry-run` を CI に入れず未生成 migration を見逃す",
+    "本番相当データ量での性能/タイムアウトを確認しない",
+  ],
+  "laravel-security": [
+    "`$fillable` 未定義 + `$guarded=[]` で mass assignment (is_admin 等を更新される)",
+    "`{!! !!}` の raw 出力で XSS。既定は `{{ }}` を使う",
+    "`DB::raw()` / `whereRaw()` に未バインドのユーザー入力を渡す",
+    "本番 `APP_DEBUG=true` 残置で Ignition がスタック/設定を露出する",
+    "route に policy/`authorize` を付け忘れて IDOR を作る",
+    "public disk 誤設定で非公開ファイルを `Storage::url` 経由で露出する",
+    "`VerifyCsrfToken::$except` へ安易に追加して CSRF を抜く",
+  ],
+  "laravel-patterns": [
+    "Eloquent の N+1。`with()` eager loading 不足 (Telescope/Debugbar で検出)",
+    "controller に業務ロジック集中。service/action クラスへ分離する",
+    "`Model::all()` を大量データに使いメモリ枯渇 (`chunk`/`cursor` を使う)",
+    "queue job の冪等性欠如で再試行が二重実行になる",
+    "実行時に `env()` を直接呼ぶと config cache で null になる。`config()` 経由にする",
+  ],
+  "laravel-tdd": [
+    "Feature test で `RefreshDatabase` を付け忘れテスト間が汚染される",
+    "実メール/実決済を mock せず外部に到達させる (`Mail::fake()` 等)",
+    "factory の states を使わず重複したセットアップを量産する",
+    "`assertDatabaseHas` だけで副作用(event/job)の検証を怠る",
+  ],
+  "laravel-verification": [
+    "route/policy/queue/DB 更新のうち queue の非同期挙動を検証しない",
+    "`php artisan route:list` で認可ミドルウェアの付与漏れを確認しない",
+    "migration の rollback を本番相当データで検証しない",
+    "config cache(`config:cache`) 後に挙動が変わる箇所を確認しない",
+  ],
+  "springboot-security": [
+    "`.anyRequest().permitAll()` の取り残しで全公開になる",
+    "REST 化で CSRF を全 disable するが cookie ベース認証が残り脆弱になる",
+    "`@PreAuthorize` が self-invocation(同クラス内呼び出し)で効かない",
+    "actuator(`/env`,`/heapdump`)を無認証で露出する",
+    "`NoOpPasswordEncoder` / 平文でパスワードを保存する",
+    "JWT で `alg=none` を受理 / secret が短小で総当たり可能",
+    "CORS `allowedOrigins(\"*\")` と credentials を併用する",
+  ],
+  "springboot-patterns": [
+    "`@Transactional` が self-invocation / private メソッドで無効になる",
+    "field injection でテスト困難化。constructor injection にする",
+    "`application.properties` に secret 直書き (profile/vault 分離する)",
+    "JPA entity を controller から直接返し lazy 例外・過剰公開を招く (DTO 化)",
+    "読取専用処理に `@Transactional(readOnly=true)` を付けず不要 dirty checking が走る",
+  ],
+  "springboot-tdd": [
+    "`@SpringBootContext` 全起動を多用しテストが遅くなる (slice test を使う)",
+    "`@MockBean` 乱用で実結線の不具合を検出できなくなる",
+    "`@DataJpaTest` の組込 DB と本番 DB の方言差で漏れる",
+    "test 用 `application.properties` の profile 分離漏れで本番設定を読む",
+  ],
+  "springboot-verification": [
+    "起動・統合・DB 接続のうち lazy 関連の境界外アクセスを検証しない",
+    "actuator/health endpoint の応答だけで実依存(DB/MQ)の死活を判断する",
+    "flyway/liquibase の migration 適用順を本番相当で確認しない",
+    "主要 API の異常系(401/403/409)の検証を省く",
+  ],
+  "golang-patterns": [
+    "`err` を `_` で握りつぶす / wrap せず原因を失う (`fmt.Errorf(\"...: %w\", err)`)",
+    "goroutine leak。context cancel / channel close 漏れを残す",
+    "Go 1.22 未満の loop 変数キャプチャを goroutine/closure が共有する",
+    "共有 map への並行書込みで data race (`-race` で検出する)",
+    "nil map への書込み panic / nil interface 比較の落とし穴",
+    "ループ内 `defer` の多用でリソース解放が関数末尾まで遅延する",
+  ],
+  "python-patterns": [
+    "mutable default 引数 (`def f(x=[])`) で状態が共有される",
+    "bare `except:` で例外を握りつぶす / 原因を失う",
+    "`None` 比較に `==` を使う (`is None` が正)",
+    "モジュールレベル副作用 / 循環 import で読込順に依存する",
+    "CPU bound を thread で並列化して GIL に阻まれる (process/別実装へ)",
+    "ログを f-string で先評価し遅延評価の利点を失う",
+  ],
+  "clickhouse-io": [
+    "列指向なのに `SELECT *` で全列読込し I/O を浪費する",
+    "行単位 INSERT を多発させ part 爆発 → merge 過負荷 (バッチ INSERT 必須)",
+    "`FINAL` 常用で性能劣化 / ReplacingMergeTree の重複解消を即時と誤解する",
+    "sorting key(`ORDER BY`)設計ミスで primary index が効かず full scan",
+    "高カーディナリティの partition key で part 数が爆発する",
+    "`ALTER UPDATE/DELETE`(mutation) を OLTP 的に使う (非同期・高コスト)",
+    "`Nullable` 乱用でストレージと性能を劣化させる",
+  ],
+  "postgres-patterns": [
+    "`WHERE lower(col)=...` 等の関数適用で index が無効化する (式 index が要る)",
+    "長時間トランザクションで VACUUM を阻害し bloat を招く",
+    "`CREATE INDEX` を `CONCURRENTLY` 無しで実行し write lock を取る",
+    "旧版で `ADD COLUMN ... DEFAULT` が full table rewrite + lock を引き起こす",
+    "接続プール(pgbouncer 等)無しで接続枯渇する",
+    "`SELECT *` + N+1 で過剰取得する",
+    "`SERIALIZABLE` の競合 retry を実装しない",
+  ],
+  "database-migrations": [
+    "rename/drop を deploy と同時実行し旧コードが落ちる (expand→contract の2段階に)",
+    "後方互換を壊す変更を 1 migration に詰め込む",
+    "大テーブルの DDL で長時間 lock (オンライン DDL / batched backfill)",
+    "down migration(rollback)を未検証のまま出す",
+    "data migration を schema migration に混在させる",
+    "本番でしか出ない順序依存・seed 依存を見逃す",
+  ],
+  "deployment-patterns": [
+    "readiness と liveness を混同し、起動中に traffic を流す",
+    "rollback 手順未整備 / DB migration が rollback 不能",
+    "ビルド時 env と実行時 env を混同する (12-factor 違反)",
+    "secret を image / CI ログに露出する",
+    "zero-downtime 前提なのに in-place restart で瞬断する",
+    "canary/blue-green で新旧スキーマ非互換 (expand/contract で吸収する)",
+  ],
+  "e2e-testing": [
+    "固定 `sleep`/`waitForTimeout` で flaky 化 (web-first assertion / auto-wait を使う)",
+    "脆い CSS セレクタ依存。role/label/test-id ベースにする",
+    "テスト間で DB/seed のリセットを怠り状態が漏れる",
+    "認証を毎テスト UI 経由にする (storageState を使い回す)",
+    "並列実行時のデータ競合を考慮しない",
+    "`networkidle` 待ちを過信して不安定化させる",
+  ],
+  "jpa-patterns": [
+    "N+1。`FetchType.EAGER` 乱用 or lazy + ループ (fetch join / `@EntityGraph`)",
+    "session 外アクセスで `LazyInitializationException`",
+    "`equals`/`hashCode` を生成 ID で実装する (永続化前は null)",
+    "更新で `save()` を多用する (dirty checking で不要)",
+    "cascade の過剰設定で意図しない delete が伝播する",
+    "`@Transactional` 境界外での lazy load を前提にする",
+  ],
+};
+
+/** Gotchas markdown ブロックを組み立てる。 */
+function buildSection(bullets) {
+  return (
+    SECTION_HEADING +
+    "\n\n" +
+    bullets.map((b) => `- ${b}`).join("\n") +
+    "\n\n"
+  );
+}
+
+function processSkillFile(skillMdPath, bullets) {
+  const original = fs.readFileSync(skillMdPath, "utf8");
+
+  if (original.includes(SECTION_HEADING)) {
+    return { status: "skip", reason: "Gotchas 既存" };
+  }
+
+  const section = buildSection(bullets);
+
+  // 挿入アンカー: `## 相性のよい command` 優先、無ければ `## 注意点`。
+  let anchor = "## 相性のよい command";
+  if (!original.includes(anchor)) anchor = "## 注意点";
+  if (!original.includes(anchor)) {
+    return { status: "error", reason: "挿入アンカーが見つからない" };
+  }
+
+  const updated = original.replace(anchor, section + anchor);
+
+  if (DRY_RUN) {
+    return { status: "would-write" };
+  }
+
+  fs.writeFileSync(skillMdPath, updated, "utf8");
+  return { status: "written" };
+}
+
+function main() {
+  const totals = { written: 0, skip: 0, error: 0, wouldWrite: 0, missing: 0 };
+  const errors = [];
+
+  for (const dir of SKILL_DIRS) {
+    if (!fs.existsSync(dir)) {
+      console.log(`⚠️  ディレクトリ無し: ${path.relative(REPO_ROOT, dir)}`);
+      continue;
+    }
+    console.log(`\n📁 ${path.relative(REPO_ROOT, dir)}`);
+
+    for (const folderName of Object.keys(GOTCHAS).sort()) {
+      const skillMdPath = path.join(dir, folderName, "SKILL.md");
+      if (!fs.existsSync(skillMdPath)) {
+        totals.missing++;
+        console.log(`   ❓ ${folderName}: SKILL.md 無し`);
+        continue;
+      }
+      const result = processSkillFile(skillMdPath, GOTCHAS[folderName]);
+      switch (result.status) {
+        case "written":
+          totals.written++;
+          console.log(`   ✅ ${folderName}`);
+          break;
+        case "would-write":
+          totals.wouldWrite++;
+          console.log(`   📝 ${folderName}`);
+          break;
+        case "skip":
+          totals.skip++;
+          console.log(`   ⏭️  ${folderName} (${result.reason})`);
+          break;
+        case "error":
+          totals.error++;
+          errors.push(`${folderName}: ${result.reason}`);
+          console.log(`   ❌ ${folderName} (${result.reason})`);
+          break;
+      }
+    }
+  }
+
+  console.log("\n📊 サマリ");
+  console.log(`   ${DRY_RUN ? "付与予定" : "付与"}: ${DRY_RUN ? totals.wouldWrite : totals.written}`);
+  console.log(`   スキップ(既存): ${totals.skip}`);
+  console.log(`   SKILL.md 欠落: ${totals.missing}`);
+  console.log(`   エラー: ${totals.error}`);
+
+  if (errors.length > 0) {
+    console.log("\n❌ エラー詳細:");
+    errors.forEach((e) => console.log(`   - ${e}`));
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/setup/add-skill-gotchas.js
+++ b/scripts/setup/add-skill-gotchas.js
@@ -38,7 +38,12 @@ const SKILL_DIRS = [
 
 const DRY_RUN = process.argv.includes("--dry-run");
 
-const SECTION_HEADING = "## Gotchas（陥りやすい失敗）";
+// CLAUDE.md §2.1「章タイトルは必ずアイコン付き」に準拠し ⚠️ を付与する。
+const SECTION_HEADING = "## ⚠️ Gotchas（陥りやすい失敗）";
+
+// 冪等チェック用: アイコン有無どちらの見出しでもヒットさせる
+// (旧版の `## Gotchas` を生成済みの登録プロジェクトでも重複挿入を防ぐ)。
+const SECTION_HEADING_RE = /^##\s+(?:⚠️\s+)?Gotchas（陥りやすい失敗）\s*$/m;
 
 // フォルダ名 -> ドメイン固有の失敗モード (実際に人を刺すものだけ)。
 const GOTCHAS = {
@@ -219,7 +224,7 @@ function buildSection(bullets) {
 function processSkillFile(skillMdPath, bullets) {
   const original = fs.readFileSync(skillMdPath, "utf8");
 
-  if (original.includes(SECTION_HEADING)) {
+  if (SECTION_HEADING_RE.test(original)) {
     return { status: "skip", reason: "Gotchas 既存" };
   }
 


### PR DESCRIPTION
## 📌 概要

Anthropic ブログ [Lessons from building Claude Code: How we use Skills](https://claude.com/blog/lessons-from-building-claude-code-how-we-use-skills) の知見を ClaudeOS に全 Tier 適用する。Closes #346

## 🔧 変更内容

| Tier | 内容 | コミット |
|---|---|---|
| **Tier 1** | 全 66 skill × 2 dir = 132 SKILL.md に `name` / `description` frontmatter 付与。モデルによる **Skills 自動発見（auto-discovery）を復活** | `5084216` |
| **Tier 2** | 主要 21 skill × 2 dir = 42 SKILL.md にドメイン固有の `## ⚠️ Gotchas（陥りやすい失敗）` セクションを追加（ブログが最重要シグナルと位置づける項目） | `62de15c` |
| **Tier 3** | (a) skill 使用計測 hook を配布テンプレ `settings.json` の PostToolUse (`Agent\|Skill`) に配線 / (b) marketplace.json 3 ファイルを公式準拠の `"source": "./"` へ修正 | `508f60d` |
| **fix** | CodeRabbit major 5 件対応。Gotchas 見出しに `⚠️` アイコン付与（CLAUDE.md §2.1 準拠）+ `add-skill-gotchas.js` を冪等化 | `94ec830` |

生成スクリプト: `scripts/setup/add-skill-frontmatter.js` / `scripts/setup/add-skill-gotchas.js`（いずれも再実行安全・idempotent）。

## 🧪 テスト結果

- ✅ `node scripts/validate-state-example.js` — PASSED
- ✅ `node scripts/check-doc-versions.js` — PASSED (README=v3.4.9, agents=44)
- ✅ Codex review — Critical/High = 0
- ✅ CodeRabbit review — major 5 件（アイコン見出し）すべて解消済み（Critical/High = 0）
- ✅ frontmatter 付与スクリプト dry-run — 132/132 検証
- ✅ Gotchas アイコン付与 — 42/42 検証（アイコン無し残 0）

## 🗺️ 影響範囲

- **配布テンプレ `Claude/templates/claudeos/` を変更** → 登録プロジェクト（約 19 件）へ波及。
- **skills（dir 型）= copy-if-missing**: `init-claudeos-project.js` は既存ファイルを上書きしないため、**オンボード済みプロジェクトの SKILL.md / marketplace.json は自動更新されない**（別途 再同期が必要 — 下記「残課題」参照）。
- **settings.json = deep-merge**: 計測 hook は次回同期で自動波及する。
- ランタイム成果物（reasoning-bank.json / trust-score.json / START_PROMPT.md / scripts/data/）は **意図的に PR 対象外**。

## 📋 残課題

1. **登録済みプロジェクトへの再同期手順**: copy-if-missing のため SKILL.md / marketplace.json の修正は既存プロジェクトに届かない。force-sync オプションまたは手動再配布の整備が必要。
2. **reasoning-bank.json の劣化（本 PR 対象外・別事象）**: 本セッションのランタイム hook 副作用で working-tree コピーが全 0.15 に劣化。HEAD/main は健全。別途調査・報告。
3. skill 使用計測 hook の収集データ可視化（ダッシュボード連携）は未着手。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * スキルドキュメント全体にメタデータ（名前と説明）を追加し、スキルの識別と検索性を改善しました。
  * 複数のスキルに「Gotchas（よくある失敗）」セクションを追加し、実装時に陥りやすい典型的な落とし穴と対策をまとめました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->